### PR TITLE
refactor: separate brave browser events into their own category

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -131,9 +131,6 @@ const browser_appnames = {
     // Pre-releases
     'Google-chrome-beta',
     'Google-chrome-unstable',
-
-    // Brave (should this be merged with the brave entry?)
-    'Brave-browser',
   ],
   firefox: [
     'Firefox',
@@ -147,7 +144,7 @@ const browser_appnames = {
     'Nightly',
   ],
   opera: ['opera.exe', 'Opera'],
-  brave: ['brave.exe'],
+  brave: ['Brave-browser', 'Brave Browser', 'brave.exe'],
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS


### PR DESCRIPTION
It looks like this was partially done, so I just cleaned it up. Also added the name of brave browser on macOS.