### PR TITLE
Fix bug where activity view doesn't use timestamp.

### DIFF
--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -310,8 +310,12 @@ export default {
     readableWebDuration: function() { return time.seconds_to_duration(this.web_duration) },
     readableEditorDuration: function() { return time.seconds_to_duration(this.editor_duration) },
     host: function() { return this.$route.params.host },
-    date: function() { return this.$route.params.date || moment().startOf('day').format() },
-    dateStart: function() { return moment(this.date).format() },
+    date: function() { 
+      var dateParam = this.$route.params.date;
+      var dateMoment = dateParam ? moment(dateParam) || moment();
+      return dateMoment.startOf('day').format();
+    },
+    dateStart: function() { return this.date },
     dateEnd: function() { return moment(this.date).add(1, 'days').format() },
     dateShort: function() { return moment(this.date).format("YYYY-MM-DD") },
     windowBucketId: function() { return "aw-watcher-window_" + this.host },

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -311,7 +311,7 @@ export default {
     readableEditorDuration: function() { return time.seconds_to_duration(this.editor_duration) },
     host: function() { return this.$route.params.host },
     date: function() { return this.$route.params.date || moment().startOf('day').format() },
-    dateStart: function() { return this.date },
+    dateStart: function() { return moment(this.date).format() },
     dateEnd: function() { return moment(this.date).add(1, 'days').format() },
     dateShort: function() { return moment(this.date).format("YYYY-MM-DD") },
     windowBucketId: function() { return "aw-watcher-window_" + this.host },


### PR DESCRIPTION
The date() function returns the date in the URL directly, which doesn't use a timestamp. This means that anytime the app has a date in the URL, it will return results for the wrong timezone.

This changes the dateStart() method to use the ISO formatted date, which will always correctly specify a timezone.