### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-organization-notice.md
+++ b/.github/ISSUE_TEMPLATE/issue-organization-notice.md
@@ -1,0 +1,10 @@
+---
+name: Issue organization notice
+about: Notice to reporters for where issues should go.
+
+---
+
+READ CAREFULLY BEFORE CREATING!
+
+ - Is this a bug that applies to general use of ActivityWatch?
+    - Create the issue in the [main ActivityWatch repository](https://github.com/ActivityWatch/activitywatch/issues), not here.


### PR DESCRIPTION
Some people sometimes report issues in submodules of the main repo (like [this issue](https://github.com/ActivityWatch/aw-webui/issues/112)). This should be discouraged, so I made an issue template that'll show up when an issue is created to redirect people to the main repo.