### PR TITLE
feat: add productivity score for categories

### DIFF
--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -78,6 +78,8 @@ export default {
         parent: [],
         inherit_color: true,
         color: null,
+        inherit_score: true,
+        score: null,
       },
     };
   },
@@ -148,7 +150,10 @@ export default {
         id: this.editing.id,
         name: this.editing.parent.concat(this.editing.name),
         rule: this.editing.rule.type !== 'none' ? this.editing.rule : { type: 'none' },
-        data: { color: this.editing.inherit_color === true ? undefined : this.editing.color },
+        data: {
+          color: this.editing.inherit_color === true ? undefined : this.editing.color,
+          score: this.editing.inherit_score === true ? undefined : this.editing.score,
+        },
       };
       this.categoryStore.updateClass(new_class);
 

--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -34,12 +34,14 @@ b-modal(id="edit" ref="edit" title="Edit category" @show="resetModal" @hidden="h
       | Inherit parent color
     div.mt-1(v-show="!editing.inherit_color")
       color-picker(v-model="editing.color")
-
-  //
-    div.my-1
-      b Productivity score
-      b-input-group.my-1(prepend="Points")
-        b-form-input(v-model="editing.productivity")
+  
+  hr
+  div.my-1
+    b Productivity score
+    b-form-checkbox(v-model="editing.inherit_score" switch)
+      | Inherit parent score
+    b-input-group.my-1(prepend="Score" v-if="!editing.inherit_score")
+      b-form-input(v-model="editing.score")
 
   hr
   div.my-1
@@ -159,13 +161,17 @@ export default {
       const cat = this.categoryStore.get_category_by_id(this.categoryId);
       const color = cat.data ? cat.data.color : undefined;
       const inherit_color = !color;
+      const score = cat.data ? cat.data.score : undefined;
+      const inherit_score = !score;
       this.editing = {
         id: cat.id,
         name: cat.subname,
         rule: _.cloneDeep(cat.rule),
+        parent: cat.parent ? cat.parent : [],
         color,
         inherit_color,
-        parent: cat.parent ? cat.parent : [],
+        score,
+        inherit_score,
       };
     },
   },

--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -11,7 +11,8 @@ div
         icon.ml-1(v-if="_class.data && _class.data.color" name="circle" :style="'color: ' + _class.data.color")
         span.ml-1(v-if="_class.children.length > 0" style="opacity: 0.5") ({{totalChildren}})
         span.d-none.d-md-inline
-          span(v-if="_class.data && _class.data.score !== undefined") {{ _class.data.score }}
+          span(v-if="_class.data && _class.data.score !== undefined" :style="'color: ' + (_class.data.score > 0 ? 'green' : 'red')")
+            | &nbsp; {{ _class.data.score >= 0 ? '+' : '' }}{{ _class.data.score }}
 
     div.col-4.col-md-8
       span.d-none.d-md-inline

--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -10,6 +10,8 @@ div
         | {{ _class.name.slice(depth).join(" ➤ ")}}
         icon.ml-1(v-if="_class.data && _class.data.color" name="circle" :style="'color: ' + _class.data.color")
         span.ml-1(v-if="_class.children.length > 0" style="opacity: 0.5") ({{totalChildren}})
+        span.d-none.d-md-inline
+          span(v-if="_class.data && _class.data.score !== undefined") {{ _class.data.score }}
 
     div.col-4.col-md-8
       span.d-none.d-md-inline

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -78,6 +78,8 @@ div
       aw-custom-vis(:visname="props.visname" :title="props.title")
     div(v-if="type == 'vis_timeline' && isSingleDay")
       vis-timeline(:buckets="timeline_buckets", :showRowLabels='true', :queriedInterval="timeline_daterange")
+    div(v-if="type == 'score'")
+      aw-score(:date="date")
 </template>
 
 <style lang="scss">
@@ -143,6 +145,7 @@ export default {
         'sunburst_clock',
         'custom_vis',
         'vis_timeline',
+        'score',
       ],
       // TODO: Move this function somewhere else
       top_editor_files_namefunc: e => {
@@ -223,6 +226,10 @@ export default {
         custom_vis: {
           title: 'Custom Visualization',
           available: true, // TODO: Implement
+        },
+        score: {
+          title: 'Score',
+          available: this.activityStore.category.available,
         },
       };
     },

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,7 @@ Vue.component('aw-categorytree', () => import('./visualizations/CategoryTree.vue
 Vue.component('aw-timeline-barchart', () => import('./visualizations/TimelineBarChart.vue'));
 Vue.component('aw-calendar', () => import('./visualizations/Calendar.vue'));
 Vue.component('aw-custom-vis', () => import('./visualizations/CustomVisualization.vue'));
+Vue.component('aw-score', () => import('./visualizations/Score.vue'));
 
 // A mixin to make async method errors propagate
 Vue.mixin(require('~/mixins/asyncErrorCaptured.js'));

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -48,6 +48,15 @@ function colorCategories(events: IEvent[]): IEvent[] {
   });
 }
 
+function scoreCategories(events: IEvent[]): IEvent[] {
+  // Set $score for categories
+  const categoryStore = useCategoryStore();
+  return events.map((e: IEvent) => {
+    e.data['$score'] = categoryStore.get_category_score(e.data['$category']);
+    return e;
+  });
+}
+
 export interface QueryOptions {
   host: string;
   date?: string;
@@ -334,8 +343,9 @@ export const useActivityStore = defineStore('activity', {
       const data = await getClient().query(periods, q);
       const data_window = data[0].window;
 
-      // Set $color for categories
+      // Set $color and $score for categories
       data_window.cat_events = colorCategories(data_window.cat_events);
+      data_window.cat_events = scoreCategories(data_window.cat_events);
 
       this.query_window_completed(data_window);
     },
@@ -369,8 +379,9 @@ export const useActivityStore = defineStore('activity', {
       const data_window = data[0].window;
       const data_browser = data[0].browser;
 
-      // Set $color for categories
+      // Set $color and $score for categories
       data_window.cat_events = colorCategories(data_window.cat_events);
+      data_window.cat_events = scoreCategories(data_window.cat_events);
 
       this.query_window_completed(data_window);
       this.query_browser_completed(data_browser);

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -18,6 +18,21 @@ interface State {
   classes_unsaved_changes: boolean;
 }
 
+function getScoreFromCategory(c: Category, allCats: Category[]): number {
+  // Returns the score for a certain category, falling back to parents if none set
+  // Very similar to getColorFromCategory
+  if (c && c.data && c.data.score) {
+    return c.data.score;
+  } else if (c && c.name.slice(0, -1).length > 0) {
+    // If no color is set on category, traverse parents until one is found
+    const parent = c.name.slice(0, -1);
+    const parentCat = allCats.find(cc => _.isEqual(cc.name, parent));
+    return getScoreFromCategory(parentCat, allCats);
+  } else {
+    return 0;
+  }
+}
+
 export const useCategoryStore = defineStore('categories', {
   state: (): State => ({
     classes: [],
@@ -83,8 +98,13 @@ export const useCategoryStore = defineStore('categories', {
       };
     },
     get_category_color() {
-      return (cat: string[]) => {
+      return (cat: string[]): string => {
         return getColorFromCategory(this.get_category(cat), this.classes);
+      };
+    },
+    get_category_score() {
+      return (cat: string[]): number => {
+        return getScoreFromCategory(this.get_category(cat), this.classes);
       };
     },
     category_select() {

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -31,7 +31,7 @@ export const defaultCategories: Category[] = [
   {
     name: ['Work'],
     rule: { type: 'regex', regex: 'Google Docs|libreoffice|ReText' },
-    data: { color: '#0F0' },
+    data: { color: '#0F0', score: 10 },
   },
   {
     name: ['Work', 'Programming'],

--- a/src/visualizations/Score.vue
+++ b/src/visualizations/Score.vue
@@ -4,6 +4,8 @@ div
     | Your total score today is:
     div(:style="'font-size: 2em; color: ' + (score >= 0 ? '#0A0' : '#F00')")
       | {{score >= 0 ? '+' : ''}}{{ (Math.round(score * 10) / 10).toFixed(1) }}
+    div.small.text-muted
+      | ({{score_productive_percent.toFixed(1)}}% productive)
   hr
   div
     b Top productive:
@@ -54,6 +56,15 @@ export default {
     },
     score: function () {
       return _.sum(_.map(this.categories_with_score, cat => cat.data.$total_score));
+    },
+    score_productive_percent() {
+      // Compute the percentage of time spent on productive activities (score > 0)
+      const total_time = _.sumBy(this.categories_with_score, cat => cat.duration);
+      const productive_time = _.sumBy(
+        _.filter(this.categories_with_score, cat => cat.data.$total_score > 0),
+        cat => cat.duration
+      );
+      return (productive_time / total_time) * 100;
     },
     top_productive: function () {
       return _.sortBy(

--- a/src/visualizations/Score.vue
+++ b/src/visualizations/Score.vue
@@ -1,0 +1,72 @@
+<template lang="pug">
+div
+  div(style="text-align: center")
+    | Your total score today is:
+    div(:style="'font-size: 2em; color: ' + (score >= 0 ? '#0A0' : '#F00')")
+      | {{score >= 0 ? '+' : ''}}{{ (Math.round(score * 10) / 10).toFixed(1) }}
+  hr
+  div
+    b Top productive:
+    div.mt-2(v-for="cat in top_productive")
+      div.d-flex
+        div
+          div
+            | {{cat.data.$category.slice(-1)[0]}}
+          div(style="font-size: 0.7em; color: #666;")
+            | {{cat.data.$category.slice(0, -1).join(" > ")}}
+        div.ml-auto
+          span(style="font-size: 1.2em; color: #0A0")
+            | +{{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+  hr
+  div
+    b Top distracting:
+    div.mt-2(v-for="cat in top_distracting")
+      div.d-flex
+        div
+          div
+            | {{cat.data.$category.slice(-1)[0]}}
+          div(style="font-size: 0.7em; color: #666;")
+            | {{cat.data.$category.slice(0, -1).join(" > ")}}
+        div.ml-auto
+          span(style="font-size: 1.2em; color: #F00")
+            | {{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+</template>
+
+<script>
+import _ from 'lodash';
+import { useActivityStore } from '~/stores/activity';
+
+// TODO: Maybe add a "Category Tree"-style visualization?
+
+export default {
+  name: 'aw-score',
+  props: {
+    fields: Array,
+  },
+  computed: {
+    categories_with_score: function () {
+      // FIXME: Does this get all category time? Or just top ones?
+      const top_categories = useActivityStore().category.top;
+      return _.map(top_categories, cat => {
+        cat.data.$total_score = (cat.duration / (60 * 60)) * cat.data.$score;
+        return cat;
+      });
+    },
+    score: function () {
+      return _.sum(_.map(this.categories_with_score, cat => cat.data.$total_score));
+    },
+    top_productive: function () {
+      return _.sortBy(
+        _.filter(this.categories_with_score, cat => cat.data.$total_score > 0.1),
+        c => -c.data.$total_score
+      );
+    },
+    top_distracting: function () {
+      return _.sortBy(
+        _.filter(this.categories_with_score, cat => cat.data.$total_score < -0.1),
+        c => c.data.$total_score
+      );
+    },
+  },
+};
+</script>


### PR DESCRIPTION
Rebased and salvaged #162

Shouldn't require any changes to backend code.

## Tasks

 - [ ] Review what would make the best UX from previous discussions
 - [ ] How long you need to engage in a 1 point activity to get 1 point? (an hour?)
 - [x] Add computation of score for period
   - ```py
     totalScore = 0
     for event in events:
       totalScore += event.duration * get_score(event.category, allCategories)
     return totalScore / (60 * 60)  # from score-seconds to score-hours
     ```
 - [x] Add visualization (just a number of the total score today?)
 - [x] Make sure score is inherited correctly
 - [ ] What should scores be for the default categories?