### PR TITLE
Workaround for bootstrap beta that breaks the dropdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: build dev clean
+.PHONY: install build dev test clean
 
 .FORCE: ;
 
-
-build: .FORCE
+install:
 	npm install
+
+build: install
 	npm run build
 
 dev:
-	npm install
 	npm run dev
 
 test:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "webpack-merge": "^0.8.3"
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "4.0.0-alpha.6",
     "bootstrap-vue": "^0.18.0",
     "d3": "^4.2.2",
     "electron-packager": "^7.3.0",


### PR DESCRIPTION
The Activity dropdown doesn't work anymore.

Related issue in bootstrap-vue: https://github.com/bootstrap-vue/bootstrap-vue/issues/747

The specific thing in there affecting us is: "`b-dropdown` popper.js positioning" which is not done as of writing.