### PR TITLE
Fix for Vivaldi-snapshot browser logging on Linux

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -89,6 +89,7 @@ const appnames = {
   vivaldi: [
     'Vivaldi-stable',
     'Vivaldi-snapshot',
+    'vivaldi.exe',
   ],
 };
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -86,7 +86,10 @@ const appnames = {
   ],
   opera: ['opera.exe', 'Opera'],
   brave: ['brave.exe'],
-  vivaldi: ['Vivaldi-stable'],
+  vivaldi: [
+    'Vivaldi-stable',
+    'Vivaldi-snapshot',
+  ],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
Vivaldi has currently 2 branches, Vivaldi-stable and Vivaldi-snapshot. Added snapshot to the list. There is also Android version, and we might want to test logging on windows as well (eg. we might need vivaldi.exe added). This is potentially part of bigger issue, having the list of all browsers listed in appnames. Solves: https://github.com/ActivityWatch/activitywatch/issues/314#issuecomment-557589185