### PR TITLE
Activity button instead of dropdown if one host

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,10 @@ div#wrapper
       b-nav-item(to="/")
         icon(name="home")
         | Home
-      b-nav-item-dropdown
+      b-nav-item(v-if="activity_hosts.length === 1", v-for="host in activity_hosts", :key="host", :to="'/activity/' + host")
+        icon(name="clock-o")
+        | Activity
+      b-nav-item-dropdown(v-if="activity_hosts.length !== 1")
         template(slot="button-content")
           icon(name="clock-o")
           | Activity


### PR DESCRIPTION
If there is only one host, don’t bother making Activity be a dropdown;
just link directly to the first host.

![image](https://user-images.githubusercontent.com/897931/36071909-180d3dca-0ecb-11e8-8aed-a41f724542f7.png)
