### PR TITLE
Add "Chromium-browser-chromium" to browser_appnames

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -25,7 +25,7 @@ function windowQuery(windowbucket, afkbucket, appcount, titlecount, filterAFK) {
 function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count, filterAFK) {
   var browser_appnames = "";
   if (browserbucket.endsWith("-chrome")){
-    browser_appnames = '["Google-chrome", "chrome.exe", "Chromium", "Google Chrome"]';
+    browser_appnames = '["Google-chrome", "chrome.exe", "Chromium", "Google Chrome", "Chromium-browser-chromium"]';
   } else if (browserbucket.endsWith("-firefox")){
     browser_appnames = '["Firefox", "Firefox.exe", "firefox", "firefox.exe"]';
   }


### PR DESCRIPTION
For some reason on Gentoo under Plasma, Chromium has `WM_CLASS` set to `"chromium-browser-chromium", "Chromium-browser-chromium"` (probably because of the `.desktop` file), so it registers as `Chromium-browser-chromium` in apps and doesn't show up in URL/domain statistics