### PR TITLE
fix: add google-chrome-stable to appnames

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -120,6 +120,7 @@ const browser_appnames = {
     'Google Chrome',
     'Google-chrome',
     'chrome.exe',
+    'google-chrome-stable',
 
     // Chromium
     'Chromium',


### PR DESCRIPTION
Add google-chrome-stable to the queries. This is the name of the chrome package when installed from the AUR