### PR TITLE
stopwatch: Fixes broken "stop" and "edit" 

### DIFF
--- a/src/components/EventEditor.vue
+++ b/src/components/EventEditor.vue
@@ -33,9 +33,9 @@ div
   hr
 
   div.float-right
-    b-button.mx-1(@click="$emit('cancel')")
+    b-button.mx-1(@click="$emit('close');")
       | Cancel
-    b-button.mx-1(@click="save()", variant="primary")
+    b-button.mx-1(@click="save(); $emit('close');", variant="primary")
       | Save
 </template>
 
@@ -56,9 +56,8 @@ export default {
   },
   methods: {
     async save() {
-      this.event.data = this.editedEvent.data;
-      await this.$aw.replaceEvent(this.bucket_id, this.event);
-      this.$emit('save');
+      await this.$aw.replaceEvent(this.bucket_id, this.editedEvent);
+      this.$emit('save', this.editedEvent);
     }
   }
 }

--- a/src/components/StopwatchEntry.vue
+++ b/src/components/StopwatchEntry.vue
@@ -18,8 +18,8 @@ div
       b-button.mx-1(@click="delete_", variant="outline-danger", size="sm")
         icon.mx-0(name="trash")
         //| Delete
-  b-modal(:id="'edit-modal-' + event.id", ref="editEventRef", title="Edit event", centered, hide-footer)
-    event-editor(:event="event", :bucket_id="bucket_id", @save="$refs.editEventRef.hide()", @cancel="$refs.editEventRef.hide()")
+  b-modal(:id="'edit-modal-' + event.id", ref="eventEditModal", title="Edit event", centered, hide-footer)
+    event-editor(:event="event", :bucket_id="bucket_id", @save="save", @close="$refs.eventEditModal.hide()")
 </template>
 
 <style scoped lang="scss">
@@ -52,12 +52,16 @@ export default {
   },
   methods: {
     stop: async function() {
-      this.event.data.running = false;
-      this.event.duration = (moment() - moment(this.event.timestamp)) / 1000;
-      await this.$aw.replaceEvent(this.bucket_id, this.event);
+      let new_event = JSON.parse(JSON.stringify(this.event));
+      new_event.data.running = false;
+      new_event.duration = (moment() - moment(new_event.timestamp)) / 1000;
+      new_event = await this.$aw.replaceEvent(this.bucket_id, new_event);
+      this.$emit('update', new_event);
+    },
+    save: async function(new_event) {
+      this.$emit('update', new_event);
     },
     delete_: async function() {
-      await this.$aw.deleteEvent(this.bucket_id, this.event.id);
       this.$emit('delete');
     },
   }


### PR DESCRIPTION
There were three bugs:
1. When pressing "stop" we modified the event within StopwatchEntry which
   tried to modify the event. Since javascript is reference by value the
   actual event in the list was never modified, only the copy. This created
   lots of Vue errors every time you pressed "stop"
2. When editing an even it was the same thing, the action was saved in aw-server
   but it was not shown in the webui since the parent component was not aware of
   the change so you have to reload the webpage.
3. We were using heartbeats instead of an insert when creating events which do
   not return anything in aw-server-rust or in aw-server-python with the sqlite
   backend. This meant that id was always "null" so instead of stopping the
   timer a new identical was created (unless you refreshed the page, then the
   usual getEvents was used so the id was correct).