### PR TITLE
Wip notices

### DIFF
--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -3,6 +3,15 @@ h2 Window Activity {{ datestr }}
 
 h5 {{ host }}
 
+h4(style="color: red;")
+  | This is currently work in progress and is known to have issues (such as 
+  a(href='https://github.com/ActivityWatch/aw-webui/issues/22') needing a date selector
+  | , 
+  a(href='https://github.com/ActivityWatch/activitywatch/issues/72') timezone issues
+  | , etc.) - see 
+  a(href='https://github.com/ActivityWatch/aw-webui/issues') all issues
+  | .
+
 h3(style="color: red;") {{ errormsg }}
 
 div.btn-group

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -13,7 +13,7 @@ accordion(:one-at-atime="false")
           span.glyphicon.glyphicon-folder-open(aria-hidden="true")
           | Open bucket
       a(v-bind:href="'/api/0/buckets/' + bucket.id + '/events?limit=-1'")
-        button.btn.btn-default.btn-sm(type="button" data-toggle="tooltip" data-placement="bottom" title="Not implemented")
+        button.btn.btn-default.btn-sm(type="button" data-toggle="tooltip" data-placement="bottom" title="Export all the events from this bucket to JSON")
           span.glyphicon.glyphicon-save(aria-hidden="true")
           | Export as JSON
       div(v-if="bucket.last_updated", style="margin-top: 0.5em; font-size: 10pt; color: #666")


### PR DESCRIPTION
Re https://github.com/ActivityWatch/activitywatch/issues/84 : add WIP notice in activity view.

Also remove "not implemented" title-text of the JSON export button.

