### PR TITLE
bug: run make install before running dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install:
 uninstall:
 	rm -r node_modules/
 
-dev:
+dev: install
 	npm run serve ${androidflag}
 
 test:


### PR DESCRIPTION
The node packages need to be installed for dev to run properly. 