### PR TITLE
Fixed export bucket (now doing a full export)

### DIFF
--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -12,7 +12,7 @@ accordion(:one-at-atime="false")
         button.btn.btn-default.btn-sm(type="button")
           span.glyphicon.glyphicon-folder-open(aria-hidden="true")
           | Open bucket
-      a(v-bind:href="'/api/0/buckets/' + bucket.id + '/events'")
+      a(v-bind:href="'/api/0/buckets/' + bucket.id + '/events?limit=-1'")
         button.btn.btn-default.btn-sm(type="button" data-toggle="tooltip" data-placement="bottom" title="Not implemented")
           span.glyphicon.glyphicon-save(aria-hidden="true")
           | Export as JSON


### PR DESCRIPTION
I've fixed this by setting `?limit=-1`, we should ensure that `limit=-1` really means **no limit** on the serverside before merging.