### PR TITLE
WIP: Sunburst view fix

### DIFF
--- a/src/visualizations/sunburst.js
+++ b/src/visualizations/sunburst.js
@@ -17,7 +17,7 @@
 const d3 = require("d3");
 const moment = require("moment");
 
-const time = require("../util/time.js");
+import time from "../util/time.js";
 const color = require("../util/color.js");
 
 // Dimensions of sunburst.
@@ -186,7 +186,7 @@ function showInfo(d) {
   hoverEl.select(".time")
       .text(m.format("HH:mm:ss"));
 
-  let durationString = time.seconds_to_duration(d.data.duration)
+  let durationString = time.seconds_to_duration(d.data.duration);
   hoverEl.select(".duration")
       .text(durationString);
 


### PR DESCRIPTION
Sunburst view doesn't work for me and doing this change fixes it.
The fix does not make sense, but it works.

For some reason when importing time in sunburst it does not contain seconds_to_duration, while on other modules where we also import time it does have seconds_to_duration.