### PR TITLE
Highlight menu items when clicked

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,4 @@
-﻿<template lang="pug">
+<template lang="pug">
 div#wrapper
   div.header
     div.container
@@ -17,10 +17,10 @@ div#wrapper
   div.container.aw-container
     // TODO: Refactor into Mainmenu component
     b-nav.row.aw-navbar
-      b-nav-item(to="/" exact :class="{inCategory: isHomePath}"  )
+      b-nav-item(to="/" exact)
         icon(name="home")
         | Home
-      b-nav-item(v-if="activity_hosts.length === 1", v-for="host in activity_hosts", :key="host", :to="'/activity/' + host" :class="{inCategory: isActivityPath}")
+      b-nav-item(v-if="activity_hosts.length === 1", v-for="host in activity_hosts", :key="host", :to="'/activity/' + host")
         icon(name="clock")
         | Activity
       b-nav-item-dropdown(v-if="activity_hosts.length !== 1")
@@ -33,10 +33,10 @@ div#wrapper
           small Make sure you have both an afk and window watcher running
         b-dropdown-item(v-for="host in activity_hosts", :key="host", :to="'/activity/' + host")
           | {{ host }}
-      b-nav-item(:class="{inCategory: isRawDataPath}" to="/buckets" )
+      b-nav-item(to="/buckets")
         icon(name="database")
         | Raw Data
-      b-nav-item(:class="{inCategory: isQueryPath}" to="/query" )
+      b-nav-item(to="/query")
         // TODO: Use 'searchengin' icon instead, when landed in vue-awesome
         icon(name="search")
         | Query
@@ -91,14 +91,6 @@ export default {
       info: {}
     }
   },
-  computed: {
-  
-      isHomePath: function(thepath) { return this.$route.path=="/" },
-      isActivityPath: function(thepath) { return this.$route.path=="/activity" },
-      isRawDataPath: function(thepath) { return this.$route.path=="/buckets" },
-      isQueryPath: function(thepath) { return this.$route.path=="/query" }
-  },
-
 
   mounted: async function() {
     this.$aw.getInfo().then(
@@ -171,6 +163,10 @@ body {
             margin-right: 7px;
         }
     }
+
+  .active {
+    background-color: #EEE;
+  }
 }
 
 .nav-item:hover {
@@ -223,10 +219,6 @@ body {
 
 .rounded-bottom {
   border-radius: 0px 0px 5px 5px;
-}
-
-.inCategory {
- background-color: #DDD;
 }
 
 #content {

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -49,40 +49,25 @@ div
     div.col-md-4
       h5 Top Applications
       aw-summary(:fields="top_apps", :namefunc="top_apps_namefunc", :colorfunc="top_apps_colorfunc")
-      b-button-group
-        b-button(size="sm", variant="outline-secondary", :disabled="top_apps.length <= 5", v-on:click="top_apps_count = 5; queryWindows()")
-          icon(name="angle-double-up")
-        b-button(size="sm", variant="outline-secondary", :disabled="top_apps.length <= 5", v-on:click="top_apps_count -= 5; queryWindows()")
-          icon(name="angle-up")
-        b-button(size="sm", variant="outline-secondary", :disabled="top_apps.length < top_apps_count", v-on:click="top_apps_count += 5; queryWindows()")
-          icon(name="angle-down")
-
+      b-button(size="sm", variant="outline-secondary", :disabled="top_apps.length < top_apps_count", v-on:click="top_apps_count += 5; queryWindows()")
+        icon(name="angle-double-down")
+        | Show more
 
     div.col-md-4
       h5 Top Window Titles
       aw-summary(:fields="top_windowtitles", :namefunc="top_windowtitles_namefunc", :colorfunc="top_windowtitles_colorfunc")
-      b-button-group
-        b-button(size="sm", variant="outline-secondary", :disabled="top_windowtitles.length <= 5", v-on:click="top_windowtitles_count = 5; queryWindows()")
-          icon(name="angle-double-up")
-        b-button(size="sm", variant="outline-secondary", :disabled="top_windowtitles.length <= 5", v-on:click="top_windowtitles_count -= 5; queryWindows()")
-          icon(name="angle-up")
-        b-button(size="sm", variant="outline-secondary", :disabled="top_windowtitles.length < top_windowtitles_count", v-on:click="top_windowtitles_count += 5; queryWindows()")
-          icon(name="angle-down")
-      br
+      b-button(size="sm", variant="outline-secondary", :disabled="top_windowtitles.length < top_windowtitles_count", v-on:click="top_windowtitles_count += 5; queryWindows()")
+        icon(name="angle-double-down")
+        | Show more
 
     div.col-md-4
       h5 Top Browser Domains
 
       div(v-if="browserBucketId")
         aw-summary(:fields="top_web_domains", :namefunc="top_web_domains_namefunc", :colorfunc="top_web_domains_colorfunc")
-        b-button-group
-          b-button(size="sm", variant="outline-secondary", :disabled="top_web_domains.length <= 5", v-on:click="top_web_count = 5; queryBrowserDomains()")
-            icon(name="angle-double-up")
-          b-button(size="sm", variant="outline-secondary", :disabled="top_web_domains.length <= 5", v-on:click="top_web_count -= 5; queryBrowserDomains()")
-            icon(name="angle-up")
-          b-button(size="sm", variant="outline-secondary", :disabled="top_web_domains.length < top_web_count", v-on:click="top_web_count += 5; queryBrowserDomains()")
-            icon(name="angle-down")
-        br
+        b-button(size="sm", variant="outline-secondary", :disabled="top_web_domains.length < top_web_count" v-on:click="top_web_count += 5; queryBrowserDomains()")
+          icon(name="angle-double-down")
+          | Show more
         br
 
   div(v-show="view == 'window'")
@@ -220,11 +205,6 @@ import time from "../util/time.js";
 import 'vue-awesome/icons/arrow-left'
 import 'vue-awesome/icons/arrow-right'
 import 'vue-awesome/icons/angle-double-down'
-import 'vue-awesome/icons/angle-double-up'
-import 'vue-awesome/icons/angle-up'
-import 'vue-awesome/icons/angle-down'
-
-
 import 'vue-awesome/icons/sync'
 
 import query from '../queries.js';


### PR DESCRIPTION
Based on https://github.com/ActivityWatch/aw-webui/pull/92

Modifications:

 - Simplified menu highlight logic (see https://github.com/ActivityWatch/aw-webui/pull/100/commits/6e992122c3f6b8bf87f34511cbc3b08c172c5a7c)
    - Note how the class `active` is already automatically set). 
 - Reverted the "show only 5, show 5 less, show 5 more" buttons (I just don't like the look of it)