### PR TITLE
ci: added starting of aw-server(-rust) in CI for use in integration tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,12 +16,19 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+        aw-version: ["v0.10.0"]
+        aw-server: ["aw-server", "aw-server-rust"]
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Install and run ActivityWatch
+      run: |
+        wget -O activitywatch.zip https://github.com/ActivityWatch/activitywatch/releases/download/${{ matrix.aw-version }}/activitywatch-${{ matrix.aw-version }}-linux-x86_64.zip
+        unzip activitywatch.zip
+        ./activitywatch/${{ matrix.aw-server }}/${{ matrix.aw-server }} &
+    - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+        python-version: ['3.9']
         aw-version: ["v0.10.0"]
         aw-server: ["aw-server", "aw-server-rust"]
 
@@ -23,15 +24,27 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Start aw-server, insert fake data
     - name: Install and run ActivityWatch
       run: |
         wget -O activitywatch.zip https://github.com/ActivityWatch/activitywatch/releases/download/${{ matrix.aw-version }}/activitywatch-${{ matrix.aw-version }}-linux-x86_64.zip
         unzip activitywatch.zip
-        ./activitywatch/${{ matrix.aw-server }}/${{ matrix.aw-server }} &
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+        ./activitywatch/${{ matrix.aw-server }}/${{ matrix.aw-server }} --testing &
+    - name: Insert fake data into aw-server
+      run: |
+        pip install git+https://github.com/ActivityWatch/aw-client.git
+        wget -O fakedata.py https://github.com/ActivityWatch/aw-fakedata/raw/ca6047e6e2cdc6aee13bc441f4fd3c9f0e36eda9/aw-fakedata.py
+        python3 fakedata.py
+
     - name: Install
       run: npm ci
     - name: Build


### PR DESCRIPTION
Progress on true integration tests with fake data using https://github.com/ActivityWatch/aw-fakedata

The idea is to use this for true E2E tests and to make automated & accurate screenshots.

Related to #246 