### PR TITLE
Include Firefox Nightly in the Firefox app names

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -31,7 +31,7 @@ function browserSummaryQuery(browserbucket, windowbucket, afkbucket, count, filt
   if (browserbucket.endsWith("-chrome")){
     browser_appnames = JSON.stringify(["Google-chrome", "chrome.exe", "Chromium", "Google Chrome", "Chromium-browser", "Chromium-browser-chromium", "Google-chrome-beta", "Google-chrome-unstable"]);
   } else if (browserbucket.endsWith("-firefox")){
-    browser_appnames = JSON.stringify(["Firefox", "Firefox.exe", "firefox", "firefox.exe", "Firefox Developer Edition", "Firefox Beta"]);
+    browser_appnames = JSON.stringify(["Firefox", "Firefox.exe", "firefox", "firefox.exe", "Firefox Developer Edition", "Firefox Beta", "Nightly"]);
   }
 
   return [


### PR DESCRIPTION
Firefox Nightly's window name apparently is Nightly, which is weird. But, since we are only checking for events in the browser bucket, it should be fine to have such a generic name like Nightly? 