### PR TITLE
Add vuex support for editor activity

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -33,27 +33,36 @@ const router = new VueRouter({
       props: true,
       children: [
         {
+          path: 'summary',
+          meta: { subview: 'summary' },
+          name: 'activity-daily-summary',
+          component: ActivityDailySummary,
+          props: true,
+        },
+        {
           path: 'window',
+          meta: { subview: 'window' },
           name: 'activity-daily-window',
           component: ActivityDailyWindow,
           props: true,
         },
         {
           path: 'browser',
+          meta: { subview: 'browser' },
           name: 'activity-daily-browser',
           component: ActivityDailyBrowser,
         },
         {
           path: 'editor',
+          meta: { subview: 'editor' },
           name: 'activity-daily-editor',
           component: ActivityDailyEditor,
         },
-        // Default view is the summary view (needs to be last since otherwise it'll always match first)
+        // Unspecified should redirect to summary view is the summary view
+        // (needs to be last since otherwise it'll always match first)
         {
           path: '',
-          name: 'activity-daily-summary',
-          component: ActivityDailySummary,
-          props: true,
+          redirect: 'summary',
         },
       ],
     },

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -22,7 +22,8 @@ div
             icon(name="folder-open").d-none.d-md-inline-block
             | Open
           b-dropdown(variant="outline-secondary", size="sm", text="More")
-            b-dropdown-item-button(:href="$aw.baseURL + '/api/0/buckets/' + data.item.id + '/export'",
+            b-dropdown-item-button(
+                       :href="$aw.baseURL + '/api/0/buckets/' + data.item.id + '/export'",
                        :download="'aw-bucket-export-' + data.item.id + '.json'",
                        title="Export bucket to JSON",
                        variant="secondary")

--- a/src/views/activity/daily/ActivityDaily.vue
+++ b/src/views/activity/daily/ActivityDaily.vue
@@ -10,18 +10,22 @@ div
   div.d-flex
     div.p-1
       b-button-group
-        b-button(:to="link_prefix + '/' + previousPeriod()", variant="outline-dark")
+        b-button(:to="link_prefix + '/' + previousPeriod() + '/' + subview",
+                 variant="outline-dark")
           icon(name="arrow-left")
           span.d-none.d-md-inline
             |  Previous
-        b-button(:to="link_prefix + '/' + nextPeriod()", :disabled="nextPeriod() > today", variant="outline-dark")
+        b-button(:to="link_prefix + '/' + nextPeriod() + '/' + subview",
+                 :disabled="nextPeriod() > today", variant="outline-dark")
           span.d-none.d-md-inline
             |  Next
           icon(name="arrow-right")
     div.p-1
-      b-select(:value="periodLength", :options="['day', 'week', 'month']", @change="(periodLength) => setDate(date, periodLength)")
+      b-select(:value="periodLength", :options="['day', 'week', 'month']",
+               @change="(periodLength) => setDate(date, periodLength)")
     div.p-1(v-if="periodLength === 'day'")
-      input.form-control(id="date" type="date" :value="date" :max="today" @change="setDate($event.target.value)")
+      input.form-control(id="date" type="date" :value="date" :max="today"
+                         @change="setDate($event.target.value)")
 
     div.p-1.ml-auto
       b-button-group
@@ -121,6 +125,7 @@ export default {
     };
   },
   computed: {
+    subview: function() { return this.$route.meta.subview; },
     categories: function() {
       const cats = this.$store.getters["settings/all_categories"];
       console.log(cats);

--- a/src/views/activity/daily/ActivityDailyBrowser.vue
+++ b/src/views/activity/daily/ActivityDailyBrowser.vue
@@ -1,23 +1,8 @@
 <template lang="pug">
 div
-  //b-input-group(size="sm")
-    b-input-group-prepend
-      span.input-group-text
-        | Bucket
-    b-dropdown(:text="(browserBucketSelected !== 'all' && browserBucketSelected) || 'Select browser watcher bucket'", size="sm", variant="outline-secondary")
-      b-dropdown-header
-        | Browser bucket to use
-      b-dropdown-item(v-if="browserBuckets.length <= 0", name="b", disabled)
-        | No browser buckets available
-        br
-        small Make sure you have an browser extension installed
-      b-dropdown-item-button(v-if="browserBuckets.length > 1", @click="browserBucketSelected = 'all'")
-        | All
-      b-dropdown-item-button(v-for="browserBucket in browserBuckets", :key="browserBucket", @click="browserBucketSelected = browserBucket")
-        | {{ browserBucket }}
-  //br
+  // TODO: Add back option to select a specific browser bucket
 
-  // h6 Active browser time: {{ web_duration | friendlyduration }}
+  h6 Active browser time: {{ $store.state.activity_daily.browser_duration | friendlyduration }}
 
   div.row
     div.col-md-6


### PR DESCRIPTION
- Fixes editor support again so it works with other dates than today again (with vuex)
- Removed support for selecting a specific editor bucket
- Added back "duration" field for browser

Solves https://github.com/ActivityWatch/activitywatch/issues/316