### PR TITLE
Update queries.js, added Brave and Vivaldi browser

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -76,7 +76,8 @@ const appnames = {
     "Chromium-browser",
     "Chromium-browser-chromium",
     "Google-chrome-beta",
-    "Google-chrome-unstable"
+    "Google-chrome-unstable",
+    "Brave-browser"
   ],
   firefox: [
     "Firefox",
@@ -88,7 +89,8 @@ const appnames = {
     "Nightly"
   ],
   opera: ["opera.exe", "Opera"],
-  brave: ["brave.exe"]
+  brave: ["brave.exe"],
+  vivaldi: ["Vivaldi-stable"]
 };
 
 export function browserSummaryQuery(
@@ -113,7 +115,7 @@ export function browserSummaryQuery(
      not_afk = filter_keyvals(not_afk, "status", ["not-afk"]);`
       : "");
 
-  _.each(["chrome", "firefox", "opera", "brave"], browserName => {
+  _.each(Object.keys(appnames), browserName => {
     let bucketId = _.filter(
       browserbuckets,
       buckets => buckets.indexOf(browserName) !== -1


### PR DESCRIPTION
Issue: no data display in Browser tab when using aw-watcher-web on Brave and Vivaldi browser on Archlinux.

Fix: 
On Archlinux Brave browser is detected by ua-parser-js as "chrome" so there is need to add "Brave-browser" in this group.
  