### PR TITLE
Display error message from API requests if available, deduplicate messages

### DIFF
--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -1,9 +1,8 @@
 <template lang="pug">
 div
-  b-alert(variant="danger", v-for="error in errors", :key='error.time', :show='!error.dismissed', dismissible, @dismissed="error.dismissed = false")
-    | {{ error.msg }}.
-    | See dev console (F12) and/or server logs for more info.
-  slot
+	b-alert(variant="danger", v-for="error in errors", :key='error.time', :show='!error.dismissed', dismissible, @dismissed="error.dismissed = false")
+		| {{ error.msg }}
+	slot
 </template>
 
 <script>
@@ -11,12 +10,25 @@ div
 export default {
   name: 'ErrorBoundary',
   data() {
-    return { errors: [] };
+    return {
+      errors: []
+    };
   },
   errorCaptured(err, vm, info) {
-    //console.error("Error captured!");
-    //console.error(err, vm, info);
-    const msg = err.name && err.message ? err.name + ': ' + err.message : err;
+    // console.error("Error captured!");
+    // console.error(err, vm, info);
+
+    //default error message
+    let msg = (err.name && err.message) ? (err.name + ": " + err.message + ". See dev console (F12) and/or server logs for more info.") : err;
+
+    //use server error response if available
+    //err.isAxiosError doesn't help much here…
+    if (err.response && err.response.data && err.response.data.message) {
+      msg = err.response.data.message;
+    }
+
+    //dedupe
+    if (this.errors.some(e => e.msg == msg)) return;
     this.errors.push({
       msg: msg,
       time: new Date().toISOString(),

--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -18,17 +18,16 @@ export default {
     // console.error("Error captured!");
     // console.error(err, vm, info);
 
-    //default error message
-    let msg = (err.name && err.message) ? (err.name + ": " + err.message + ". See dev console (F12) and/or server logs for more info.") : err;
-
-    //use server error response if available
-    //err.isAxiosError doesn't help much here…
+    // fallback
+    let msg = err;
+    // use server error response if available; err.isAxiosError doesn't help much here…
     if (err.response && err.response.data && err.response.data.message) {
       msg = err.response.data.message;
+    } else if (err.name && err.message) {
+      msg = `${err.name}: ${err.message}.
+				See dev console (F12) and/or server logs for more info.`;
     }
 
-    //dedupe
-    if (this.errors.some(e => e.msg == msg)) return;
     this.errors.push({
       msg: msg,
       time: new Date().toISOString(),


### PR DESCRIPTION
This pull request aims to fix my issue #188.
> There's no bucket named 'aw-watcher-window_MYPCHOSTNAME'

While that particular error message does not appear in the latest version of _aw-webui_, it should make it easier for people unfamiliar with a browser's developer tools to spot and report server/API errors.

Furthermore, I added deduplication for error messages. 

PS: My patch worked well on top of https://github.com/ActivityWatch/aw-webui/commit/6379134ac15fa7f13e06bcd4fbdc93ae9fc96b24 – However, I did not verify that error messages are correctly shown with my patch on top of 353634bc585441920650d1660f88208d0dfd0fec.