### PR TITLE
Fix: update project to ignore aw-client-js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build/*.js
 config/*.js
+aw-client-js/**

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "lint": "vue-cli-service lint",
     "lint_old": "eslint --ignore-path=.gitignore --ext .vue,.js,.ts ."
   },
-  "eslintIgnore": [
-    "aw-client-js/**"
-  ],
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
The eslintIgnore that existed in package.json
did not work. This is moved to the .eslintignore
file and should work as intended in this commit.