### PR TITLE
fix: fix category name change affecting sister category (ActivityWatch/activitywatch#361)

### DIFF
--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -24,7 +24,7 @@ div
       b-input-group.my-1(prepend="Name")
         b-form-input(v-model="editing.name")
       b-input-group(prepend="Parent")
-        b-select(v-model="editing.parent_id", :options="allOtherCategories")
+        b-select(v-model="editing.parentId", :options="allOtherCategories")
 
     hr
 
@@ -72,7 +72,7 @@ export default {
         id: null,
         name: null,
         rule: {},
-        parent_id: null,
+        parentId: null,
       },
     };
   },
@@ -84,14 +84,8 @@ export default {
         return { text: c.name.join('->'), value: c.id };
       });
 
-      const subtreeIds = [];
-      function findSubtree(node) {
-        subtreeIds.push(node.id);
-        if (node.children) {
-          node.children.forEach(c => findSubtree(c));
-        }
-      }
-      findSubtree(this._class);
+      const findSubtree = this.$store.getters['categories/find_subtree'];
+      const subtreeIds = findSubtree(this._class.id);
 
       return [{ value: -1, text: 'None' }].concat(
         entries.filter(c => !subtreeIds.includes(c.value))
@@ -109,7 +103,7 @@ export default {
     addSubclass: function (parent) {
       this.$store.commit('categories/addClass', {
         name: parent.name.concat(['New class']),
-        parent_id: parent.id,
+        parentId: parent.id,
         rule: { type: 'regex', regex: 'FILL ME' },
       });
     },
@@ -140,16 +134,16 @@ export default {
 
       // Save the category
       const getCategoryById = this.$store.getters['categories/get_category_by_id'];
-      const parent_class = getCategoryById(this.editing.parent_id);
+      const parent_cat = getCategoryById(this.editing.parentId);
 
-      const new_class = {
+      const new_cat = {
         id: this.editing.id,
-        parent_id: this.editing.parent_id,
-        name: parent_class ? parent_class.name.concat(this.editing.name) : [this.editing.name],
+        parentId: this.editing.parentId,
+        name: parent_cat ? parent_cat.name.concat(this.editing.name) : [this.editing.name],
         rule: this.editing.rule.type !== null ? this.editing.rule : { type: null },
-        depth: parent_class ? parent_class.name.length + 1 : 0,
+        depth: parent_cat ? parent_cat.name.length + 1 : 0,
       };
-      this.$store.commit('categories/updateClass', new_class);
+      this.$store.commit('categories/updateClass', new_cat);
 
       // Hide the modal manually
       this.$nextTick(() => {
@@ -161,7 +155,7 @@ export default {
         id: this._class.id,
         name: this._class.subname,
         rule: _.cloneDeep(this._class.rule),
-        parent_id: this._class.parent_id,
+        parentId: this._class.parentId,
       };
     },
   },

--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -11,6 +11,8 @@ div
         span(v-if="_class.rule.type === 'regex'") Rule ({{_class.rule.type}}): #[code {{_class.rule.regex}}]
         span(v-else, style="color: #888") No rule
       span.float-right
+        b-btn.ml-1(size="sm", variant="outline-danger", @click="showDeleteModal()" style="border: 0;" pill)
+          icon(name="trash")
         b-btn.ml-1(size="sm", variant="outline-secondary", @click="showEditModal()" style="border: 0;" pill)
           icon(name="edit")
         b-btn.ml-1(size="sm", variant="outline-success", @click="addSubclass(_class)" style="border: 0;" pill)
@@ -19,7 +21,7 @@ div
     div.pa-2(v-for="child in _class.children", style="background: rgba(0, 0, 0, 0);", v-show="expanded")
       CategoryEditTree(:_class="child", :depth="depth+1")
 
-  b-modal(id="edit" ref="edit" title="Edit category" @show="resetModal" @hidden="resetModal" @ok="handleOk")
+  b-modal(id="edit" ref="edit" title="Edit category" @show="resetData" @hidden="resetData" @ok="handleOk")
     div.my-1
       b-input-group.my-1(prepend="Name")
         b-form-input(v-model="editing.name")
@@ -38,12 +40,17 @@ div
         b-form-checkbox(v-model="editing.rule.ignore_case" switch)
           | Ignore case
 
+  b-modal(id="delete" ref="delete" title="Danger!" @show="resetData"  centered hide-footer)
+    | Are you sure you want to delete the category "{{_class.name[0]}}" and all of its subcategories?
+    br
+    br
+    b This is permanent and cannot be undone!
     hr
-
-    div.my-1
-      b-btn(variant="danger", @click="removeClass(_class); $refs.edit.hide()")
-        icon(name="trash")
-        | Remove category
+    div.float-right
+      b-button.mx-2(@click="$root.$emit('bv::hide::modal','delete')")
+        | Cancel
+      b-button(@click="removeClass(_class)", variant="danger")
+        | Confirm
 </template>
 
 <script>
@@ -108,13 +115,19 @@ export default {
       });
     },
     removeClass: function (_class) {
-      // TODO: Show a confirmation dialog
-      // TODO: Remove children as well?
       // TODO: Move button to edit modal?
       this.$store.commit('categories/removeClass', _class);
+
+      // Hide the modal manually
+      this.$nextTick(() => {
+        this.$refs.delete.hide();
+      });
     },
     showEditModal() {
       this.$refs.edit.show();
+    },
+    showDeleteModal() {
+      this.$refs.delete.show();
     },
     checkFormValidity() {
       // FIXME
@@ -150,7 +163,7 @@ export default {
         this.$refs.edit.hide();
       });
     },
-    resetModal() {
+    resetData() {
       this.editing = {
         id: this._class.id,
         name: this._class.subname,

--- a/src/store/modules/categories.js
+++ b/src/store/modules/categories.js
@@ -68,7 +68,10 @@ const mutations = {
     // When a parent category is renamed, we also need to rename the children
     const parent_depth = old_class.name.length;
     _.map(state.classes, c => {
-      if (_.isEqual(old_class.name, c.name.slice(0, parent_depth))) {
+      if (
+        _.isEqual(old_class.name, c.name.slice(0, parent_depth)) &&
+        c.name.length > parent_depth
+      ) {
         c.name = new_class.name.concat(c.name.slice(parent_depth));
         console.log('Renamed child:', c.name);
       }

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -8,12 +8,11 @@ interface Rule {
 
 interface Category {
   id: number;
-  parent_id?: number;
+  parentId?: number;
   name: string[];
   subname?: string;
   rule: Rule;
   depth?: number;
-  // parent?: string[];
   children?: Category[];
 }
 
@@ -21,51 +20,51 @@ export const defaultCategories: Category[] = [
   { id: 0, name: ['Work'], rule: { type: 'regex', regex: 'Google Docs|libreoffice|ReText' } },
   {
     id: 1,
-    parent_id: 0,
+    parentId: 0,
     name: ['Work', 'Programming'],
     rule: { type: 'regex', regex: 'GitHub|Stack Overflow|BitBucket|Gitlab|vim|Spyder|kate' },
   },
   {
     id: 2,
-    parent_id: 1,
+    parentId: 1,
     name: ['Work', 'Programming', 'ActivityWatch'],
     rule: { type: 'regex', regex: 'ActivityWatch|aw-', ignore_case: true },
   },
   { name: ['Media'], rule: { type: null }, id: 3 },
   {
     id: 4,
-    parent_id: 3,
+    parentId: 3,
     name: ['Media', 'Games'],
     rule: { type: 'regex', regex: 'Minecraft|RimWorld' },
   },
   {
     id: 5,
-    parent_id: 3,
+    parentId: 3,
     name: ['Media', 'Video'],
     rule: { type: 'regex', regex: 'YouTube|Plex|VLC' },
   },
   {
     id: 6,
-    parent_id: 3,
+    parentId: 3,
     name: ['Media', 'Social Media'],
     rule: { type: 'regex', regex: 'reddit|Facebook|Twitter|Instagram|devRant', ignore_case: true },
   },
   {
     id: 7,
-    parent_id: 3,
+    parentId: 3,
     name: ['Media', 'Music'],
     rule: { type: 'regex', regex: 'Spotify|Deezer', ignore_case: true },
   },
   { id: 8, name: ['Comms'], rule: { type: null } },
   {
     id: 9,
-    parent_id: 8,
+    parentId: 8,
     name: ['Comms', 'IM'],
     rule: { type: 'regex', regex: 'Messenger|Telegram|Signal|WhatsApp|Rambox|Slack|Riot|Discord' },
   },
   {
     id: 10,
-    parent_id: 8,
+    parentId: 8,
     name: ['Comms', 'Email'],
     rule: { type: 'regex', regex: 'Gmail|Thunderbird|mutt|alpine' },
   },
@@ -74,8 +73,8 @@ export const defaultCategories: Category[] = [
 export function build_category_hierarchy(classes: Category[]): Category[] {
   function annotate(c: Category) {
     const ch = c.name;
-    // Use -1 as id for root
-    c.parent_id = c.parent_id !== undefined ? c.parent_id : -1;
+    // Use -1 as parentId if no parent
+    c.parentId = c.parentId !== undefined ? c.parentId : -1;
     c.subname = ch.slice(-1)[0];
     c.depth = ch.length - 1;
     return c;
@@ -86,14 +85,14 @@ export function build_category_hierarchy(classes: Category[]): Category[] {
   function assignChildren(classes_at_level: Category[]) {
     return classes_at_level.map(cls => {
       cls.children = classes.filter(child => {
-        return child.parent_id == cls.id;
+        return child.parentId == cls.id;
       });
       assignChildren(cls.children);
       return cls;
     });
   }
 
-  return assignChildren(classes.filter(c => c.parent_id === -1));
+  return assignChildren(classes.filter(c => c.parentId === -1));
 }
 
 export function flatten_category_hierarchy(hier: Category[]): Category[] {

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -162,18 +162,17 @@ export default {
     categories: function () {
       const cats = this.$store.getters['categories/all_categories'];
       const entries = cats.map(c => {
-        return { text: c.join(' > '), value: c };
+        return { text: c.name.join(' > '), value: c.id };
       });
       return [
         { text: 'All', value: null },
-        { text: 'Uncategorized', value: ['Uncategorized'] },
+        { text: 'Uncategorized', value: -2 },
       ].concat(entries);
     },
     filterCategories: function () {
       if (this.filterCategory) {
         const cats = this.$store.getters['categories/all_categories'];
-        const isChild = p => c => c.length > p.length && _.isEqual(p, c.slice(0, p.length));
-        const children = _.filter(cats, isChild(this.filterCategory));
+        const children = _.filter(cats, c => c.parentId === this.filterCategory.id);
         return [this.filterCategory].concat(children);
       } else {
         return null;


### PR DESCRIPTION
The following changes address this issue: https://github.com/ActivityWatch/activitywatch/issues/361. 
* Use category ID to identify categories
* Delete category is moved from the edit modal to be its own button, it also has a confirmation modal now
* Delete category also deletes all descendents of that category (i.e. deletes its subtree)
* In the edit modal, it will no longer show categories in that category's subtree as its potential parent

Here are the new UI changes: 
![Screenshot from 2021-01-09 20-06-00](https://user-images.githubusercontent.com/15698580/104111926-2d272e00-52b6-11eb-9c9f-e4071572e0a8.png)
![Screenshot from 2021-01-09 20-06-14](https://user-images.githubusercontent.com/15698580/104111928-2e585b00-52b6-11eb-866e-ae1314291db6.png)

The following code changes also allow two categories with the same path and name (e.g. Work -> Programming and Work -> Programming). I was originally thinking that I would have to change the backend to support this change. However, we don't have to change the backend if we disallow these duplicates. Then the web app can still query categories by using its full name (e.g. `['Work', 'Programming']`). Let me know if you think of any other solutions.

Edit: It is failing two tests because I removed the code from `build_category_hierarchy` that fills in missing parents. This is because before this change, each category's name (e.g. `['Work', 'Programming', 'ActivityWatch']`) already stores information about all of its parents, so you can keep only this information in storage and generate the parent categories Work and Work -> Programming. But now each category only keeps a reference to its immediate parent or children, which is why we can no longer generate parents. 

**Edit 2: I'm starting to think that an easier solution is to require all full names are unique and it would not need use ID, it would resolve the problems that I mentioned in the two paragraphs above.**