### PR TITLE
Added computation of demo data from single list of events

### DIFF
--- a/src/store/modules/activity_daily.ts
+++ b/src/store/modules/activity_daily.ts
@@ -212,7 +212,7 @@ const actions = {
           app: 'Firefox',
           title: 'Inbox - Gmail - Mozilla Firefox',
           url: 'https://mail.google.com',
-          $category: ['Work'],
+          $category: ['Comms', 'Email'],
         },
       },
       {
@@ -240,6 +240,39 @@ const actions = {
           title: 'Home / Twitter - Mozilla Firefox',
           url: 'https://twitter.com',
           $category: ['Media', 'Social Media'],
+        },
+      },
+      {
+        duration: 0.15 * 60 * 60,
+        data: {
+          app: 'Firefox',
+          title: 'Stack Overflow',
+          url: 'https://stackoverflow.com',
+          $category: ['Work', 'Programming'],
+        },
+      },
+      {
+        duration: 48.2 * 60,
+        data: {
+          app: 'Terminal',
+          title: 'vim ~/code/activitywatch/aw-server/aw-webui/src',
+          $category: ['Work', 'Programming', 'ActivityWatch'],
+        },
+      },
+      {
+        duration: 12.6 * 60,
+        data: {
+          app: 'Terminal',
+          title: 'bash ~/code/activitywatch',
+          $category: ['Work', 'Programming', 'ActivityWatch'],
+        },
+      },
+      {
+        duration: 58.1 * 60,
+        data: {
+          app: 'zoom',
+          title: 'Zoom Meeting',
+          $category: ['Comms', 'Video Conferencing'],
         },
       },
       {


### PR DESCRIPTION
Demodata that made sense (times adding up) was hard to create before, this fixes that (and adds demodata that actually looks somewhat like real data).

Looks like this:

![image](https://user-images.githubusercontent.com/1405370/76750161-0d9aa400-677e-11ea-9674-700a107162be.png)
