### PR TITLE
Add support for Firefox Beta/Dev, and Chrome Beta/Unstable

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -29,9 +29,9 @@ function windowQuery(windowbucket, afkbucket, appcount, titlecount, filterAFK) {
 function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count, filterAFK) {
   var browser_appnames = "";
   if (browserbucket.endsWith("-chrome")){
-    browser_appnames = '["Google-chrome", "chrome.exe", "Chromium", "Google Chrome", "Chromium-browser-chromium"]';
+    browser_appnames = '["Google-chrome", "chrome.exe", "Chromium", "Google Chrome", "Chromium-browser-chromium", "Google-chrome-beta", "Google-chrome-unstable"]';
   } else if (browserbucket.endsWith("-firefox")){
-    browser_appnames = '["Firefox", "Firefox.exe", "firefox", "firefox.exe"]';
+    browser_appnames = '["Firefox", "Firefox.exe", "firefox", "firefox.exe", "Firefox Developer Edition", "Firefox Beta"]';
   }
 
   return [


### PR DESCRIPTION
Data recorded with browsers mentioned in the title will now show up under browser activity.

https://forum.activitywatch.net/t/you-can-now-track-your-web-browsing-with-activitywatch/28/7