### PR TITLE
Minor improvements to the Buckets and Bucket views

### DIFF
--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -3,14 +3,14 @@ div
   div
     table
       tr
-        td.pr-2
+        th.pr-2
           label(for="mode") Interval mode:
         td
           select(id="mode" v-model="mode")
             option(value='last_duration') Last duration
             option(value='range') Date range
       tr(v-if="mode == 'last_duration'")
-        td.pr-2
+        th.pr-2
           label(for="duration") Show last:
         td
           select(id="duration" :value="duration", @change="valueChanged")
@@ -23,7 +23,7 @@ div
             option(:value="12*60*60") 12h
             option(:value="24*60*60") 24h
       tr(v-if="mode == 'range'")
-        td.pr-2 Range:
+        th.pr-2 Range:
         td
           input(type="date", v-model="start", @input="valueChanged")
           input(type="date", v-model="end", @input="valueChanged")

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -15,6 +15,11 @@ div
     tr
       td Created:
       td {{ bucket.created | iso8601 }}
+    tr(v-if="bucket.metadata")
+      td First/last event:
+      td
+        | {{ bucket.metadata.start}} /
+        | {{ bucket.metadata.end }}
     tr
       td Eventcount:
       td {{ eventcount }}

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -4,24 +4,24 @@ div
   h3 {{ id }}
   table
     tr
-      td Type:
+      th Type:
       td {{ bucket.type }}
     tr
-      td Client:
+      th Client:
       td {{ bucket.client }}
     tr
-      td Hostname:
+      th Hostname:
       td {{ bucket.hostname }}
     tr
-      td Created:
+      th Created:
       td {{ bucket.created | iso8601 }}
     tr(v-if="bucket.metadata")
-      td First/last event:
+      th First/last event:
       td
         | {{ bucket.metadata.start}} /
         | {{ bucket.metadata.end }}
     tr
-      td Eventcount:
+      th Eventcount:
       td {{ eventcount }}
 
   input-timeinterval(v-model="daterange")

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -13,8 +13,12 @@ div
       small
         | {{ data.item.hostname }}
     template(v-slot:cell(last_updated)="data")
+      // aw-server-python
       small(v-if="data.item.last_updated")
         | {{ data.item.last_updated | friendlytime }}
+      // aw-server-rust
+      small(v-if="data.item.metadata.end")
+        | {{ data.item.metadata.end | friendlytime }}
     template(v-slot:cell(actions)="data")
       b-button-toolbar.float-right
         b-button-group(size="sm", class="mx-1")


### PR DESCRIPTION
- fix: Fix 'Updated' field in buckets view for aw-server-rust
    - The API is slightly different for aw-server-rust
- feat: Add first/last event to Bucket view 
    - Only works for aw-server-rust as that's the only one which has the bucket.metadata field
- fix: Set headers on tables where they belong