### PR TITLE
Integrate eslint and prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  extends: ['plugin:prettier/recommended', 'plugin:vue/recommended'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2017,
+  },
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'error',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,23 @@
         "acorn": "4.0.13"
       }
     },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
@@ -106,6 +123,12 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -115,6 +138,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "aproba": {
       "version": "1.2.0",
@@ -173,10 +202,31 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
@@ -1303,6 +1353,21 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camel-case": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
@@ -1427,6 +1492,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1434,6 +1500,12 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1444,6 +1516,12 @@
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
       }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "clap": {
       "version": "1.2.3",
@@ -1485,6 +1563,24 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
       "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
       "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        }
+      }
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1651,6 +1747,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "config-chain": {
       "version": "1.1.11",
@@ -2297,6 +2404,12 @@
         "assert-plus": "1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -2323,6 +2436,12 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2333,6 +2452,21 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2385,6 +2519,15 @@
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
       }
     },
     "doctypes": {
@@ -2510,6 +2653,12 @@
       "version": "1.3.22",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.22.tgz",
       "integrity": "sha1-QyLVLBUUBuPq73StAmdog+hBZBg=",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "elliptic": {
@@ -2705,10 +2854,249 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.3",
+        "esquery": "1.0.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.3.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.0.6",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "5.0.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
+    "eslint-plugin-vue": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.2.2.tgz",
+      "integrity": "sha1-Y+VcYVdK+O+YMyjd0miNY4mgIUs=",
+      "dev": true,
+      "requires": {
+        "vue-eslint-parser": "2.0.2"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.4.1",
+        "acorn-jsx": "3.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
@@ -2934,6 +3322,18 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2951,6 +3351,16 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-loader": {
@@ -3021,6 +3431,12 @@
         "pkg-dir": "2.0.0"
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3028,6 +3444,18 @@
       "dev": true,
       "requires": {
         "locate-path": "2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "flatten": {
@@ -3090,6 +3518,910 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -3117,6 +4449,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -3162,6 +4500,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -3222,6 +4566,20 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "globule": {
       "version": "1.2.0",
@@ -3561,6 +4919,31 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3576,6 +4959,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imports-loader": {
@@ -3607,6 +4996,12 @@
           }
         }
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
@@ -3794,6 +5189,15 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
@@ -3900,6 +5304,45 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -3953,6 +5396,18 @@
       "requires": {
         "has": "1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4013,6 +5468,67 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "jquery": {
       "version": "3.2.1",
@@ -4123,6 +5639,12 @@
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -4140,6 +5662,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4235,6 +5763,12 @@
         "less": "1.5.1"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4242,6 +5776,290 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lint-staged": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.1.0.tgz",
+      "integrity": "sha512-RMB6BUd2bEKaPnj06F7j8RRB8OHM+UP4fQS2LT8lF+X9BjSaezw1oVB5hc4elLhYvzlFCkhAaatzYz+x53YHgw==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "cosmiconfig": "4.0.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -4577,6 +6395,62 @@
         "lodash._root": "3.0.1"
       }
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -4874,6 +6748,12 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "ncname": {
@@ -5209,6 +7089,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -5216,6 +7105,17 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0",
+        "npm-path": "2.0.4",
+        "which": "1.3.0"
       }
     },
     "npmlog": {
@@ -5448,6 +7348,12 @@
         "p-limit": "1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -5545,6 +7451,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -5618,6 +7530,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "pn": {
       "version": "1.0.0",
@@ -6260,6 +8178,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "dev": true
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -6268,6 +8192,33 @@
       "requires": {
         "renderkid": "2.0.1",
         "utila": "0.4.0"
+      }
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        }
       }
     },
     "private": {
@@ -6286,6 +8237,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
     "promise": {
@@ -6893,6 +8850,16 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6906,6 +8873,12 @@
       "requires": {
         "path-parse": "1.0.5"
       }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -6961,6 +8934,23 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -7249,6 +9239,23 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
     "snake-case": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
@@ -7337,6 +9344,12 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -7380,6 +9393,15 @@
         "xtend": "4.0.1"
       }
     },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
+      }
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -7404,6 +9426,17 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "stringstream": {
@@ -7442,6 +9475,12 @@
       "requires": {
         "get-stdin": "4.0.1"
       }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "style-loader": {
       "version": "0.6.5",
@@ -7489,10 +9528,110 @@
         "upper-case": "1.1.3"
       }
     },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.3.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "tapable": {
       "version": "0.2.8",
@@ -7510,6 +9649,12 @@
         "fstream": "1.0.11",
         "inherits": "2.0.3"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -7658,6 +9803,12 @@
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -7874,6 +10025,31 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/vue-awesome/-/vue-awesome-2.3.3.tgz",
       "integrity": "sha512-1Kc7E8jaHRswRA2qLr8Dgq3NhbNQ/DgCBBgxX1218MCXzs5pxMV38QoM79TEkXvw7R+8S6aIKDrgEmli+ErTFw=="
+    },
+    "vue-eslint-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.2.tgz",
+      "integrity": "sha512-MQE1Tl4kYhp51opFMtRcZuyrFru/erpRI82w96tPiSnhcwK3QjJejAEJ5RlLcLU07Ua7A1WvhXG3i2KFveeGsA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.3",
+        "esquery": "1.0.0",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "vue-functional-data-merge": {
       "version": "1.0.7",
@@ -8465,6 +10641,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
     },
     "xml-char-classes": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
     "package": "node build/package_electron.js",
-    "test": ""
+    "test": "",
+    "lint": "eslint --fix --ext .js,.vue src",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": ["eslint --fix --ext .js,.vue src", "git add"]
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",
@@ -20,6 +25,10 @@
     "connect-history-api-fallback": "^1.1.0",
     "crypto-js": "^3.1.6",
     "css-loader": "^0.23.0",
+    "eslint": "^4.17.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-vue": "^4.2.2",
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^3.0.0",
@@ -27,12 +36,15 @@
     "function-bind": "^1.0.2",
     "html-webpack-plugin": "^2.8.1",
     "http-proxy-middleware": "^0.12.0",
+    "husky": "^0.14.3",
     "json-loader": "^0.5.4",
+    "lint-staged": "^6.1.0",
     "lodash": "^4.17.4",
     "moment": "^2.14.1",
     "moment-range": "^3.0.3",
     "node-sass": "^4.7.2",
     "ora": "^0.2.0",
+    "prettier": "^1.10.2",
     "sass-loader": "^6.0.6",
     "shelljs": "^0.6.0",
     "url-loader": "^0.5.7",
@@ -62,5 +74,10 @@
     "pug": "^2.0.0-rc.3",
     "style-loader": "^0.6.5",
     "vue-awesome": "^2.3.1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "bracketSpacing": false
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,19 +62,16 @@ div#wrapper
 </template>
 
 <script>
-
 // only import the icons you use to reduce bundle size
 import 'vue-awesome/icons/home';
 import 'vue-awesome/icons/database';
 import 'vue-awesome/icons/check-circle';
 import 'vue-awesome/icons/times-circle';
 import 'vue-awesome/icons/clock-o';
-import 'vue-awesome/icons/twitter'
-import 'vue-awesome/icons/github'
-
+import 'vue-awesome/icons/twitter';
+import 'vue-awesome/icons/github';
 
 import Resources from './resources.js';
-
 
 let $Info = Resources.$Info;
 let $Bucket = Resources.$Bucket;
@@ -86,57 +83,58 @@ export default {
     return {
       activity_hosts: [],
       connected: false,
-    }
+    };
   },
 
   mounted: function() {
     $Info.get().then(
-      (response) => {
+      response => {
         if (response.status > 304) {
-          console.error("Status code from return call was >304");
+          console.error('Status code from return call was >304');
         } else {
           this.connected = true;
         }
       },
-      (response) => {
+      response => {
         this.connected = false;
-      }
+      },
     );
 
-    $Bucket.get().then((response) => {
-        let buckets = response.json();
-        let types_by_host = {};
-        _.each(buckets, (v, k) => {
-            types_by_host[v.hostname] = types_by_host[v.hostname] || {};
-            if(v.type == "afkstatus") {
-                types_by_host[v.hostname].afk = true;
-            } else if(v.type == "currentwindow") {
-                types_by_host[v.hostname].window = true;
-            }
-        })
+    $Bucket.get().then(response => {
+      let buckets = response.json();
+      let types_by_host = {};
+      _.each(buckets, (v, k) => {
+        types_by_host[v.hostname] = types_by_host[v.hostname] || {};
+        if (v.type == 'afkstatus') {
+          types_by_host[v.hostname].afk = true;
+        } else if (v.type == 'currentwindow') {
+          types_by_host[v.hostname].window = true;
+        }
+      });
 
-        _.each(types_by_host, (types, hostname) => {
-            if(types.afk === true && types.window === true) {
-                this.activity_hosts.push(hostname);
-            }
-        })
-    })
-  }
-}
-
+      _.each(types_by_host, (types, hostname) => {
+        if (types.afk === true && types.window === true) {
+          this.activity_hosts.push(hostname);
+        }
+      });
+    });
+  },
+};
 </script>
 
 <style lang="scss">
-$bgcolor: #FFF;
+$bgcolor: #fff;
 $textcolor: #000;
 
-html, body, button {
+html,
+body,
+button {
   color: $textcolor;
   font-family: 'Varela Round', sans-serif !important;
 }
 
 body {
-  background-color: #EEE;
+  background-color: #eee;
 }
 
 .fa-icon {
@@ -154,23 +152,23 @@ body {
 }
 
 .aw-navbar {
-    li > a {
-        padding: 10px 15px 10px 15px;
-        color: #555;
-        font-size: 12pt;
+  li > a {
+    padding: 10px 15px 10px 15px;
+    color: #555;
+    font-size: 12pt;
 
-        span {
-            margin-right: 7px;
-        }
+    span {
+      margin-right: 7px;
     }
+  }
 }
 
 .nav-item:hover {
-  background-color: #DDD;
+  background-color: #ddd;
 }
 
 .header {
-  border-bottom: 1px solid #CCC;
+  border-bottom: 1px solid #ccc;
   height: 55px;
   line-height: 55px;
   font-family: 'Varela Round', sans-serif;
@@ -185,8 +183,8 @@ body {
     white-space: nowrap;
 
     img {
-        width: 1.2em;
-        height: 1.2em;
+      width: 1.2em;
+      height: 1.2em;
     }
   }
 
@@ -194,22 +192,22 @@ body {
     float: right;
 
     .text {
-        margin-left: 1em;
+      margin-left: 1em;
     }
 
     .good {
-        color: green;
+      color: green;
     }
 
     .bad {
-        color: red;
+      color: red;
     }
   }
 }
 
 .aw-container {
-  background-color: #FFF;
-  border: 1px solid #CCC;
+  background-color: #fff;
+  border: 1px solid #ccc;
   border-top: 0;
 }
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -5,25 +5,29 @@ import Vue from 'vue';
 
 import moment from 'moment';
 
-Vue.filter('friendlytime', function (timestamp) {
+Vue.filter('friendlytime', function(timestamp) {
   let m = moment.parseZone(timestamp);
   let sinceNow = moment.duration(m.diff(moment()));
-  if(-sinceNow.asSeconds() <= 60) {
-    return "" + -sinceNow.asSeconds() + "s ago";
-  } else if(-sinceNow.asSeconds() <= 60*60*24) {
+  if (-sinceNow.asSeconds() <= 60) {
+    return '' + -sinceNow.asSeconds() + 's ago';
+  } else if (-sinceNow.asSeconds() <= 60 * 60 * 24) {
     return sinceNow.humanize(true);
   }
   return sinceNow.humanize(true);
   //return timestamp;
 });
 
-Vue.filter('friendlyduration', function (seconds) {
-  let d = moment.duration(Number.parseFloat(seconds)*1000);
-  let s = [Math.floor(d.asHours()) + "h", d.minutes() + "m", d.seconds() + "s"].join(" ");
-  s = s.replace(/(0h| 0[ms])/g, "");
-  s = s.replace(/ +/g, " ").trim();
-  if(s === "") {
-    s = "<1 s";
+Vue.filter('friendlyduration', function(seconds) {
+  let d = moment.duration(Number.parseFloat(seconds) * 1000);
+  let s = [
+    Math.floor(d.asHours()) + 'h',
+    d.minutes() + 'm',
+    d.seconds() + 's',
+  ].join(' ');
+  s = s.replace(/(0h| 0[ms])/g, '');
+  s = s.replace(/ +/g, ' ').trim();
+  if (s === '') {
+    s = '<1 s';
   }
   return s;
 });
@@ -31,6 +35,6 @@ Vue.filter('friendlyduration', function (seconds) {
 // Apparently this is how we should do filters now
 // https://github.com/vuejs/vue/issues/2756#issuecomment-215508316
 Vue.prototype.filters = {
-//  filterBy: ...,
-  orderBy: _.orderBy
-}
+  //  filterBy: ...,
+  orderBy: _.orderBy,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -19,13 +19,13 @@ import './filters.js';
 import router from './route.js';
 
 // Register Font Awesome icon component
-import Icon from 'vue-awesome/components/Icon'
-Vue.component('icon', Icon)
+import Icon from 'vue-awesome/components/Icon';
+Vue.component('icon', Icon);
 
 // Setup Vue app
 import App from './App';
 new Vue({
   el: '#app',
   router: router,
-  render: h => h(App)
+  render: h => h(App),
 });

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,68 +1,79 @@
 // TODO: Sanitize string input of buckets
 
-function windowTimelineQuery(windowbucket, afkbucket){
-  return { "query": [
-    'not_afk = query_bucket("'+afkbucket+'");',
-    'events  = query_bucket("'+windowbucket+'");',
-    'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
-    'events  = filter_period_intersect(events, not_afk);',
-    'events  = sort_by_timestamp(events);',
-    'RETURN  = events;',
-  ]};
+function windowTimelineQuery(windowbucket, afkbucket) {
+  return {
+    query: [
+      'not_afk = query_bucket("' + afkbucket + '");',
+      'events  = query_bucket("' + windowbucket + '");',
+      'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
+      'events  = filter_period_intersect(events, not_afk);',
+      'events  = sort_by_timestamp(events);',
+      'RETURN  = events;',
+    ],
+  };
 }
 
-function appSummaryQuery(windowbucket, afkbucket, count){
-  return { "query": [
-    'not_afk = query_bucket("'+afkbucket+'");',
-    'events  = query_bucket("'+windowbucket+'");',
-    'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
-    'events  = filter_period_intersect(events, not_afk);',
-    'events  = merge_events_by_keys(events, "app");',
-    'events  = sort_by_duration(events);',
-    'events  = limit_events(events, '+count+');',
-    'RETURN  = events;',
-  ]};
+function appSummaryQuery(windowbucket, afkbucket, count) {
+  return {
+    query: [
+      'not_afk = query_bucket("' + afkbucket + '");',
+      'events  = query_bucket("' + windowbucket + '");',
+      'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
+      'events  = filter_period_intersect(events, not_afk);',
+      'events  = merge_events_by_keys(events, "app");',
+      'events  = sort_by_duration(events);',
+      'events  = limit_events(events, ' + count + ');',
+      'RETURN  = events;',
+    ],
+  };
 }
 
-function titleSummaryQuery(windowbucket, afkbucket, count){
-  return { "query": [
-    'not_afk=query_bucket("'+afkbucket+'");',
-    'events=query_bucket("'+windowbucket+'");',
-    'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
-    'events=filter_period_intersect(events, not_afk);',
-    'events=merge_events_by_keys(events, "app", "title");',
-    'events=sort_by_duration(events);',
-    'events=limit_events(events, '+count+');',
-    'RETURN=events;',
-  ]};
+function titleSummaryQuery(windowbucket, afkbucket, count) {
+  return {
+    query: [
+      'not_afk=query_bucket("' + afkbucket + '");',
+      'events=query_bucket("' + windowbucket + '");',
+      'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
+      'events=filter_period_intersect(events, not_afk);',
+      'events=merge_events_by_keys(events, "app", "title");',
+      'events=sort_by_duration(events);',
+      'events=limit_events(events, ' + count + ');',
+      'RETURN=events;',
+    ],
+  };
 }
 
-function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count){
-  var browser_appnames = "";
-  if (browserbucket.endsWith("-chrome")){
-    browser_appnames = '"Google-chrome", "chrome.exe", "Chromium", "Google Chrome"';
-  } else if (browserbucket.endsWith("-firefox")){
+function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count) {
+  var browser_appnames = '';
+  if (browserbucket.endsWith('-chrome')) {
+    browser_appnames =
+      '"Google-chrome", "chrome.exe", "Chromium", "Google Chrome"';
+  } else if (browserbucket.endsWith('-firefox')) {
     browser_appnames = '"Firefox", "Firefox.exe", "firefox"';
   }
-  return { "query": [
-    'events=query_bucket("'+browserbucket+'");',
-    'not_afk=query_bucket("'+afkbucket+'");',
-    'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
-    'window_browser=query_bucket("'+windowbucket+'");',
-    'window_browser=filter_keyvals(window_browser, "app", '+browser_appnames+');',
-    'window_browser=filter_period_intersect(window_browser, not_afk);',
-    'events=filter_period_intersect(events, window_browser);',
-    'events=split_url_events(events);',
-    'events=merge_events_by_keys(events, "domain");',
-    'events=sort_by_duration(events);',
-    'events=limit_events(events, '+count+');',
-    'RETURN=events;',
-  ]};
+  return {
+    query: [
+      'events=query_bucket("' + browserbucket + '");',
+      'not_afk=query_bucket("' + afkbucket + '");',
+      'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
+      'window_browser=query_bucket("' + windowbucket + '");',
+      'window_browser=filter_keyvals(window_browser, "app", ' +
+        browser_appnames +
+        ');',
+      'window_browser=filter_period_intersect(window_browser, not_afk);',
+      'events=filter_period_intersect(events, window_browser);',
+      'events=split_url_events(events);',
+      'events=merge_events_by_keys(events, "domain");',
+      'events=sort_by_duration(events);',
+      'events=limit_events(events, ' + count + ');',
+      'RETURN=events;',
+    ],
+  };
 }
 
 module.exports = {
-    "windowTimelineQuery": windowTimelineQuery,
-    "appSummaryQuery": appSummaryQuery,
-    "titleSummaryQuery": titleSummaryQuery,
-    "browserSummaryQuery": browserSummaryQuery,
-}
+  windowTimelineQuery: windowTimelineQuery,
+  appSummaryQuery: appSummaryQuery,
+  titleSummaryQuery: titleSummaryQuery,
+  browserSummaryQuery: browserSummaryQuery,
+};

--- a/src/resources.js
+++ b/src/resources.js
@@ -2,32 +2,31 @@ import Vue from 'vue';
 
 Vue.use(require('vue-resource'));
 
-
-let origin = "";
+let origin = '';
 
 // If running with `npm node dev`, use testing server as origin.
 // Works since CORS is enabled by default when running `aw-server --testing`.
-if(!PRODUCTION) {
-    let protocol = "http";
-    let hostname = "localhost";
-    let port = "5666";
-    origin = protocol + "://" + hostname + ":" + port;
+if (!PRODUCTION) {
+  let protocol = 'http';
+  let hostname = 'localhost';
+  let port = '5666';
+  origin = protocol + '://' + hostname + ':' + port;
 }
 
-
-let $Info       = Vue.resource(origin + '/api/0/info');
-let $Bucket     = Vue.resource(origin + '/api/0/buckets/{id}?force=1');
-let $Event      = Vue.resource(origin + '/api/0/buckets/{id}/events');
+let $Info = Vue.resource(origin + '/api/0/info');
+let $Bucket = Vue.resource(origin + '/api/0/buckets/{id}?force=1');
+let $Event = Vue.resource(origin + '/api/0/buckets/{id}/events');
 let $EventCount = Vue.resource(origin + '/api/0/buckets/{id}/events/count');
-let $Query      = Vue.resource(origin + '/api/0/query/?name={name}&start={start}&end={end}&cache={cache}');
-let $Log        = Vue.resource(origin + '/api/0/log');
+let $Query = Vue.resource(
+  origin + '/api/0/query/?name={name}&start={start}&end={end}&cache={cache}',
+);
+let $Log = Vue.resource(origin + '/api/0/log');
 
 export default {
-  $Info:        $Info,
-  $Bucket:      $Bucket,
-  $Event:       $Event,
-  $EventCount:  $EventCount,
-  $Query:       $Query,
-  $Log:         $Log,
+  $Info: $Info,
+  $Bucket: $Bucket,
+  $Event: $Event,
+  $EventCount: $EventCount,
+  $Query: $Query,
+  $Log: $Log,
 };
-

--- a/src/route.js
+++ b/src/route.js
@@ -13,15 +13,15 @@ Vue.use(VueRouter);
 
 var router = new VueRouter({
   routes: [
-    { path: '/',                        component: Home },
-    { path: '/activity/:host',          component: Activity },
-    { path: '/activity/:host/:date',    component: Activity },
-    { path: '/buckets',                 component: Buckets },
-    { path: '/buckets/:id',             component: Bucket },
-    { path: '/log',                     component: Log },
-    { path: '/u/:username',             component: User },
-    { path: '/settings',                component: Settings },
-  ]
+    {path: '/', component: Home},
+    {path: '/activity/:host', component: Activity},
+    {path: '/activity/:host/:date', component: Activity},
+    {path: '/buckets', component: Buckets},
+    {path: '/buckets/:id', component: Bucket},
+    {path: '/log', component: Log},
+    {path: '/u/:username', component: User},
+    {path: '/settings', component: Settings},
+  ],
 });
 
 export default router;

--- a/src/style/globalvars.scss
+++ b/src/style/globalvars.scss
@@ -1,4 +1,4 @@
 $bgcolor: #242832;
-$textcolor: #CCC;
+$textcolor: #ccc;
 
 $sidebar_width: 200px;

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const d3 = require("d3");
+const d3 = require('d3');
 
 // See here for examples:
 //   https://bl.ocks.org/pstuffa/3393ff2711a53975040077b7453781a9
@@ -8,40 +8,62 @@ const d3 = require("d3");
 let scale = d3.scaleOrdinal(['#90CAF9', '#FFE082', '#EF9A9A', '#A5D6A7']);
 
 // Needed to prewarm the color table
-scale.domain([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+scale.domain([
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+]);
 
 let customColors = {
-    "afk": "#EEE",
-    "not-afk": "#7F6",
-    "hibernating": "#DD6",
+  afk: '#EEE',
+  'not-afk': '#7F6',
+  hibernating: '#DD6',
 
-    "google-chrome": "#6AA7FE",   // Google Blue: "#4885ed"
-    "chromium": "#8CF", // Google Blue: "#4885ed"
-    "firefox": "#F94", // Firefox Orange: "#E55B0A"
-    "spotify": "#5FA",  // Spotify Green: "#1ED760"
-    "alacritty": "#FC7"
+  'google-chrome': '#6AA7FE', // Google Blue: "#4885ed"
+  chromium: '#8CF', // Google Blue: "#4885ed"
+  firefox: '#F94', // Firefox Orange: "#E55B0A"
+  spotify: '#5FA', // Spotify Green: "#1ED760"
+  alacritty: '#FC7',
 };
 
-function hashcode(str){
-    let hash = 0;
-    if (str.length === 0) {
-      return hash;
-    }
-    for (var i = 0; i < str.length; i++) {
-        var character = str.charCodeAt(i);
-        hash = ((hash<<5)-hash)+character;
-        hash = hash & hash; // Convert to 32bit integer
-    }
+function hashcode(str) {
+  let hash = 0;
+  if (str.length === 0) {
     return hash;
+  }
+  for (var i = 0; i < str.length; i++) {
+    var character = str.charCodeAt(i);
+    hash = (hash << 5) - hash + character;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return hash;
 }
 
 function getColorFromString(appname) {
-    appname = appname || "";
-    appname = appname.toLowerCase();
-    return customColors[appname] || scale(Math.abs(hashcode(appname) % 20));
+  appname = appname || '';
+  appname = appname.toLowerCase();
+  return customColors[appname] || scale(Math.abs(hashcode(appname) % 20));
 }
 
 module.exports = {
-    getAppColor: getColorFromString,
-    getColorFromString: getColorFromString
+  getAppColor: getColorFromString,
+  getColorFromString: getColorFromString,
 };

--- a/src/util/event_parsing.js
+++ b/src/util/event_parsing.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-function parse_eventlist_by_apps(eventlist){
+function parse_eventlist_by_apps(eventlist) {
   /*
     This code is ugly and somewhat complex, will hopefully be moved to aw-server in the future
   */
@@ -9,38 +9,37 @@ function parse_eventlist_by_apps(eventlist){
   var curr_app = null;
   var curr_title = null;
   var curr_event = null;
-  for (var event_i in eventlist){
+  for (var event_i in eventlist) {
     var event = eventlist[event_i];
     curr_app = event.data.app;
     curr_title = event.data.title;
-    if (curr_app != prev_app){
-      if (prev_app != null){
+    if (curr_app != prev_app) {
+      if (prev_app != null) {
         apptimeline.push(curr_event);
       }
       curr_event = {
-        "appname": curr_app,
-        "duration": 0,
+        appname: curr_app,
+        duration: 0,
         //"time": moment(event.timestamp).format('HH:mm:ss'), // This is cleaner, i do not know why it doesn't work though
-        "time": moment(new Date(event.timestamp)).format('HH:mm:ss'),
-        "titles": []
+        time: moment(new Date(event.timestamp)).format('HH:mm:ss'),
+        titles: [],
       };
     }
-    curr_event["duration"] += event.duration;
-    curr_event["titles"].push({
-      "title": curr_title,
-      "duration": event.duration,
-      "timestamp": event["timestamp"]
+    curr_event['duration'] += event.duration;
+    curr_event['titles'].push({
+      title: curr_title,
+      duration: event.duration,
+      timestamp: event['timestamp'],
     });
 
     prev_app = curr_app;
   }
-  if (curr_event != null)
-    apptimeline.push(curr_event);
+  if (curr_event != null) apptimeline.push(curr_event);
 
   //console.log(apptimeline);
-  return apptimeline
+  return apptimeline;
 }
 
 export default {
-    parse_eventlist_by_apps: parse_eventlist_by_apps,
-}
+  parse_eventlist_by_apps: parse_eventlist_by_apps,
+};

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,37 +1,34 @@
 import moment from 'moment';
 
 module.exports = {
-    seconds_to_duration: function(seconds){
-        var result = "";
-        var hrs = Math.floor(seconds/60/60);
-        var min = Math.floor(seconds/60%60);
-        var sec = Math.floor(seconds%60);
-        if (hrs != 0)
-            result += hrs + "h";
-        if (hrs != 0 || min != 0)
-            result += min + "m";
-        if (hrs == 0)
-            result += sec + "s";
-        return result;
-    },
+  seconds_to_duration: function(seconds) {
+    var result = '';
+    var hrs = Math.floor(seconds / 60 / 60);
+    var min = Math.floor((seconds / 60) % 60);
+    var sec = Math.floor(seconds % 60);
+    if (hrs != 0) result += hrs + 'h';
+    if (hrs != 0 || min != 0) result += min + 'm';
+    if (hrs == 0) result += sec + 's';
+    return result;
+  },
 
-    get_day_start: function(datestr){
-      // Get start time of date
-      var datestart = moment(datestr);
-      datestart.set('hour', 0);
-      datestart.set('minute', 0);
-      datestart.set('second', 0);
-      datestart.set('millisecond', 0);
-      return datestart;
-    },
+  get_day_start: function(datestr) {
+    // Get start time of date
+    var datestart = moment(datestr);
+    datestart.set('hour', 0);
+    datestart.set('minute', 0);
+    datestart.set('second', 0);
+    datestart.set('millisecond', 0);
+    return datestart;
+  },
 
-    get_prev_day(datestr){
-      var newdate = moment(datestr).add(-1, 'days');
-      return newdate;
-    },
+  get_prev_day(datestr) {
+    var newdate = moment(datestr).add(-1, 'days');
+    return newdate;
+  },
 
-    get_next_day(datestr){
-      var newdate = moment(datestr).add(1, 'days');
-      return newdate;
-    },
-}
+  get_next_day(datestr) {
+    var newdate = moment(datestr).add(1, 'days');
+    return newdate;
+  },
+};

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -38,14 +38,18 @@ div
   div.row
     div.col-md-6
       h5 Top Applications
-      aw-summary(:fields="top_applications", :namefunc="top_applications_namefunc", :colorfunc="top_applications_colorfunc")
+
+      div#appsummary-container
+
       b-button(size="sm", variant="outline-secondary", v-on:click="numberOfWindowApps += 5; queryApps()")
         icon(name="angle-double-down")
         | Show more
 
     div.col-md-6
       h5 Top Window Titles
-      aw-summary(:fields="top_window_titles", :namefunc="top_window_titles_namefunc", :colorfunc="top_window_titles_colorfunc")
+
+      div#windowtitles-container
+
       b-button(size="sm", variant="outline-secondary", v-on:click="numberOfWindowTitles += 5; queryWindowTitles()")
         icon(name="angle-double-down")
         | Show more
@@ -93,7 +97,7 @@ div
 
   div(v-show="browserBucketId")
     br
-    aw-summary(:fields="top_web_domains", :namefunc="top_web_domains_namefunc", :colorfunc="top_web_domains_colorfunc")
+    div#browserdomains-container
 
     b-button(size="sm", variant="outline-secondary", v-on:click="numberOfBrowserDomains += 5; queryBrowserDomains()")
       icon(name="angle-double-down")
@@ -104,114 +108,122 @@ div
 </template>
 
 <style lang="scss">
-
 #apptimeline-container {
-    white-space: nowrap;
-    font-family: sans-serif;
-    font-size: 11pt;
-    line-height: 1.2em;
+  white-space: nowrap;
+  font-family: sans-serif;
+  font-size: 11pt;
+  line-height: 1.2em;
 }
-
 </style>
 
 <script>
 import moment from 'moment';
 import timeline from '../visualizations/timeline.js';
 import summary from '../visualizations/summary.js';
-import time from "../util/time.js";
-import event_parsing from "../util/event_parsing.js";
+import time from '../util/time.js';
+import event_parsing from '../util/event_parsing.js';
 
-import 'vue-awesome/icons/arrow-left'
-import 'vue-awesome/icons/arrow-right'
-import 'vue-awesome/icons/angle-double-down'
-import 'vue-awesome/icons/refresh'
+import 'vue-awesome/icons/arrow-left';
+import 'vue-awesome/icons/arrow-right';
+import 'vue-awesome/icons/angle-double-down';
+import 'vue-awesome/icons/refresh';
 
-import query from '../queries.js';
-
-import Summary from '../visualizations/Summary.vue';
 import Sunburst from '../visualizations/Sunburst.vue';
 
 import Resources from '../resources.js';
-let $Query  = Resources.$Query;
-let $Info  = Resources.$Info;
+let $Query = Resources.$Query;
+let $Info = Resources.$Info;
 let $Bucket = Resources.$Bucket;
-let $Event  = Resources.$Event;
+let $Event = Resources.$Event;
 
 var daylength = 86400000;
 
 export default {
-  name: "Activity",
+  name: 'Activity',
+
+  components: {
+    'aw-sunburst': Sunburst,
+  },
+
   data: () => {
     return {
-      today: moment().startOf('day').format("YYYY-MM-DD"),
+      today: moment()
+        .startOf('day')
+        .format('YYYY-MM-DD'),
 
       filterAFK: true,
       timelineShowAFK: true,
 
       // Query variables
-      duration: "",
-      errormsg: "",
+      duration: '',
+      errormsg: '',
       numberOfWindowApps: 5,
       numberOfWindowTitles: 5,
       numberOfBrowserDomains: 5,
 
       browserBuckets: [],
-      browserBucketId: "",
-
-      top_applications: [],
-      top_applications_namefunc: null,
-      top_applications_colorfunc: null,
-
-      top_window_titles: [],
-      top_window_titles_namefunc: null,
-      top_window_titles_colorfunc: null,
-
-      top_web_domains: {},
-      top_web_domains_namefunc: null,
-      top_web_domains_colorfunc: null,
-    }
+      browserBucketId: '',
+    };
   },
 
-  components: {
-    "aw-sunburst": Sunburst,
-    "aw-summary": Summary,
+  computed: {
+    readableDuration: function() {
+      return time.seconds_to_duration(this.duration);
+    },
+    host: function() {
+      return this.$route.params.host;
+    },
+    date: function() {
+      return (
+        this.$route.params.date ||
+        moment()
+          .startOf('day')
+          .format()
+      );
+    },
+    dateStart: function() {
+      return moment(this.date)
+        .startOf('day')
+        .format();
+    },
+    dateShort: function() {
+      return moment(this.date).format('YYYY-MM-DD');
+    },
+    windowBucketId: function() {
+      return 'aw-watcher-window_' + this.host;
+    },
+    afkBucketId: function() {
+      return 'aw-watcher-afk_' + this.host;
+    },
   },
 
   watch: {
-    '$route': function(to, from) {
-      console.log("Route changed");
+    $route: function(to, from) {
+      console.log('Route changed');
       this.refresh();
     },
-    'filterAFK': function(to, from) {
+    filterAFK: function(to, from) {
       this.refresh();
     },
-    'timelineShowAFK': function(to, from) {
+    timelineShowAFK: function(to, from) {
       this.refresh();
     },
-    'filterAFK': function(to, from) {
+    filterAFK: function(to, from) {
       this.refresh();
     },
-    'timelineShowAFK': function(to, from) {
+    timelineShowAFK: function(to, from) {
       this.refresh();
     },
-    'browserBucketId': function(to, from) {
+    browserBucketId: function(to, from) {
       this.queryBrowserDomains();
     },
   },
 
-  computed: {
-    readableDuration: function() { return time.seconds_to_duration(this.duration) },
-    host: function() { return this.$route.params.host },
-    date: function() { return this.$route.params.date || moment().startOf('day').format() },
-    dateStart: function() { return this.date },
-    dateEnd: function() { return moment(this.date).add(1, 'days').format() },
-    dateShort: function() { return moment(this.date).format("YYYY-MM-DD") },
-    windowBucketId: function() { return "aw-watcher-window_" + this.host },
-    afkBucketId:    function() { return "aw-watcher-afk_"    + this.host },
-  },
-
   mounted: function() {
-    timeline.create(document.getElementById("apptimeline-container"));
+    summary.create(document.getElementById('appsummary-container'));
+    summary.create(document.getElementById('windowtitles-container'));
+    summary.create(document.getElementById('browserdomains-container'));
+    timeline.create(document.getElementById('apptimeline-container'));
 
     this.getBrowserBucket();
 
@@ -219,25 +231,34 @@ export default {
   },
 
   methods: {
-    previousDay: function() { return moment(this.dateStart).subtract(1, 'days').format("YYYY-MM-DD") },
-    nextDay: function() { return moment(this.dateStart).add(1, 'days').format("YYYY-MM-DD") },
+    previousDay: function() {
+      return moment(this.dateStart)
+        .subtract(1, 'days')
+        .format('YYYY-MM-DD');
+    },
+    nextDay: function() {
+      return moment(this.dateStart)
+        .add(1, 'days')
+        .format('YYYY-MM-DD');
+    },
 
     refresh: function() {
-      this.queryAll();
-      this.duration = "";
+      this.query();
+      this.duration = '';
       this.numberOfWindowApps = 5;
       this.numberOfWindowTitles = 5;
     },
 
     errorHandler: function(response) {
       console.error(response);
-      this.errormsg = "Request error " + response.status + ". See F12 console for more info.";
+      this.errormsg =
+        'Request error ' + response.status + '. See F12 console for more info.';
     },
 
-    queryAll: function() {
-      this.duration = "";
+    query: function() {
+      this.duration = '';
       this.eventcount = 0;
-      this.errormsg = "";
+      this.errormsg = '';
 
       this.queryApps();
       this.queryWindowTitles();
@@ -246,91 +267,265 @@ export default {
     },
 
     getBrowserBucket: function() {
-      $Bucket.get().then((response) => {
+      $Bucket.get().then(response => {
         let buckets = response.json();
-        for (var bucket in buckets){
-          if (buckets[bucket]["type"] === "web.tab.current"){
+        for (var bucket in buckets) {
+          if (buckets[bucket]['type'] === 'web.tab.current') {
             this.browserBuckets.push(bucket);
           }
         }
-        if (this.browserBuckets.length > 0){
-          this.browserBucketId = this.browserBuckets[0]
+        if (this.browserBuckets.length > 0) {
+          this.browserBucketId = this.browserBuckets[0];
         }
       });
     },
 
     queryTimeline: function() {
-      var timeline_elem = document.getElementById("apptimeline-container")
-      timeline.set_status(timeline_elem, "Loading...");
-      var q = query.windowTimelineQuery(this.windowBucketId, this.afkBucketId);
-      $Query.save({"name": "window_timeline@"+this.host, "start": this.dateStart, "end": this.dateEnd, "cache": 0}, q).then(
-        (response) => { // Success
-          if (response.status > 304){
+      let starttime = moment(this.dateStart).format();
+      let endtime = moment(this.dateStart)
+        .add(1, 'days')
+        .format();
+
+      var timeline_elem = document.getElementById('apptimeline-container');
+      timeline.set_status(timeline_elem, 'Loading...');
+      var query = this.windowTimelineQuery(
+        this.windowBucketId,
+        this.afkBucketId,
+      );
+      $Query
+        .save(
+          {
+            name: 'window_timeline@' + this.host,
+            start: starttime,
+            end: endtime,
+            cache: 0,
+          },
+          query,
+        )
+        .then(response => {
+          // Success
+          if (response.status > 304) {
             this.errorHandler(response);
           } else {
             var eventlist = response.json();
             var apptimeline = event_parsing.parse_eventlist_by_apps(eventlist);
             var total_duration = this.totalDuration(eventlist);
             this.duration = total_duration;
-            timeline.update(timeline_elem, apptimeline, total_duration, this.timelineShowAFK);
+            timeline.update(
+              timeline_elem,
+              apptimeline,
+              total_duration,
+              this.timelineShowAFK,
+            );
           }
         }, this.errorHandler);
     },
 
     queryWindowTitles: function() {
-      var q = query.titleSummaryQuery(this.windowBucketId, this.afkBucketId, this.numberOfWindowTitles);
-      $Query.save({"name": "title_summary@"+this.host, "start": this.dateStart, "end": this.dateEnd, "cache": 1}, q).then(
-        (response) => { // Success
-          if (response.status > 304){
+      let starttime = moment(this.dateStart).format();
+      let endtime = moment(this.dateStart)
+        .add(1, 'days')
+        .format();
+
+      var container = document.getElementById('windowtitles-container');
+      summary.set_status(container, 'Loading...');
+      var query = this.titleSummaryQuery(
+        this.windowBucketId,
+        this.afkBucketId,
+        this.numberOfWindowTitles,
+      );
+      $Query
+        .save(
+          {
+            name: 'title_summary@' + this.host,
+            start: starttime,
+            end: endtime,
+            cache: 1,
+          },
+          query,
+        )
+        .then(response => {
+          // Success
+          if (response.status > 304) {
             this.errorHandler(response);
           } else {
-            this.top_window_titles_namefunc = (e) => e.data.title;
-            this.top_window_titles_colorfunc = (e) => e.data.app;
-            this.top_window_titles = response.json();
+            var summedEvents = response.json();
+            summary.updateSummedEvents(
+              container,
+              summedEvents,
+              e => e.data.title,
+              e => e.data.app,
+            );
           }
-        }, this.errorHandler
+        }, this.errorHandler);
+    },
+
+    totalDuration: function(eventlist) {
+      var duration = 0;
+      for (var i in eventlist) {
+        duration += eventlist[i].duration;
+      }
+      return duration;
+    },
+
+    queryApps: function() {
+      let starttime = moment(this.dateStart).format();
+      let endtime = moment(this.dateStart)
+        .add(1, 'days')
+        .format();
+
+      var container = document.getElementById('appsummary-container');
+      summary.set_status(container, 'Loading...');
+      var query = this.appSummaryQuery(
+        this.windowBucketId,
+        this.afkBucketId,
+        this.numberOfWindowApps,
       );
-    },
-
-    totalDuration: function(eventlist){
-        var duration = 0;
-        for (var i in eventlist){
-            duration += eventlist[i].duration;
-        }
-        return duration;
-    },
-
-    queryApps: function(){
-      var q = query.appSummaryQuery(this.windowBucketId, this.afkBucketId, this.numberOfWindowApps);
-      $Query.save({"name": "appsummary@"+this.host, "start": this.dateStart, "end": this.dateEnd, "cache": 1}, q).then(
-        (response) => { // Success
-          if (response.status > 304){
+      $Query
+        .save(
+          {
+            name: 'appsummary@' + this.host,
+            start: starttime,
+            end: endtime,
+            cache: 1,
+          },
+          query,
+        )
+        .then(response => {
+          // Success
+          if (response.status > 304) {
             this.errorHandler(response);
           } else {
-            this.top_applications_namefunc = (e) => e.data.app;
-            this.top_applications_colorfunc = (e) => e.data.app;
-            this.top_applications = response.json();
+            var summedEvents = response.json();
+            summary.updateSummedEvents(
+              container,
+              summedEvents,
+              e => e.data.app,
+              e => e.data.app,
+            );
           }
-        }, this.errorHandler
-      );
+        }, this.errorHandler);
     },
 
-    queryBrowserDomains: function(){
-      if (this.browserBucketId !== ""){
-        var q = query.browserSummaryQuery(this.browserBucketId, this.windowBucketId, this.afkBucketId, this.numberOfBrowserDomains);
-        $Query.save({"name": "browser_summary@"+this.host, "start": this.dateStart, "end": this.dateEnd, "cache": 1}, q).then(
-          (response) => { // Success
-            if (response.status > 304){
+    queryBrowserDomains: function() {
+      let starttime = moment(this.dateStart).format();
+      let endtime = moment(this.dateStart)
+        .add(1, 'days')
+        .format();
+
+      var container = document.getElementById('browserdomains-container');
+      summary.set_status(container, 'Loading...');
+      if (this.browserBucketId !== '') {
+        var query = this.browserSummaryQuery(
+          this.browserBucketId,
+          this.windowBucketId,
+          this.afkBucketId,
+          this.numberOfBrowserDomains,
+        );
+        $Query
+          .save(
+            {
+              name: 'browser_summary@' + this.host,
+              start: starttime,
+              end: endtime,
+              cache: 1,
+            },
+            query,
+          )
+          .then(response => {
+            // Success
+            if (response.status > 304) {
               this.errorHandler(response);
             } else {
-              this.top_web_domains_namefunc = (e) => e.data.domain;
-              this.top_web_domains_colorfunc = (e) => e.data.domain;
-              this.top_web_domains = response.json();
+              var summedEvents = response.json();
+              summary.updateSummedEvents(
+                container,
+                summedEvents,
+                e => e.data.domain,
+                e => e.data.domain,
+              );
             }
-          }, this.errorHandler
-        );
+          }, this.errorHandler);
       }
     },
+
+    // TODO: Sanitize string input of buckets
+
+    windowTimelineQuery: function(windowbucket, afkbucket) {
+      return {
+        query: [
+          'not_afk = query_bucket("' + afkbucket + '");',
+          'events  = query_bucket("' + windowbucket + '");',
+          'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
+          'events  = filter_period_intersect(events, not_afk);',
+          'events  = sort_by_timestamp(events);',
+          'RETURN  = events;',
+        ],
+      };
+    },
+
+    appSummaryQuery: function(windowbucket, afkbucket, count) {
+      return {
+        query: [
+          'not_afk = query_bucket("' + afkbucket + '");',
+          'events  = query_bucket("' + windowbucket + '");',
+          'not_afk = filter_keyvals(not_afk, "status", "not-afk");',
+          'events  = filter_period_intersect(events, not_afk);',
+          'events  = merge_events_by_keys(events, "app");',
+          'events  = sort_by_duration(events);',
+          'events  = limit_events(events, ' + count + ');',
+          'RETURN  = events;',
+        ],
+      };
+    },
+
+    titleSummaryQuery: function(windowbucket, afkbucket, count) {
+      return {
+        query: [
+          'not_afk=query_bucket("' + afkbucket + '");',
+          'events=query_bucket("' + windowbucket + '");',
+          'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
+          'events=filter_period_intersect(events, not_afk);',
+          'events=merge_events_by_keys(events, "app", "title");',
+          'events=sort_by_duration(events);',
+          'events=limit_events(events, ' + count + ');',
+          'RETURN=events;',
+        ],
+      };
+    },
+
+    browserSummaryQuery: function(
+      browserbucket,
+      windowbucket,
+      afkbucket,
+      count,
+    ) {
+      var browser_appnames = '';
+      if (browserbucket.endsWith('-chrome')) {
+        browser_appnames =
+          '"Google-chrome", "chrome.exe", "Chromium", "Google Chrome"';
+      } else if (browserbucket.endsWith('-firefox')) {
+        browser_appnames = '"Firefox", "Firefox.exe", "firefox"';
+      }
+      return {
+        query: [
+          'events=query_bucket("' + browserbucket + '");',
+          'not_afk=query_bucket("' + afkbucket + '");',
+          'not_afk=filter_keyvals(not_afk, "status", "not-afk");',
+          'window_browser=query_bucket("' + windowbucket + '");',
+          'window_browser=filter_keyvals(window_browser, "app", ' +
+            browser_appnames +
+            ');',
+          'window_browser=filter_period_intersect(window_browser, not_afk);',
+          'events=filter_period_intersect(events, window_browser);',
+          'events=split_url_events(events);',
+          'events=merge_events_by_keys(events, "domain");',
+          'events=sort_by_duration(events);',
+          'events=limit_events(events, ' + count + ');',
+          'RETURN=events;',
+        ],
+      };
+    },
   },
-}
+};
 </script>

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -59,7 +59,6 @@ div
 </template>
 
 <style scoped lang="scss">
-
 $border-color: #ddd;
 
 .card {
@@ -128,7 +127,8 @@ $border-color: #ddd;
 
 /* Flips the outer element once, then all direct children once,
    leaving the scrollbar in the first flipped yet the content correct */
-.scrollbar-flipped, .scrollbar-flipped > * {
+.scrollbar-flipped,
+.scrollbar-flipped > * {
   transform: rotateX(180deg);
   -ms-transform: rotateX(180deg); /* IE 9 */
   -webkit-transform: rotateX(180deg); /* Safari and Chrome */
@@ -140,57 +140,60 @@ import Resources from '../resources.js';
 
 import Timeline from '../visualizations/Timeline.vue';
 
-import 'vue-awesome/icons/tags'
-import 'vue-awesome/icons/clock-o'
-import 'vue-awesome/icons/calendar-o'
+import 'vue-awesome/icons/tags';
+import 'vue-awesome/icons/clock-o';
+import 'vue-awesome/icons/calendar-o';
 
 let $Bucket = Resources.$Bucket;
 let $Event = Resources.$Event;
 let $EventCount = Resources.$EventCount;
 
 export default {
-  name: "Bucket",
+  name: 'Bucket',
   components: {
-    "aw-timeline": Timeline,
+    'aw-timeline': Timeline,
   },
+
   data: () => {
     return {
       id: String,
       bucket: Object,
       events: [],
       isListExpanded: false,
-      eventcount: "?",
-    }
+      eventcount: '?',
+    };
   },
-  methods: {
-    getBucketInfo: function(bucket_id) {
-      $Bucket.get({"id": bucket_id}).then((response) => {
-        this.bucket = response.json();
-      });
-    },
 
-    getEvents: function(bucket_id) {
-      $Event.get({"id": bucket_id}).then((response) => {
-        this.events = response.json();
-      });
-    },
-
-    getEventCount: function(bucket_id) {
-      $EventCount.get({"id": bucket_id}).then((response) => {
-        this.eventcount = response.json();
-      });
-    },
-
-    expandList: function() {
-      this.isListExpanded = !this.isListExpanded;
-      console.log("List should be expanding: ", this.isListExpanded);
-    }
-  },
   mounted: function() {
     this.id = this.$route.params.id;
     this.getBucketInfo(this.id);
     this.getEvents(this.id);
     this.getEventCount(this.id);
   },
-}
+
+  methods: {
+    getBucketInfo: function(bucket_id) {
+      $Bucket.get({id: bucket_id}).then(response => {
+        this.bucket = response.json();
+      });
+    },
+
+    getEvents: function(bucket_id) {
+      $Event.get({id: bucket_id}).then(response => {
+        this.events = response.json();
+      });
+    },
+
+    getEventCount: function(bucket_id) {
+      $EventCount.get({id: bucket_id}).then(response => {
+        this.eventcount = response.json();
+      });
+    },
+
+    expandList: function() {
+      this.isListExpanded = !this.isListExpanded;
+      console.log('List should be expanding: ', this.isListExpanded);
+    },
+  },
+};
 </script>

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -52,7 +52,8 @@ div
 <style lang="scss">
 // This won't work if scoped
 .bucket-card {
-  .card-header, .card-footer {
+  .card-header,
+  .card-footer {
     padding: 0.5em 0.75em 0.5em 0.75em;
   }
 
@@ -68,7 +69,7 @@ div
 }
 
 .bucket-last-updated {
-    color: #666;
+  color: #666;
 }
 </style>
 
@@ -80,37 +81,40 @@ import 'vue-awesome/icons/trash';
 let $Bucket = Resources.$Bucket;
 
 export default {
-  name: "Buckets",
-  mounted: function() {
-    this.getBuckets();
-  },
+  name: 'Buckets',
+
   data: () => {
     return {
       buckets: [],
-      bucket_to_delete: "",
-    }
+      bucket_to_delete: '',
+    };
   },
+
+  mounted: function() {
+    this.getBuckets();
+  },
+
   methods: {
     getBuckets: function() {
-      $Bucket.get().then((response) => {
+      $Bucket.get().then(response => {
         let buckets = response.json();
-        buckets = _.orderBy(buckets, [(b) => b.last_updated], ["desc"]);
+        buckets = _.orderBy(buckets, [b => b.last_updated], ['desc']);
         this.buckets = buckets;
       });
     },
 
     getBucketInfo: function(bucket_id) {
-      $Bucket.get({"id": bucket_id}).then((response) => {
+      $Bucket.get({id: bucket_id}).then(response => {
         this.buckets[bucket_id] = response.json();
       });
     },
 
     deleteBucket: function(bucket_id) {
-      console.log("Deleting bucket " + bucket_id);
-      $Bucket.delete({"id": bucket_id}).then(() => {
+      console.log('Deleting bucket ' + bucket_id);
+      $Bucket.delete({id: bucket_id}).then(() => {
         this.getBuckets();
       });
-    }
-  }
-}
+    },
+  },
+};
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -63,10 +63,11 @@ div
 </template>
 
 <style scoped lang="scss">
+
 </style>
 
 <script>
 export default {
-  name: "Home"
-}
+  name: 'Home',
+};
 </script>

--- a/src/views/Log.vue
+++ b/src/views/Log.vue
@@ -16,7 +16,7 @@ div
 
 <style lang="scss">
 .panel-default {
-  border-color: #BBB;
+  border-color: #bbb;
   border-radius: 4px;
 
   .panel-heading {
@@ -37,7 +37,6 @@ div
     }
   }
 }
-
 </style>
 
 <script>
@@ -46,21 +45,24 @@ import Resources from '../resources.js';
 let $Log = Resources.$Log;
 
 export default {
-  name: "Log",
-  mounted: function() {
-    this.getLog();
-  },
+  name: 'Log',
+
   data: () => {
     return {
       logs: [],
-    }
+    };
   },
+
+  mounted: function() {
+    this.getLog();
+  },
+
   methods: {
     getLog: function() {
-      $Log.get().then((response) => {
+      $Log.get().then(response => {
         this.logs = response.json();
       });
     },
-  }
-}
+  },
+};
 </script>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -4,6 +4,6 @@ h2 this is settings
 
 <script>
 export default {
-  name: "Settings"
-}
+  name: 'Settings',
+};
 </script>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -11,25 +11,28 @@ div
 </template>
 
 <style lang="scss">
+
 </style>
 
 <script>
 export default {
-  name: "User",
+  name: 'User',
+
   data: () => {
     return {
       user: {
-          name: "Erik Bjäreholt",
-          username: "erb",
-          email: "erik@bjareho.lt"
-      }
-    }
+        name: 'Erik Bjäreholt',
+        username: 'erb',
+        email: 'erik@bjareho.lt',
+      },
+    };
   },
-  methods: {
-  },
+
   mounted: function() {
-      let username = this.$route.params.username;
-      // Fetch user by username
-  }
-}
+    let username = this.$route.params.username;
+    // Fetch user by username
+  },
+
+  methods: {},
+};
 </script>

--- a/src/visualizations/Summary.vue
+++ b/src/visualizations/Summary.vue
@@ -4,8 +4,8 @@ div.aw-summary-container
 
 <style scoped lang="scss">
 svg {
-    border: 1px solid #999;
-    border-radius: 0.5em;
+  border: 1px solid #999;
+  border-radius: 0.5em;
 }
 </style>
 
@@ -16,17 +16,28 @@ svg {
 import summary from './summary.js';
 
 export default {
-  name: "aw-summary",
-  props: ['fields', 'namefunc', 'colorfunc'],
-  mounted: function() {
-    console.log("Mounting aw-summary");
-    summary.create(this.$el);
-    summary.set_status(this.$el, "Loading...");
+  name: 'AwSummary',
+  props: {
+    fields: {type: Array, required: true},
+    namefunc: {type: Function, required: true},
+    colorfunc: {type: Function, required: true},
   },
+
   watch: {
-    "fields": function() {
-      summary.updateSummedEvents(this.$el, this.fields, this.namefunc, this.colorfunc)
-    }
-  }
-}
+    fields: function() {
+      summary.updateSummedEvents(
+        this.$el,
+        this.fields,
+        this.namefunc,
+        this.colorfunc,
+      );
+    },
+  },
+
+  mounted: function() {
+    console.log('Mounting aw-summary');
+    summary.create(this.$el);
+    summary.set_status(this.$el, 'Loading...');
+  },
+};
 </script>

--- a/src/visualizations/Timeline.vue
+++ b/src/visualizations/Timeline.vue
@@ -4,8 +4,8 @@ svg
 
 <style scoped lang="scss">
 svg {
-    border: 1px solid #999;
-    border-radius: 0.5em;
+  border: 1px solid #999;
+  border-radius: 0.5em;
 }
 </style>
 
@@ -18,19 +18,25 @@ svg {
 import timeline_simple from './timeline-simple.js';
 
 export default {
-  name: "aw-timeline",
-  props: ['type', 'event_type', 'events'],
+  name: 'AwTimeline',
+  props: {
+    type: {type: String, required: true},
+    event_type: {type: String, required: true},
+    events: {type: Array, required: true},
+  },
+
+  watch: {
+    events: function() {
+      timeline_simple.update(this.$el, this.events, this.event_type);
+    },
+  },
+
   mounted: function() {
-    if(this.type == "simple") {
+    if (this.type == 'simple') {
       timeline_simple.create(this.$el);
     } else {
-      console.error("Unknown type");
+      console.error('Unknown type');
     }
   },
-  watch: {
-    "events": function() {
-      timeline_simple.update(this.$el, this.events, this.event_type)
-    }
-  }
-}
+};
 </script>

--- a/src/visualizations/coloring.js
+++ b/src/visualizations/coloring.js
@@ -1,13 +1,12 @@
 export default {
-    currentwindow: {
-        key: "app"
-    },
-    afkstatus: {
-        key: "status",
-        colors: {"afk": "#CCC", "not-afk": "#0F4", "hibernating": "#FF6"}
-    },
-    "currently-playing": {
-        key: "title"
-    }
-}
-
+  currentwindow: {
+    key: 'app',
+  },
+  afkstatus: {
+    key: 'status',
+    colors: {afk: '#CCC', 'not-afk': '#0F4', hibernating: '#FF6'},
+  },
+  'currently-playing': {
+    key: 'title',
+  },
+};

--- a/src/visualizations/summary.js
+++ b/src/visualizations/summary.js
@@ -1,59 +1,69 @@
-"use strict";
+'use strict';
 
-const d3 = require("d3");
-const Color = require("color");
-const _ = require("lodash");
+const d3 = require('d3');
+const Color = require('color');
+const _ = require('lodash');
 
-import color from "../util/color.js";
+import color from '../util/color.js';
 
-var time = require("../util/time.js");
+var time = require('../util/time.js');
 
-function create(container){
+function create(container) {
   // Clear element
-  container.innerHTML = "";
+  container.innerHTML = '';
 
   // Create svg canvas
-  let svg = d3.select(container).append("svg");
-  svg.attr("width", "100%")
-   .attr("height", "100px")
-   .attr("class", "appsummary");
+  let svg = d3.select(container).append('svg');
+  svg
+    .attr('width', '100%')
+    .attr('height', '100px')
+    .attr('class', 'appsummary');
 }
 
-function set_status(container, msg){
+function set_status(container, msg) {
   // Select svg canvas
-  let svg_elem = container.querySelector(".appsummary");
+  let svg_elem = container.querySelector('.appsummary');
   let svg = d3.select(svg_elem);
-  svg_elem.innerHTML = "";
+  svg_elem.innerHTML = '';
 
-  svg.append("text")
-   .attr("x", "0px")
-   .attr("y", "25px")
-   .text(msg)
-   .attr("font-family", "sans-serif")
-   .attr("font-size", "25px")
-   .attr("fill", "black");
+  svg
+    .append('text')
+    .attr('x', '0px')
+    .attr('y', '25px')
+    .text(msg)
+    .attr('font-family', 'sans-serif')
+    .attr('font-size', '25px')
+    .attr('fill', 'black');
 }
 
-function updateSummedEvents(container, summedEvents,
-                            titleKeyFunc, colorKeyFunc) {
-  let apps = _.map(summedEvents, (e) => { return {name: titleKeyFunc(e),
-                                                  duration: e.duration,
-                                                  colorKey: colorKeyFunc(e)}; });
+function updateSummedEvents(
+  container,
+  summedEvents,
+  titleKeyFunc,
+  colorKeyFunc,
+) {
+  let apps = _.map(summedEvents, e => {
+    return {
+      name: titleKeyFunc(e),
+      duration: e.duration,
+      colorKey: colorKeyFunc(e),
+    };
+  });
   update(container, apps);
 }
 
 function update(container, apps) {
   // No apps, sets status to "No data"
-  if (apps.length <= 0){
-    set_status(container, "No data");
+  if (apps.length <= 0) {
+    set_status(container, 'No data');
     return container;
   }
 
-  let svg_elem = container.querySelector(".appsummary");
+  let svg_elem = container.querySelector('.appsummary');
   let svg = d3.select(svg_elem);
 
   // Remove apps without a duration from list
-  apps = apps.filter(function(app){
+  apps = apps.filter(function(app) {
     return app.duration !== undefined;
   });
 
@@ -63,60 +73,71 @@ function update(container, apps) {
     // TODO: Expand on click and list titles
 
     // Variables
-    var width = (app.duration/longest_duration)*80+"%";
+    var width = app.duration / longest_duration * 80 + '%';
     let barHeight = 50;
     let textSize = 15;
     var baseappcolor = color.getAppColor(app.colorKey || app.name);
-    var appcolor = Color(baseappcolor).lighten(0.1).hex();
-    var hovercolor = Color(baseappcolor).darken(0.1).hex();
+    var appcolor = Color(baseappcolor)
+      .lighten(0.1)
+      .hex();
+    var hovercolor = Color(baseappcolor)
+      .darken(0.1)
+      .hex();
 
     // The group representing an application in the barchart
-    let eg = svg.append("g");
-    eg.attr("id", "summary_app_"+i)
-      .on("mouseover", function() { eg.select("rect").style("fill", hovercolor); })
-      .on("mouseout", function() { eg.select("rect").style("fill", appcolor); });
+    let eg = svg.append('g');
+    eg
+      .attr('id', 'summary_app_' + i)
+      .on('mouseover', function() {
+        eg.select('rect').style('fill', hovercolor);
+      })
+      .on('mouseout', function() {
+        eg.select('rect').style('fill', appcolor);
+      });
 
     // Color box background
-    eg.append("rect")
-     .attr("x", 0)
-     .attr("y", curr_y)
-     .attr("rx", 5)
-     .attr("ry", 5)
-     .attr("width", width)
-     .attr("height", barHeight)
-     .style("fill", appcolor);
+    eg
+      .append('rect')
+      .attr('x', 0)
+      .attr('y', curr_y)
+      .attr('rx', 5)
+      .attr('ry', 5)
+      .attr('width', width)
+      .attr('height', barHeight)
+      .style('fill', appcolor);
 
     // App name
-    eg.append("text")
-     .attr("x", 5)
-     .attr("y", curr_y + 5 + textSize)
-     .text(app.name)
-     .attr("font-family", "sans-serif")
-     .attr("font-size", textSize + "px")
-     .attr("fill", "black");
+    eg
+      .append('text')
+      .attr('x', 5)
+      .attr('y', curr_y + 5 + textSize)
+      .text(app.name)
+      .attr('font-family', 'sans-serif')
+      .attr('font-size', textSize + 'px')
+      .attr('fill', 'black');
 
     // Duration
-    eg.append("text")
-     .attr("x", 5)
-     .attr("y", curr_y + 5 + textSize + 5 + textSize)
-     .text(time.seconds_to_duration(app.duration))
-     .attr("font-family", "sans-serif")
-     .attr("font-size", textSize + "px")
-     .attr("fill", "black");
+    eg
+      .append('text')
+      .attr('x', 5)
+      .attr('y', curr_y + 5 + textSize + 5 + textSize)
+      .text(time.seconds_to_duration(app.duration))
+      .attr('font-family', 'sans-serif')
+      .attr('font-size', textSize + 'px')
+      .attr('fill', 'black');
 
     curr_y += barHeight + 5;
-
   });
   curr_y -= 5;
 
-  svg.attr("height", curr_y);
+  svg.attr('height', curr_y);
 
   return container;
 }
 
 module.exports = {
-  "create": create,
-  "update": update,
-  "updateSummedEvents": updateSummedEvents,
-  "set_status": set_status,
+  create: create,
+  update: update,
+  updateSummedEvents: updateSummedEvents,
+  set_status: set_status,
 };

--- a/src/visualizations/sunburst.js
+++ b/src/visualizations/sunburst.js
@@ -14,11 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const d3 = require("d3");
-const moment = require("moment");
+const d3 = require('d3');
+const moment = require('moment');
 
-const time = require("../util/time.js");
-const color = require("../util/color.js");
+const time = require('../util/time.js');
+const color = require('../util/color.js');
 
 // Dimensions of sunburst.
 var width = 750;
@@ -27,76 +27,89 @@ var radius = Math.min(width, height) / 2;
 
 // Breadcrumb dimensions: width, height, spacing, width of tip/tail.
 var b = {
-  w: 75, h: 30, s: 3, t: 10
+  w: 75,
+  h: 30,
+  s: 3,
+  t: 10,
 };
 
 var legendData = {
-    "afk": color.getColorFromString("afk"),
-    "not-afk": color.getColorFromString("not-afk"),
-    "hibernating": color.getColorFromString("hibernating"),
-}
+  afk: color.getColorFromString('afk'),
+  'not-afk': color.getColorFromString('not-afk'),
+  hibernating: color.getColorFromString('hibernating'),
+};
 
 // Total size of all segments; we set this later, after loading the data.
 var totalSize = 0;
 
-var rootEl;  // The root DOM node of the graph as a d3 object
-var vis;     // The root SVG node of the graph as a d3 object
+var rootEl; // The root DOM node of the graph as a d3 object
+var vis; // The root SVG node of the graph as a d3 object
 var partition;
 var arc;
 
 function create(el) {
   // Clear the svg in case we are redrawing
-  rootEl = d3.select(".chart");
-  rootEl.selectAll("svg").remove();
+  rootEl = d3.select('.chart');
+  rootEl.selectAll('svg').remove();
 
-  vis = rootEl.append("svg:svg")
-      .attr("width", width)
-      .attr("height", height)
-      .append("svg:g")
-      .attr("id", "container")
-      .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+  vis = rootEl
+    .append('svg:svg')
+    .attr('width', width)
+    .attr('height', height)
+    .append('svg:g')
+    .attr('id', 'container')
+    .attr('transform', 'translate(' + width / 2 + ',' + height / 2 + ')');
 
   drawLegend(el);
 
-  partition = d3.partition()
-      .size([2 * Math.PI, radius * radius]);
+  partition = d3.partition().size([2 * Math.PI, radius * radius]);
 
-  arc = d3.arc()
-      .startAngle(function(d) { return d.x0; })
-      .endAngle(function(d) { return d.x1; })
-      .innerRadius(function(d) { return Math.sqrt(d.y0); })
-      .outerRadius(function(d) { return Math.sqrt(d.y1); });
+  arc = d3
+    .arc()
+    .startAngle(function(d) {
+      return d.x0;
+    })
+    .endAngle(function(d) {
+      return d.x1;
+    })
+    .innerRadius(function(d) {
+      return Math.sqrt(d.y0);
+    })
+    .outerRadius(function(d) {
+      return Math.sqrt(d.y1);
+    });
 }
 
 function drawClockTick(a) {
   let xn = Math.cos(a);
   let yn = Math.sin(a);
 
-  vis.append("line")
-     .attr("x1", 170 * xn)
-     .attr("y1", 170 * yn)
-     .attr("x2", 155 * xn)
-     .attr("y2", 155 * yn)
-     .style("stroke", "#CCC")
-     .style("stroke-width", 1);
+  vis
+    .append('line')
+    .attr('x1', 170 * xn)
+    .attr('y1', 170 * yn)
+    .attr('x2', 155 * xn)
+    .attr('y2', 155 * yn)
+    .style('stroke', '#CCC')
+    .style('stroke-width', 1);
 }
 
 function drawClock(h, m, text) {
-  let a = 2 * Math.PI * ((h / 24) + (m / 24 / 60)) - (1/2 * Math.PI);
+  let a = 2 * Math.PI * (h / 24 + m / 24 / 60) - 1 / 2 * Math.PI;
   drawClockTick(a);
 
   let xn = Math.cos(a);
   let yn = Math.sin(a);
 
-  vis.append("text")
-     .text(text || moment({hours: h}).format("HH:mm"))
-     .attr("text-anchor", "middle")
-     .attr("font-size", "1.2em")
-     //.attr("font-weight", "bold")
-     .style("fill", "#999")
-     .attr("x", 130 * xn)
-     .attr("y", 5 + 140 * yn);
-
+  vis
+    .append('text')
+    .text(text || moment({hours: h}).format('HH:mm'))
+    .attr('text-anchor', 'middle')
+    .attr('font-size', '1.2em')
+    //.attr("font-weight", "bold")
+    .style('fill', '#999')
+    .attr('x', 130 * xn)
+    .attr('y', 5 + 140 * yn);
 }
 
 // Main function to draw and set up the visualization, once we have the data.
@@ -104,28 +117,29 @@ function update(el, json) {
   // Basic setup of page elements.
   initializeBreadcrumbTrail();
 
-  el.querySelector("#container").innerHTML = "";
+  el.querySelector('#container').innerHTML = '';
 
   // Bounding circle underneath the sunburst, to make it easier to detect
   // when the mouse leaves the parent g.
-  vis.append("svg:circle")
-      .attr("r", radius)
-      .style("opacity", 0);
+  vis
+    .append('svg:circle')
+    .attr('r', radius)
+    .style('opacity', 0);
 
   // Turn the data into a d3 hierarchy and calculate the sums.
   var root = d3.hierarchy(json);
   var nodes = partition(root);
 
   let mode_clock = true;
-  if(mode_clock) {
+  if (mode_clock) {
     // TODO: Make this a checkbox in the UI
     let show_whole_day = true;
 
     let root_start = moment(json.timestamp);
-    let root_end = moment(json.timestamp).add(json.duration, "seconds");
-    if(show_whole_day) {
-      root_start = root_start.startOf("day");
-      root_end = root_start.clone().endOf("day");
+    let root_end = moment(json.timestamp).add(json.duration, 'seconds');
+    if (show_whole_day) {
+      root_start = root_start.startOf('day');
+      root_end = root_start.clone().endOf('day');
 
       drawClock(0, 0);
       drawClock(6, 0);
@@ -134,23 +148,40 @@ function update(el, json) {
 
       // TODO: Draw only if showing today
       let now = moment();
-      drawClock(now.hour(), now.minute(), "Now");
+      drawClock(now.hour(), now.minute(), 'Now');
     }
 
-    nodes = nodes.each(function(d) {
-        let loc_start_sec = moment(d.data.timestamp).diff(root_start, "seconds", true);
-        let loc_end_sec = moment(d.data.timestamp).add(d.data.duration, "seconds").diff(root_start, "seconds", true);
+    nodes = nodes
+      .each(function(d) {
+        let loc_start_sec = moment(d.data.timestamp).diff(
+          root_start,
+          'seconds',
+          true,
+        );
+        let loc_end_sec = moment(d.data.timestamp)
+          .add(d.data.duration, 'seconds')
+          .diff(root_start, 'seconds', true);
 
-        let loc_start = Math.max(0, loc_start_sec / ((root_end - root_start) / 1000));
-        let loc_end = Math.min(1, loc_end_sec / ((root_end - root_start) / 1000));
+        let loc_start = Math.max(
+          0,
+          loc_start_sec / ((root_end - root_start) / 1000),
+        );
+        let loc_end = Math.min(
+          1,
+          loc_end_sec / ((root_end - root_start) / 1000),
+        );
 
         d.x0 = 2 * Math.PI * loc_start;
         d.x1 = 2 * Math.PI * loc_end;
-      }).descendants()
+      })
+      .descendants();
   } else {
-      root = root.sum((d) => d.duration)
-                 .sort((a, b) => JSON.stringify(a.data.data).localeCompare(JSON.stringify(b.data.data)));
-      nodes = nodes.descendants();
+    root = root
+      .sum(d => d.duration)
+      .sort((a, b) =>
+        JSON.stringify(a.data.data).localeCompare(JSON.stringify(b.data.data)),
+      );
+    nodes = nodes.descendants();
   }
 
   // For efficiency, filter nodes to keep only those large enough to see.
@@ -160,56 +191,55 @@ function update(el, json) {
     //   0.0044 rad = 1min
     //   0.0011 rad = 15s
     let threshold = 0.001;
-    return (d.x1 - d.x0 > threshold);
+    return d.x1 - d.x0 > threshold;
   });
 
-  var path = vis.data([json]).selectAll("path")
-      .data(nodes)
-      .enter().append("svg:path")
-      .attr("display", function(d) { return d.depth ? null : "none"; })
-      .attr("d", arc)
-      .attr("fill-rule", "evenodd")
-      .style("fill", function(d) {
-          return color.getColorFromString(d.data.data.status || d.data.data.app);
-      })
-      .style("opacity", 1)
-      .on("mouseover", mouseover)
-      .on("click", mouseclick);
+  var path = vis
+    .data([json])
+    .selectAll('path')
+    .data(nodes)
+    .enter()
+    .append('svg:path')
+    .attr('display', function(d) {
+      return d.depth ? null : 'none';
+    })
+    .attr('d', arc)
+    .attr('fill-rule', 'evenodd')
+    .style('fill', function(d) {
+      return color.getColorFromString(d.data.data.status || d.data.data.app);
+    })
+    .style('opacity', 1)
+    .on('mouseover', mouseover)
+    .on('click', mouseclick);
 
   // Add the mouseleave handler to the bounding circle.
-  d3.select("#container").on("mouseleave", mouseleave);
+  d3.select('#container').on('mouseleave', mouseleave);
 
   // Get total size of the tree = value of root node from partition.
   totalSize = path.datum().value;
 }
 
 function mouseclick(d) {
-  console.log("Clicked");
+  console.log('Clicked');
   console.log(d);
 }
 
 function showInfo(d) {
-  let hoverEl = d3.select(".explanation > .hover");
+  let hoverEl = d3.select('.explanation > .hover');
 
   let m = moment(d.data.timestamp);
-  hoverEl.select(".date")
-      .text(m.format("YYYY-MM-DD"));
-  hoverEl.select(".time")
-      .text(m.format("HH:mm:ss"));
+  hoverEl.select('.date').text(m.format('YYYY-MM-DD'));
+  hoverEl.select('.time').text(m.format('HH:mm:ss'));
 
-  let durationString = time.seconds_to_duration(d.data.duration)
-  hoverEl.select(".duration")
-      .text(durationString);
+  let durationString = time.seconds_to_duration(d.data.duration);
+  hoverEl.select('.duration').text(durationString);
 
-  hoverEl.select(".title")
-    .text(d.data.data.app || d.data.data.status);
+  hoverEl.select('.title').text(d.data.data.app || d.data.data.status);
 
-  hoverEl.select(".data")
-      .text(d.data.data.title || "");
+  hoverEl.select('.data').text(d.data.data.title || '');
 
-  d3.select(".explanation > .base")
-      .style("display", "none");
-  hoverEl.style("visibility", "");
+  d3.select('.explanation > .base').style('display', 'none');
+  hoverEl.style('visibility', '');
 }
 
 // Fade all but the current sequence, and show it in the breadcrumb trail.
@@ -220,86 +250,101 @@ function mouseover(d) {
   sequenceArray.shift(); // remove root node from the array
 
   // Fade all the segments.
-  rootEl.selectAll("path")
-      .style("opacity", 0.5);
+  rootEl.selectAll('path').style('opacity', 0.5);
 
   // Then highlight only those that are an ancestor of the current segment.
   // FIXME: This currently makes all other svg paths on the page faded as well
-  rootEl.selectAll("path")
-      .filter(function(node) {
-                return (sequenceArray.indexOf(node) >= 0);
-              })
-      .style("opacity", 1);
+  rootEl
+    .selectAll('path')
+    .filter(function(node) {
+      return sequenceArray.indexOf(node) >= 0;
+    })
+    .style('opacity', 1);
 }
 
 // Restore everything to full opacity when moving off the visualization.
 function mouseleave(d) {
   // Deactivate all segments during transition.
-  rootEl.selectAll("path").on("mouseover", null);
+  rootEl.selectAll('path').on('mouseover', null);
 
   // Transition each segment to full opacity and then reactivate it.
-  rootEl.selectAll("path")
+  rootEl
+    .selectAll('path')
     .transition()
     .duration(100)
-    .style("opacity", 1)
-    .on("end", function() {
-                 d3.select(this).on("mouseover", mouseover);
-               });
+    .style('opacity', 1)
+    .on('end', function() {
+      d3.select(this).on('mouseover', mouseover);
+    });
 
-  rootEl.select(".explanation > .base")
-        .style("display", "");
-  rootEl.select(".explanation > .hover")
-        .style("visibility", "hidden");
+  rootEl.select('.explanation > .base').style('display', '');
+  rootEl.select('.explanation > .hover').style('visibility', 'hidden');
 }
 
 function initializeBreadcrumbTrail() {
   // Add the svg area.
-  var trail = d3.select(".sequence").append("svg:svg")
-      .attr("width", width)
-      .attr("height", 50)
-      .attr("id", "trail");
+  var trail = d3
+    .select('.sequence')
+    .append('svg:svg')
+    .attr('width', width)
+    .attr('height', 50)
+    .attr('id', 'trail');
   // Add the label at the end, for the percentage.
-  trail.append("svg:text")
-    .attr("id", "endlabel")
-    .style("fill", "#000");
+  trail
+    .append('svg:text')
+    .attr('id', 'endlabel')
+    .style('fill', '#000');
 }
 
 function drawLegend() {
   // Dimensions of legend item: width, height, spacing, radius of rounded rect.
   var li = {
-    w: 75, h: 30, s: 3, r: 3
+    w: 75,
+    h: 30,
+    s: 3,
+    r: 3,
   };
 
-  var legend = d3.select(".legend").append("svg:svg")
-      .attr("width", li.w)
-      .attr("height", d3.keys(legendData).length * (li.h + li.s));
+  var legend = d3
+    .select('.legend')
+    .append('svg:svg')
+    .attr('width', li.w)
+    .attr('height', d3.keys(legendData).length * (li.h + li.s));
 
-  var g = legend.selectAll("g")
-      .data(d3.entries(legendData))
-      .enter().append("svg:g")
-      .attr("transform", function(d, i) {
-              return "translate(0," + i * (li.h + li.s) + ")";
-           });
+  var g = legend
+    .selectAll('g')
+    .data(d3.entries(legendData))
+    .enter()
+    .append('svg:g')
+    .attr('transform', function(d, i) {
+      return 'translate(0,' + i * (li.h + li.s) + ')';
+    });
 
-  g.append("svg:rect")
-      .attr("rx", li.r)
-      .attr("ry", li.r)
-      .attr("width", li.w)
-      .attr("height", li.h)
-      .style("fill", function(d) { return d.value; });
+  g
+    .append('svg:rect')
+    .attr('rx', li.r)
+    .attr('ry', li.r)
+    .attr('width', li.w)
+    .attr('height', li.h)
+    .style('fill', function(d) {
+      return d.value;
+    });
 
-  g.append("svg:text")
-      .attr("x", li.w / 2)
-      .attr("y", li.h / 2)
-      .attr("dy", "0.35em")
-      .attr("text-anchor", "middle")
-      .text(function(d) { return d.key; });
+  g
+    .append('svg:text')
+    .attr('x', li.w / 2)
+    .attr('y', li.h / 2)
+    .attr('dy', '0.35em')
+    .attr('text-anchor', 'middle')
+    .text(function(d) {
+      return d.key;
+    });
 }
 
 // NOTE: The original version of this sunburst contained a buildHierarchy
 //       function that's not used in our version.
 
 export default {
-    "create": create,
-    "update": update
-}
+  create: create,
+  update: update,
+};

--- a/src/visualizations/timeline-simple.js
+++ b/src/visualizations/timeline-simple.js
@@ -1,56 +1,58 @@
-"use strict";
+'use strict';
 
-const d3 = require("d3");
-const Color = require("color");
-const _ = require("lodash");
-const moment = require("moment");
+const d3 = require('d3');
+const Color = require('color');
+const _ = require('lodash');
+const moment = require('moment');
 
-import event_parsing from "../util/event_parsing";
-import color from "../util/color.js";
-import coloring_types from "./coloring.js";
+import event_parsing from '../util/event_parsing';
+import color from '../util/color.js';
+import coloring_types from './coloring.js';
 
-var time = require("../util/time.js");
+var time = require('../util/time.js');
 
 // Helper functions used when hover state changes.
 function set_color(elem_id, color) {
   var rect = document.getElementById(elem_id).children[0];
   rect.style.fill = color;
-};
+}
 
 function create(svg_el) {
   // Clear element
-  svg_el.innerHTML = "";
+  svg_el.innerHTML = '';
 
   // svg for the colored timeline
-  let timeline = d3.select(svg_el)
-    .attr("viewBox", "0 0 100 4")
-    .attr("width", "100%");
+  let timeline = d3
+    .select(svg_el)
+    .attr('viewBox', '0 0 100 4')
+    .attr('width', '100%');
 }
 
-function set_status(svg_el, text){
+function set_status(svg_el, text) {
   let timeline = d3.select(svg_el);
-  timeline.selectAll("*").remove();
+  timeline.selectAll('*').remove();
 
-  timeline.append("text")
-   .attr("x", "0")
-   .attr("y", "3")
-   .text(text)
-   .attr("font-family", "sans-serif")
-   .attr("font-size", "2")
-   .attr("fill", "black")
+  timeline
+    .append('text')
+    .attr('x', '0')
+    .attr('y', '3')
+    .text(text)
+    .attr('font-family', 'sans-serif')
+    .attr('font-size', '2')
+    .attr('fill', 'black');
 }
 
 function update(svg_el, events, event_type) {
-  if(coloring_types[event_type] === undefined) {
-    console.log("");
+  if (coloring_types[event_type] === undefined) {
+    console.log('');
   }
   let coloring = coloring_types[event_type];
 
   let timeline = d3.select(svg_el);
-  timeline.selectAll("*").remove();
+  timeline.selectAll('*').remove();
 
-  if (events.length <= 0){
-    set_status(svg_el, "No data");
+  if (events.length <= 0) {
+    set_status(svg_el, 'No data');
     return;
   }
 
@@ -61,18 +63,21 @@ function update(svg_el, events, event_type) {
   let m_first = moment(e_first.timestamp);
   let m_last = moment(e_last.timestamp);
   let total_duration = (m_last - m_first) / 1000 + e_last.duration;
-  console.log("First: " + m_first.format());
-  console.log("Last: " + m_last.format());
-  console.log("Duration: " + total_duration);
+  console.log('First: ' + m_first.format());
+  console.log('Last: ' + m_last.format());
+  console.log('Duration: ' + total_duration);
 
   // Iterate over each event and create interval boxes
   _.each(events, function(e, i) {
-    let id = "timeline_event_" + i;
+    let id = 'timeline_event_' + i;
     let timestamp = moment(e.timestamp);
 
     let color_base = undefined;
-    let color_key = coloring.key !== undefined ? e.data[coloring.key] : JSON.stringify(e.data);
-    if(coloring.colors !== undefined) {
+    let color_key =
+      coloring.key !== undefined
+        ? e.data[coloring.key]
+        : JSON.stringify(e.data);
+    if (coloring.colors !== undefined) {
       color_base = coloring.colors[color_key];
     } else {
       // Get one random color per value
@@ -82,34 +87,45 @@ function update(svg_el, events, event_type) {
     let x = (timestamp - m_first) / 1000 / total_duration;
     let width = 100 * e.duration / total_duration;
 
-    let eg = timeline.append("g")
-      .attr("id", id)
-      .attr("transform", "translate(" + 100 * x + "," + 0 + ")");
+    let eg = timeline
+      .append('g')
+      .attr('id', id)
+      .attr('transform', 'translate(' + 100 * x + ',' + 0 + ')');
 
-    let rect = eg.append("rect")
-      .attr("width", width)
-      .attr("height", 4)
-      .style("fill", color_base)
-      .on("mouseover", () => {
-          let color_hover = Color(color_base).darken(0.4).hex();
-          set_color(id, color_hover);
+    let rect = eg
+      .append('rect')
+      .attr('width', width)
+      .attr('height', 4)
+      .style('fill', color_base)
+      .on('mouseover', () => {
+        let color_hover = Color(color_base)
+          .darken(0.4)
+          .hex();
+        set_color(id, color_hover);
       })
-      .on("mouseout", () => {
-          set_color(id, color_base);
+      .on('mouseout', () => {
+        set_color(id, color_base);
       });
 
-    rect.append("title")
-        .text(timestamp.format() + "\n"
-            + "Duration: " + time.seconds_to_duration(e.duration) + "\n"
-            + JSON.stringify(e.data));
+    rect
+      .append('title')
+      .text(
+        timestamp.format() +
+          '\n' +
+          'Duration: ' +
+          time.seconds_to_duration(e.duration) +
+          '\n' +
+          JSON.stringify(e.data),
+      );
 
-    if(e.duration > 0.05 * total_duration) {
-      eg.append("text")
-        .attr("font-size", 2)
-        .attr("x", 1)
-        .attr("y", 2.5)
-        .attr("pointer-events", "none")
-        .text(e.data[coloring.key])
+    if (e.duration > 0.05 * total_duration) {
+      eg
+        .append('text')
+        .attr('font-size', 2)
+        .attr('x', 1)
+        .attr('y', 2.5)
+        .attr('pointer-events', 'none')
+        .text(e.data[coloring.key]);
     }
   });
 
@@ -117,6 +133,6 @@ function update(svg_el, events, event_type) {
 }
 
 module.exports = {
-  "create": create,
-  "update": update,
+  create: create,
+  update: update,
 };

--- a/src/visualizations/timeline.js
+++ b/src/visualizations/timeline.js
@@ -1,100 +1,114 @@
-"use strict";
+'use strict';
 
 /*
  * Creates a colored timeline where you can hover for more info.
  */
 
-const d3 = require("d3");
-const Color = require("color");
-const _ = require("lodash");
-const moment = require("moment");
+const d3 = require('d3');
+const Color = require('color');
+const _ = require('lodash');
+const moment = require('moment');
 
-import event_parsing from "../util/event_parsing";
-import color from "../util/color.js"
+import event_parsing from '../util/event_parsing';
+import color from '../util/color.js';
 
-const time = require("../util/time.js");
+const time = require('../util/time.js');
 
 function show_info(elem_id) {
   var title_event_box = document.getElementById(elem_id);
-  var titleinfo = document.getElementById("titleinfo-container");
+  var titleinfo = document.getElementById('titleinfo-container');
   titleinfo.innerHTML = title_event_box.innerHTML;
-  titleinfo.style.height = title_event_box.getAttribute("height");
-};
+  titleinfo.style.height = title_event_box.getAttribute('height');
+}
 
 function create(container) {
   // Clear element
-  container.innerHTML = "";
+  container.innerHTML = '';
 
   // svg for the colored timeline
-  let timeline = d3.select(container).append("svg")
-    .attr("viewBox", "0 0 100 10")
-    .attr("width", "100%")
-    .attr("class", "apptimeline");
+  let timeline = d3
+    .select(container)
+    .append('svg')
+    .attr('viewBox', '0 0 100 10')
+    .attr('width', '100%')
+    .attr('class', 'apptimeline');
 
   // Hidden svg image that stores all titleinfo for each timeperiod
-  let titleinfo_list = d3.select(container).append("div")
-    .attr("display", "none")
-    .attr("class", "titleinfo_list");
+  let titleinfo_list = d3
+    .select(container)
+    .append('div')
+    .attr('display', 'none')
+    .attr('class', 'titleinfo_list');
 
   // Container for titleinfo that has a fixed size and a overflow scroll
-  let titleinfo_container = document.createElement("div");
-  titleinfo_container.style.width = "100%";
-  titleinfo_container.style.height = "200px";
-  titleinfo_container.style.overflowY = "scroll";
+  let titleinfo_container = document.createElement('div');
+  titleinfo_container.style.width = '100%';
+  titleinfo_container.style.height = '200px';
+  titleinfo_container.style.overflowY = 'scroll';
   container.appendChild(titleinfo_container);
 
   // Titleinfo box that changes content depending on what was timeperiod was last recently hovered on
-  let titleinfo = d3.select(titleinfo_container).append("div")
-    .attr("width", "100%")
-    .attr("id", "titleinfo-container");
+  let titleinfo = d3
+    .select(titleinfo_container)
+    .append('div')
+    .attr('width', '100%')
+    .attr('id', 'titleinfo-container');
 }
 
-function set_status(container, text){
-  let timeline_elem = container.querySelector(".apptimeline");
-  let titleinfo_list_elem = container.querySelector(".titleinfo_list");
-  let titleinfo_container_elem = container.querySelector("#titleinfo-container");
+function set_status(container, text) {
+  let timeline_elem = container.querySelector('.apptimeline');
+  let titleinfo_list_elem = container.querySelector('.titleinfo_list');
+  let titleinfo_container_elem = container.querySelector(
+    '#titleinfo-container',
+  );
 
   let timeline = d3.select(timeline_elem);
-  timeline_elem.innerHTML = "";
-  titleinfo_list_elem.innerHTML = "";
-  titleinfo_container_elem.innerHTML = "";
+  timeline_elem.innerHTML = '';
+  titleinfo_list_elem.innerHTML = '';
+  titleinfo_container_elem.innerHTML = '';
 
-  timeline.append("text")
-   .attr("x", "0")
-   .attr("y", "3")
-   .text(text)
-   .attr("font-family", "sans-serif")
-   .attr("font-size", "3")
-   .attr("fill", "black")
+  timeline
+    .append('text')
+    .attr('x', '0')
+    .attr('y', '3')
+    .text(text)
+    .attr('font-family', 'sans-serif')
+    .attr('font-size', '3')
+    .attr('fill', 'black');
 }
 
-function update(container, events, total_duration, showAFK){
-  let timeline_elem = container.querySelector(".apptimeline");
-  let titleinfo_list_elem = container.querySelector(".titleinfo_list");
-  let titleinfo_container_elem = container.querySelector("#titleinfo-container");
+function update(container, events, total_duration, showAFK) {
+  let timeline_elem = container.querySelector('.apptimeline');
+  let titleinfo_list_elem = container.querySelector('.titleinfo_list');
+  let titleinfo_container_elem = container.querySelector(
+    '#titleinfo-container',
+  );
 
   let timeline = d3.select(timeline_elem);
-  timeline_elem.innerHTML = "";
+  timeline_elem.innerHTML = '';
 
   let titleinfo_list = d3.select(titleinfo_list_elem);
-  titleinfo_list_elem.innerHTML = "";
+  titleinfo_list_elem.innerHTML = '';
 
   let titleinfo_container = d3.select(titleinfo_container_elem);
-  titleinfo_container_elem.innerHTML = "";
+  titleinfo_container_elem.innerHTML = '';
 
-  if (events.length <= 0){
-    set_status(container, "No data");
+  if (events.length <= 0) {
+    set_status(container, 'No data');
     return;
   }
 
-  if(showAFK) {
-    let firstEvent = _.minBy(events, (o) => o.titles[0].timestamp);
-    let lastEvent = _.maxBy(events, (o) => o.titles[0].timestamp);
+  if (showAFK) {
+    let firstEvent = _.minBy(events, o => o.titles[0].timestamp);
+    let lastEvent = _.maxBy(events, o => o.titles[0].timestamp);
 
     var timeStart = moment(firstEvent.titles[0].timestamp);
-    var timeEnd = moment(lastEvent.titles[0].timestamp).add(lastEvent.duration, "seconds");
+    var timeEnd = moment(lastEvent.titles[0].timestamp).add(
+      lastEvent.duration,
+      'seconds',
+    );
 
-    var secSinceStart = timeEnd.diff(timeStart, "seconds", true);
+    var secSinceStart = timeEnd.diff(timeStart, 'seconds', true);
 
     // If we want to show from 00:00
     //timeStart = timeStart.startOf('day');
@@ -105,67 +119,72 @@ function update(container, events, total_duration, showAFK){
   _.each(events, function(e, i) {
     // Timeline rect
 
-    if(showAFK) {
-      let eventBegin = moment(_.minBy(e.titles, (t) => t.timestamp).timestamp);
-      var eventX = eventBegin.diff(timeStart, "seconds", true) / secSinceStart;
-      eventX = eventX * 100 + "%";
-      var eventWidth = e.duration / secSinceStart * 100 + "%";
+    if (showAFK) {
+      let eventBegin = moment(_.minBy(e.titles, t => t.timestamp).timestamp);
+      var eventX = eventBegin.diff(timeStart, 'seconds', true) / secSinceStart;
+      eventX = eventX * 100 + '%';
+      var eventWidth = e.duration / secSinceStart * 100 + '%';
     } else {
       var eventX = curr_x;
       var eventWidth = e.duration / total_duration * 100;
     }
 
     var appcolor = color.getAppColor(e.appname);
-    var hovercolor = Color(appcolor).darken(0.4).hex();
+    var hovercolor = Color(appcolor)
+      .darken(0.4)
+      .hex();
 
-    let eg = timeline.append("g")
-      .attr("id", "timeline_event_"+i);
+    let eg = timeline.append('g').attr('id', 'timeline_event_' + i);
 
-    let rect = eg.append("rect")
-      .attr("x", eventX)
-      .attr("y", 0)
-      .attr("width", eventWidth)
-      .attr("height", 10)
-      .style("fill", color.getAppColor(e.appname))
-      .on("mouseover", () => {
-          rect.style("fill", hovercolor);
-          show_info("titleinfo_event_" + i);
+    let rect = eg
+      .append('rect')
+      .attr('x', eventX)
+      .attr('y', 0)
+      .attr('width', eventWidth)
+      .attr('height', 10)
+      .style('fill', color.getAppColor(e.appname))
+      .on('mouseover', () => {
+        rect.style('fill', hovercolor);
+        show_info('titleinfo_event_' + i);
       })
-      .on("mouseout", () => {
-          rect.style("fill", appcolor);
-      })
+      .on('mouseout', () => {
+        rect.style('fill', appcolor);
+      });
 
     // Titleinfo box
-    var infobox = titleinfo_list.append("div")
-      .attr("id", "titleinfo_event_"+i)
-      .style("display", "none");
+    var infobox = titleinfo_list
+      .append('div')
+      .attr('id', 'titleinfo_event_' + i)
+      .style('display', 'none');
 
     // Appname and duration text
-    infobox.append("h5")
-      .attr("x", "10px")
-      .attr("y", "20px")
-      .text(e.appname + " (" + time.seconds_to_duration(e.duration) + ")")
-      .attr("font-family", "sans-serif")
-      .attr("font-size", "20px")
-      .attr("fill", "black");
+    infobox
+      .append('h5')
+      .attr('x', '10px')
+      .attr('y', '20px')
+      .text(e.appname + ' (' + time.seconds_to_duration(e.duration) + ')')
+      .attr('font-family', 'sans-serif')
+      .attr('font-size', '20px')
+      .attr('fill', 'black');
 
     // Titleinfo
-    var infolist = infobox.append("table");
-    _.each(e.titles, function(t, i){
-      var inforow = infolist.append("tr");
+    var infolist = infobox.append('table');
+    _.each(e.titles, function(t, i) {
+      var inforow = infolist.append('tr');
       // Clocktime
-      var clocktime = moment(t.timestamp).format("HH:mm:ss");
-      inforow.append("td")
-        .text(clocktime);
+      var clocktime = moment(t.timestamp).format('HH:mm:ss');
+      inforow.append('td').text(clocktime);
       // Duration
       var duration = time.seconds_to_duration(t.duration);
-      inforow.append("td")
+      inforow
+        .append('td')
         .text(duration)
-        .style("padding-left", "1em");
+        .style('padding-left', '1em');
       // Title
-      inforow.append("td")
+      inforow
+        .append('td')
         .text(t.title)
-        .style("padding-left", "1em");
+        .style('padding-left', '1em');
     });
 
     curr_x += eventWidth;
@@ -175,7 +194,7 @@ function update(container, events, total_duration, showAFK){
 }
 
 module.exports = {
-  "create": create,
-  "update": update,
-  "set_status": set_status,
+  create: create,
+  update: update,
+  set_status: set_status,
 };


### PR DESCRIPTION
Integrate eslint and prettier with a pre-commit hook. I tried to choose defaults that matched the code style as closely as possible. Second commit applies the eslint fixes (which include prettier) to all the code.

You can run it yourself with 👍 
```
npm run lint
# or in watch mode
watch --color npm run lint --color
```

Test plan:
- npm run dev
- http://localhost:27180/#/ (make sure server is running in testing mode)