### PR TITLE
fix: fix timeline updating before new range is selected (#449 from ac…

### DIFF
--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -18,7 +18,7 @@ div
         th.pr-2
           label(for="duration") Show last:
         td
-          select(id="duration" :value="duration" @change="valueChanged")
+          select(id="duration" v-model="duration" @change="valueChanged")
             option(:value="15*60") 15min
             option(:value="30*60") 30min
             option(:value="60*60") 1h
@@ -74,14 +74,6 @@ export default {
           return [moment().subtract(this.duration, 'seconds'), moment()];
         }
       },
-      set(newValue) {
-        if (!isNaN(newValue) && newValue != '') {
-          // Set new duration
-          this.duration = newValue;
-        } else {
-          // Not required for mode='range', start and end set directly through v-model
-        }
-      },
     },
     emptyDaterange() {
       return !(this.start && this.end);
@@ -94,14 +86,11 @@ export default {
     },
   },
   methods: {
-    valueChanged(e) {
-      console.log('valueChanged');
+    valueChanged() {
       if (
         this.mode == 'last_duration' ||
         (!this.emptyDaterange && !this.invalidDaterange && !this.daterangeTooLong)
       ) {
-        console.log('entered if');
-        this.value = e.target.value;
         this.$emit('input', this.value);
       }
     },

--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
 div
   div
-    b-alert(v-if="mode == 'range' && invalidDaterange" variant="warning" show)
+    b-alert(v-if="mode == 'range' && invalidDaterange", variant="warning", show)
       | The selected date range is invalid. The second date must be greater than the first date.
-    b-alert(v-if="mode == 'range' && daterangeTooLong" variant="warning" show)
+    b-alert(v-if="mode == 'range' && daterangeTooLong", variant="warning", show)
       | The selected date range is too long. The maximum is {{ maxDuration/(24*60*60) }} days.
 
     table
@@ -11,14 +11,14 @@ div
         th.pr-2
           label(for="mode") Interval mode:
         td
-          select(id="mode" v-model="mode")
+          select(id="mode", v-model="mode")
             option(value='last_duration') Last duration
             option(value='range') Date range
       tr(v-if="mode == 'last_duration'")
         th.pr-2
           label(for="duration") Show last:
         td
-          select(id="duration" v-model="duration" @change="valueChanged")
+          select(id="duration", v-model="duration", @change="valueChanged")
             option(:value="15*60") 15min
             option(:value="30*60") 30min
             option(:value="60*60") 1h
@@ -30,8 +30,8 @@ div
       tr(v-if="mode == 'range'")
         th.pr-2 Range:
         td
-          input(type="date" v-model="start")
-          input(type="date" v-model="end")
+          input(type="date", v-model="start")
+          input(type="date", v-model="end")
           button(
             class="btn btn-outline-dark btn-sm",
             type="button", 
@@ -84,6 +84,9 @@ export default {
     daterangeTooLong() {
       return moment(this.start).add(this.maxDuration, 'seconds').isBefore(moment(this.end));
     },
+  },
+  mounted() {
+    this.valueChanged();
   },
   methods: {
     valueChanged() {

--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -95,12 +95,12 @@ export default {
   },
   methods: {
     valueChanged(e) {
-      console.log("valueChanged");
+      console.log('valueChanged');
       if (
         this.mode == 'last_duration' ||
         (!this.emptyDaterange && !this.invalidDaterange && !this.daterangeTooLong)
       ) {
-        console.log("entered if");
+        console.log('entered if');
         this.value = e.target.value;
         this.$emit('input', this.value);
       }

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -24,7 +24,7 @@ div
       th Eventcount:
       td {{ eventcount }}
 
-  input-timeinterval(v-model="daterange", @update-timeline="updateTimeline")
+  input-timeinterval(v-model="daterange", :maxDuration="maxDuration")
 
   vis-timeline(:buckets="[bucket_with_events]", :showRowLabels="false")
 
@@ -33,7 +33,6 @@ div
 
 <script>
 import moment from 'moment';
-
 export default {
   name: 'Bucket',
   props: {
@@ -45,6 +44,7 @@ export default {
       events: [],
       eventcount: '?',
       daterange: [moment().subtract(1, 'hour'), moment()],
+      maxDuration: 31 * 24 * 60 * 60,
     };
   },
   computed: {
@@ -52,7 +52,12 @@ export default {
       return this.$store.getters['buckets/getBucket'](this.id) || {};
     },
   },
-  mounted: async function() {
+  watch: {
+    daterange: async function () {
+      await this.getEvents(this.id);
+    },
+  },
+  mounted: async function () {
     await this.$store.dispatch('buckets/ensureBuckets');
     await this.getEvents(this.id);
     await this.getEventCount(this.id);
@@ -79,10 +84,6 @@ export default {
         console.error(':(');
       }
     },
-    updateTimeline: async function(daterange) {
-      this.daterange = daterange;
-      await this.getEvents(this.id);
-    }
   },
 };
 </script>

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -24,7 +24,7 @@ div
       th Eventcount:
       td {{ eventcount }}
 
-  input-timeinterval(v-model="daterange")
+  input-timeinterval(v-model="daterange", @update-timeline="updateTimeline")
 
   vis-timeline(:buckets="[bucket_with_events]", :showRowLabels="false")
 
@@ -84,6 +84,10 @@ export default {
         console.error(':(');
       }
     },
+    updateTimeline: async function(daterange) {
+      this.daterange = daterange;
+      await this.getEvents(this.id);
+    }
   },
 };
 </script>

--- a/src/views/Bucket.vue
+++ b/src/views/Bucket.vue
@@ -32,7 +32,6 @@ div
 </template>
 
 <script>
-import moment from 'moment';
 export default {
   name: 'Bucket',
   props: {
@@ -43,7 +42,7 @@ export default {
       bucket_with_events: { events: [] },
       events: [],
       eventcount: '?',
-      daterange: [moment().subtract(1, 'hour'), moment()],
+      daterange: null,
       maxDuration: 31 * 24 * 60 * 60,
     };
   },
@@ -59,7 +58,6 @@ export default {
   },
   mounted: async function () {
     await this.$store.dispatch('buckets/ensureBuckets');
-    await this.getEvents(this.id);
     await this.getEventCount(this.id);
   },
   methods: {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -2,7 +2,7 @@
 div
   h2 Timeline
 
-  input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration" :maxDuration="maxDuration")
+  input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", :maxDuration="maxDuration")
 
   div(v-show="buckets !== null")
     div
@@ -17,11 +17,10 @@ div
 </template>
 
 <script>
-import moment from 'moment';
 import _ from 'lodash';
 export default {
   name: 'Timeline',
-  data: () => {
+  data() {
     return {
       buckets: null,
       daterange: null,
@@ -38,10 +37,6 @@ export default {
     daterange() {
       this.getBuckets();
     },
-  },
-  mounted: function () {
-    (this.daterange = [moment().subtract(this.timeintervalDefaultDuration, 'seconds'), moment()]),
-      this.getBuckets(this.daterange);
   },
   methods: {
     getBuckets: async function () {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -40,8 +40,8 @@ export default {
     },
   },
   mounted: function () {
-    this.daterange = [moment().subtract(this.timeintervalDefaultDuration, 'seconds'), moment()],
-    this.getBuckets(this.daterange);
+    (this.daterange = [moment().subtract(this.timeintervalDefaultDuration, 'seconds'), moment()]),
+      this.getBuckets(this.daterange);
   },
   methods: {
     getBuckets: async function () {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -2,7 +2,7 @@
 div
   h2 Timeline
 
-  input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", @update-timeline="getBuckets")
+  input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration" :maxDuration="maxDuration")
 
   div(v-show="buckets !== null")
     div
@@ -19,7 +19,6 @@ div
 <script>
 import moment from 'moment';
 import _ from 'lodash';
-
 export default {
   name: 'Timeline',
   data: () => {
@@ -27,6 +26,7 @@ export default {
       buckets: null,
       daterange: null,
       timeintervalDefaultDuration: localStorage.durationDefault,
+      maxDuration: 31 * 24 * 60 * 60,
     };
   },
   computed: {
@@ -34,13 +34,17 @@ export default {
       return _.sumBy(this.buckets, 'events.length');
     },
   },
-  mounted: function() {
-    this.daterange = [moment().subtract(this.timeintervalDefaultDuration, "seconds"), moment()],
+  watch: {
+    daterange() {
+      this.getBuckets();
+    },
+  },
+  mounted: function () {
+    this.daterange = [moment().subtract(this.timeintervalDefaultDuration, 'seconds'), moment()],
     this.getBuckets(this.daterange);
   },
   methods: {
-    getBuckets: async function(daterange) {
-      this.daterange = daterange;
+    getBuckets: async function () {
       this.buckets = await this.$store.dispatch('buckets/getBucketsWithEvents', {
         start: this.daterange[0].format(),
         end: this.daterange[1].format(),

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -2,7 +2,7 @@
 div
   h2 Timeline
 
-  input-timeinterval(v-model="daterange", v-bind:duration="timeintervalDefaultDuration")
+  input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", @update-timeline="getBuckets")
 
   div(v-show="buckets !== null")
     div
@@ -25,7 +25,7 @@ export default {
   data: () => {
     return {
       buckets: null,
-      daterange: [moment().subtract(1, 'hour'), moment()],
+      daterange: null,
       timeintervalDefaultDuration: localStorage.durationDefault,
     };
   },


### PR DESCRIPTION
Hello! This is my first pull request, please feel free to let me know if you have feedback. I found this issue on the activitywatch repo (https://github.com/ActivityWatch/activitywatch/issues/449) and I thought that the pull request should go here.

### Before My Changes
Timeline View
![Screenshot from 2020-07-15 13-41-58](https://user-images.githubusercontent.com/15698580/87584157-11e2b980-c6ab-11ea-8a0c-ee46743e6d7b.png)
Bucket View
![Screenshot from 2020-07-15 13-42-22](https://user-images.githubusercontent.com/15698580/87584168-15764080-c6ab-11ea-9964-fcaa9ec6c4f8.png)

### My Changes
I added a "Show Timeline" button that will send a request to the server if pressed. The default timeline range will still be showed when the page loads in the beginning. I also made the select boxes and the button horizontal because I thought that was better use of space.
![Screenshot from 2020-07-15 14-30-16](https://user-images.githubusercontent.com/15698580/87584236-2de65b00-c6ab-11ea-84ae-19a209d2fcab.png)
In Range mode, the "Show Timeline" button will be disabled (grey) until the user has selected both dates.
![Screenshot from 2020-07-15 14-30-40](https://user-images.githubusercontent.com/15698580/87584281-40609480-c6ab-11ea-8252-8aa3e8547bb9.png)
Red text telling the user that the date range is invalid will also show if the first date is less than or equal to the second, the button is also greyed out.
![Screenshot from 2020-07-15 14-30-58](https://user-images.githubusercontent.com/15698580/87584342-59694580-c6ab-11ea-846f-b4ff0779a91d.png)
![Screenshot from 2020-07-15 14-31-24](https://user-images.githubusercontent.com/15698580/87584359-5e2df980-c6ab-11ea-8f3f-974859640879.png)
The following two images are the new Bucket view.
![Screenshot from 2020-07-15 14-57-30](https://user-images.githubusercontent.com/15698580/87584534-a6e5b280-c6ab-11ea-9da9-d75e50822b65.png)
![Screenshot from 2020-07-15 14-58-00](https://user-images.githubusercontent.com/15698580/87584538-a77e4900-c6ab-11ea-8f40-8fb7c361a5fc.png)



