### PR TITLE
Made activity view categorized by tabs and added top URL summary

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,9 +11,8 @@ div#wrapper
           | Connected
           icon(name="check-circle")
         span.bad(v-show="!connected")
-          span.text
-            | Not connected
-            icon(name="times-circle")
+          | Not connected
+          icon(name="times-circle")
 
   div.container.aw-container
     // TODO: Refactor into Mainmenu component

--- a/src/App.vue
+++ b/src/App.vue
@@ -225,6 +225,5 @@ body {
 
 #content {
   padding: 1em;
-  padding-top: 2em;
 }
 </style>

--- a/src/queries.js
+++ b/src/queries.js
@@ -41,10 +41,14 @@ function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count, filt
   .concat([
     'events = filter_period_intersect(events, window_browser);',
     'events = split_url_events(events);',
-    'events = merge_events_by_keys(events, ["domain"]);',
-    'events = sort_by_duration(events);',
-    'events = limit_events(events, ' + count + ');',
-    'RETURN = events;',
+    'urls = merge_events_by_keys(events, ["domain", "url"]);',
+    'urls = sort_by_duration(urls);',
+    'urls = limit_events(urls, ' + count + ');',
+    'domains = split_url_events(events);',
+    'domains = merge_events_by_keys(domains, ["domain"]);',
+    'domains = sort_by_duration(domains);',
+    'domains = limit_events(domains, ' + count + ');',
+    'RETURN = {"domains": domains, "urls": urls};',
   ]);
 }
 

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -27,7 +27,6 @@ div
 
   aw-periodusage(:periodusage_arr="daily_activity", :host="host")
 
-
   hr
 
   div.row
@@ -40,9 +39,24 @@ div
         b-form-checkbox(v-model="filterAFK")
           | Filter away AFK time
 
-  hr
+  br
 
-  div.row
+  ul.nav.nav-tabs
+    li.nav-item
+      a.nav-link(v-on:click="view = 'summary'" v-bind:class="{ active: view=='summary'}")
+        | Summary
+    li.nav-item
+      a.nav-link(v-on:click="view = 'window'" v-bind:class="{ active: view=='window'}")
+        | Window
+    li.nav-item
+      a.nav-link(v-on:click="view = 'browser'" v-bind:class="{ active: view=='browser'}")
+        | Browser
+    li.nav-item
+      a.nav-link(v-on:click="view = 'editor'" v-bind:class="{ active: view=='editor'}")
+        | Editor
+  br
+
+  div.row(v-show="view == 'summary'")
     div.col-md-4
       h5 Top Applications
       aw-summary(:fields="top_apps", :namefunc="top_apps_namefunc", :colorfunc="top_apps_colorfunc")
@@ -69,74 +83,84 @@ div
         br
         br
 
-      b-input-group(size="sm")
-        b-input-group-prepend
-          span.input-group-text
-            | Bucket
-        b-dropdown(:text="browserBucketId || 'Select browser watcher bucket'", size="sm", variant="outline-secondary")
-          b-dropdown-header
-            | Browser bucket to use
-          b-dropdown-item(v-if="browserBuckets.length <= 0", name="b", disabled)
-            | No browser buckets available
-            br
-            small Make sure you have an browser extension installed
-          b-dropdown-item-button(v-for="browserBucket in browserBuckets", :key="browserBucket", v-on:click="browserBucketId = browserBucket")
-            | {{ browserBucket }}
+  div(v-show="view == 'window'")
 
-  hr
+    b-form-checkbox(v-model="timelineShowAFK")
+      | Show AFK time
 
-  h4 Timeline
+    aw-timeline(:events="events_apptimeline", :total_duration='duration', :show_afk='timelineShowAFK')
 
-  b-form-checkbox(v-model="timelineShowAFK")
-    | Show AFK time
+    hr
 
-  aw-timeline(:events="events_apptimeline", :total_duration='duration', :show_afk='timelineShowAFK')
+    aw-sunburst(:date="date", :afkBucketId="afkBucketId", :windowBucketId="windowBucketId")
 
-  hr
+  div(v-show="view == 'browser'")
+    b-input-group(size="sm")
+      b-input-group-prepend
+        span.input-group-text
+          | Bucket
+      b-dropdown(:text="browserBucketId || 'Select browser watcher bucket'", size="sm", variant="outline-secondary")
+        b-dropdown-header
+          | Browser bucket to use
+        b-dropdown-item(v-if="browserBuckets.length <= 0", name="b", disabled)
+          | No browser buckets available
+          br
+          small Make sure you have an browser extension installed
+        b-dropdown-item-button(v-for="browserBucket in browserBuckets", :key="browserBucket", v-on:click="browserBucketId = browserBucket")
+          | {{ browserBucket }}
+    br
 
-  h4 Clock
+    div.row
+      div.col-md-6
+        h5 Top Browser Domains
 
-  //b-alert(variant="warning" show)
-  //  | #[b Note:] This is an early version. It has known issues that will be resolved in a future update.
-  //  | See #[a(href="https://github.com/ActivityWatch/aw-webui/issues/36") issue #36] for details.
+        div(v-if="browserBucketId")
+          aw-summary(:fields="top_web_domains", :namefunc="top_web_domains_namefunc", :colorfunc="top_web_domains_colorfunc")
 
-  aw-sunburst(:date="date", :afkBucketId="afkBucketId", :windowBucketId="windowBucketId")
+      div.col-md-6
+        h5 Top Browser URLs
 
-  hr
+        div(v-if="browserBucketId")
+          aw-summary(:fields="top_web_urls", :namefunc="top_web_urls_namefunc", :colorfunc="top_web_urls_colorfunc")
 
-  h4 Editor activity
-
-  b-input-group(size="sm")
-    b-input-group-prepend
-      span.input-group-text
-        | Bucket
-    b-dropdown(:text="editorBucketId || 'Select editor watcher bucket'", size="sm", variant="outline-secondary")
-      b-dropdown-header
-        | Editor bucket to use
-      b-dropdown-item(v-if="editorBuckets.length <= 0", name="b", disabled)
-        | No editor buckets available
-        br
-        small Make sure you have an editor watcher installed to use this feature
-      b-dropdown-item-button(v-for="editorBucket in editorBuckets", :key="editorBucket", v-on:click="editorBucketId = editorBucket")
-        | {{ editorBucket }}
-
-  div(v-if="editorBucketId")
-    div.row(style="padding-top: 0.5em;")
-      div.col-md-4
-        h5 Top file activity
-        aw-summary(:fields="top_editor_files", :namefunc="top_editor_files_namefunc", :colorfunc="top_editor_files_colorfunc")
-
-      div.col-md-4
-        h5 Top language activity
-        aw-summary(:fields="top_editor_languages", :namefunc="top_editor_languages_namefunc", :colorfunc="top_editor_languages_colorfunc")
-
-      div.col-md-4
-        h5 Top project activity
-        aw-summary(:fields="top_editor_projects", :namefunc="top_editor_projects_namefunc", :colorfunc="top_editor_projects_colorfunc")
-
-    b-button(size="sm", variant="outline-secondary", v-on:click="top_editor_count += 5; queryEditorActivity()")
+    b-button(size="sm", variant="outline-secondary", :disabled="top_web_urls.length < top_web_count && top_web_domains.length < top_web_count" v-on:click="top_web_count += 5; queryBrowserDomains()")
       icon(name="angle-double-down")
       | Show more
+
+
+  div(v-show="view == 'editor'")
+
+    b-input-group(size="sm")
+      b-input-group-prepend
+        span.input-group-text
+          | Bucket
+      b-dropdown(:text="editorBucketId || 'Select editor watcher bucket'", size="sm", variant="outline-secondary")
+        b-dropdown-header
+          | Editor bucket to use
+        b-dropdown-item(v-if="editorBuckets.length <= 0", name="b", disabled)
+          | No editor buckets available
+          br
+          small Make sure you have an editor watcher installed to use this feature
+        b-dropdown-item-button(v-for="editorBucket in editorBuckets", :key="editorBucket", v-on:click="editorBucketId = editorBucket")
+          | {{ editorBucket }}
+
+    div(v-if="editorBucketId")
+      div.row(style="padding-top: 0.5em;")
+        div.col-md-4
+          h5 Top file activity
+          aw-summary(:fields="top_editor_files", :namefunc="top_editor_files_namefunc", :colorfunc="top_editor_files_colorfunc")
+
+        div.col-md-4
+          h5 Top language activity
+          aw-summary(:fields="top_editor_languages", :namefunc="top_editor_languages_namefunc", :colorfunc="top_editor_languages_colorfunc")
+
+        div.col-md-4
+          h5 Top project activity
+          aw-summary(:fields="top_editor_projects", :namefunc="top_editor_projects_namefunc", :colorfunc="top_editor_projects_colorfunc")
+
+      b-button(size="sm", variant="outline-secondary", v-on:click="top_editor_count += 5; queryEditorActivity()")
+        icon(name="angle-double-down")
+        | Show more
 
 </template>
 
@@ -175,6 +199,8 @@ export default {
       filterAFK: true,
       timelineShowAFK: true,
 
+      view: "summary",
+
       // Query variables
       duration: "",
       errormsg: "",
@@ -198,10 +224,15 @@ export default {
       top_windowtitles_namefunc: (e) => e.data.title,
       top_windowtitles_colorfunc: (e) => e.data.app,
 
+      top_web_count: 5,
+
       top_web_domains: [],
-      top_web_domains_count: 4,
       top_web_domains_namefunc: (e) => e.data.domain,
       top_web_domains_colorfunc: (e) => e.data.domain,
+
+      top_web_urls: [],
+      top_web_urls_namefunc: (e) => e.data.url,
+      top_web_urls_colorfunc: (e) => e.data.domain,
 
       top_editor_count: 5,
 
@@ -364,13 +395,14 @@ export default {
     queryBrowserDomains: function(){
       if (this.browserBucketId !== ""){
         var periods = [this.dateStart + "/" + this.dateEnd];
-        var q = query.browserSummaryQuery(this.browserBucketId, this.windowBucketId, this.afkBucketId, this.top_web_domains_count, this.filterAFK);
+        var q = query.browserSummaryQuery(this.browserBucketId, this.windowBucketId, this.afkBucketId, this.top_web_count, this.filterAFK);
         awclient.query(periods, q).then(
           (response) => { // Success
             if (response.status > 304){
               this.errorHandler(response);
             } else {
-              this.top_web_domains = response.data[0];
+              this.top_web_domains = response.data[0]["domains"];
+              this.top_web_urls = response.data[0]["urls"];
             }
           }, this.errorHandler
         );

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -2,7 +2,10 @@
 div
   h2 Activity for {{ dateShort }}
 
-  p Host: {{ host }}
+  p
+    | Host: {{ host }}
+    br
+    | Active time: {{ readableDuration }}
 
   b-alert(variant="danger" :show="errormsg.length > 0")
     | {{ errormsg }}
@@ -27,33 +30,19 @@ div
 
   aw-periodusage(:periodusage_arr="daily_activity", :host="host")
 
-  hr
-
-  div.row
-    div.col-md-6
-      h5 Summary
-      | Total active time: {{ readableDuration }}
-    div.col-md-6
-      b Options
-      div
-        b-form-checkbox(v-model="filterAFK")
-          | Filter away AFK time
-
-  br
-
   ul.nav.nav-tabs
-    li.nav-item
-      a.nav-link(v-on:click="view = 'summary'" v-bind:class="{ active: view=='summary'}")
-        | Summary
-    li.nav-item
-      a.nav-link(v-on:click="view = 'window'" v-bind:class="{ active: view=='window'}")
-        | Window
-    li.nav-item
-      a.nav-link(v-on:click="view = 'browser'" v-bind:class="{ active: view=='browser'}")
-        | Browser
-    li.nav-item
-      a.nav-link(v-on:click="view = 'editor'" v-bind:class="{ active: view=='editor'}")
-        | Editor
+    li.nav-item.aw-nav-item
+      a.nav-link.aw-nav-link(v-on:click="view = 'summary'" v-bind:class="{ active: view=='summary' }")
+        h5 Summary
+    li.nav-item.aw-nav-item
+      a.nav-link.aw-nav-link(v-on:click="view = 'window'" v-bind:class="{ active: view=='window' }")
+        h5 Window
+    li.nav-item.aw-nav-item
+      a.nav-link.aw-nav-link(v-on:click="view = 'browser'" v-bind:class="{ active: view=='browser' }")
+        h5.active-h5 Browser
+    li.nav-item.aw-nav-item
+      a.nav-link.aw-nav-link(v-on:click="view = 'editor'" v-bind:class="{ active: view=='editor' }")
+        h5 Editor
   br
 
   div.row(v-show="view == 'summary'")
@@ -162,9 +151,37 @@ div
         icon(name="angle-double-down")
         | Show more
 
+
+  hr
+
+  div.row
+    div.col-md-6
+      b Options
+      div
+        b-form-checkbox(v-model="filterAFK")
+          | Filter away AFK time
+
+
 </template>
 
 <style lang="scss">
+
+.aw-nav-link {
+  background-color: #eee;
+  border: 2px solid #eee !important;
+  border-bottom: none !important;
+  margin-left: 0.1em;
+  margin-right: 0.1em;
+  border-top-left-radius: 0.5rem !important;
+  border-top-right-radius: 0.5rem !important;
+}
+.aw-nav-link:hover {
+  background-color: #fff;
+}
+
+.aw-nav-item:hover {
+  background-color: #fff !important;
+}
 
 </style>
 


### PR DESCRIPTION
Made activity view tabbed.

We need some way to hide stuff such as editors which will not be used by everyone since the page will otherwise be very long, but not sure if this is the perfect solution.

![screenshot-2018-6-17 activitywatch](https://user-images.githubusercontent.com/1398500/41511719-bdca119c-727c-11e8-9625-36ef2e6ad089.png)