### PR TITLE
feat: improve formatting of query range in Activity view

### DIFF
--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
 div
-  h3.mb-0 Activity for {{ timeperiod | friendlyperiod }}
+  h3 Activity
+    span.text-secondary.aw-period-range  {{ timeperiod | friendlyperiod }}
 
   div.mb-2
     ul.list-group.list-group-horizontal-md.mb-3(style="font-size: 0.9em; opacity: 0.7")
@@ -127,6 +128,17 @@ div
     }
   }
 }
+
+@import 'bootstrap/scss/_functions';
+@import 'bootstrap/scss/_variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+
+@include media-breakpoint-down(sm) {
+  .aw-period-range {
+    display: block;
+    font-size: 0.75em;
+  }
+}
 </style>
 
 <script>
@@ -241,11 +253,11 @@ export default {
         // it's helpful to render a range for the week as opposed to just the start of the week
         // or the number of the week so users can easily determine (a) if we are using monday/sunday as the week
         // start and exactly when the week ends. The formatting code ends up being a bit more wonky, but it's
-        // worth the tradeoff.
+        // worth the tradeoff. https://github.com/ActivityWatch/aw-webui/pull/284
 
         const startOfWeek = periodStart.format(dateFormatString);
         const endOfWeek = periodStart.add(1, 'week').format(dateFormatString);
-        return `${startOfWeek} — ${endOfWeek}`;
+        return `${startOfWeek}—${endOfWeek}`;
       } else {
         return periodStart.format(dateFormatString);
       }

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -1,14 +1,21 @@
 <template lang="pug">
 div
-  h3 Activity
-    span.text-secondary.aw-period-range  {{ timeperiod | friendlyperiod }}
+  h3 Activity #[span.d-sm-inline.d-none for ]
+    span.text-muted.d-sm-inline-block.d-block  {{ timeperiod | friendlyperiod }}
 
   div.mb-2
-    ul.list-group.list-group-horizontal-md.mb-3(style="font-size: 0.9em; opacity: 0.7")
+    ul.list-group.list-group-horizontal-md
       li.list-group-item.pl-0.pr-3.py-0(style="border: 0")
-        | #[b Host:] {{ host }}
+        b.mr-1.text-dark Host:
+        span.text-muted {{ host }}
       li.list-group-item.pl-0.pr-3.py-0(style="border: 0")
-        | #[b Time active:] {{ $store.state.activity.active.duration | friendlyduration }}
+        b.mr-1.text-dark Time active:
+        span.text-muted {{ $store.state.activity.active.duration | friendlyduration }}
+    ul.list-group.list-group-horizontal-md(v-if="this.periodLength != 'day'")
+      li.list-group-item.pl-0.pr-3.py-0(style="border: 0")
+        b.mr-1.text-dark Query range:
+        span.text-muted {{ this.periodReadableRange }}
+
 
   div.mb-2.d-flex
     div
@@ -128,17 +135,6 @@ div
     }
   }
 }
-
-@import 'bootstrap/scss/_functions';
-@import 'bootstrap/scss/_variables';
-@import 'bootstrap/scss/mixins/_breakpoints';
-
-@include media-breakpoint-down(sm) {
-  .aw-period-range {
-    display: block;
-    font-size: 0.75em;
-  }
-}
 </style>
 
 <script>
@@ -236,7 +232,7 @@ export default {
       if (this.periodLength === 'day') {
         return 'YYYY-MM-DD';
       } else if (this.periodLength === 'week') {
-        return 'YYYY-MM-DD';
+        return 'YYYY[ W]WW';
       } else if (this.periodLength === 'month') {
         return 'YYYY-MM';
       } else if (this.periodLength === 'year') {
@@ -245,25 +241,18 @@ export default {
         return 'YYYY-MM-DD';
       }
     },
-    periodReadable: function () {
+    periodReadableRange: function () {
       const periodStart = moment(this.timeperiod.start);
-      const dateFormatString = this.dateformat;
+      const dateFormatString = 'YYYY-MM-DD';
 
-      if (this.periodLength === 'week') {
-        // it's helpful to render a range for the week as opposed to just the start of the week
-        // or the number of the week so users can easily determine (a) if we are using monday/sunday as the week
-        // start and exactly when the week ends. The formatting code ends up being a bit more wonky, but it's
-        // worth the tradeoff. https://github.com/ActivityWatch/aw-webui/pull/284
+      // it's helpful to render a range for the week as opposed to just the start of the week
+      // or the number of the week so users can easily determine (a) if we are using monday/sunday as the week
+      // start and exactly when the week ends. The formatting code ends up being a bit more wonky, but it's
+      // worth the tradeoff. https://github.com/ActivityWatch/aw-webui/pull/284
 
-        const startOfWeek = periodStart.format(dateFormatString);
-        const endOfWeek = periodStart.add(1, 'week').format(dateFormatString);
-        return `${startOfWeek}—${endOfWeek}`;
-      } else {
-        return periodStart.format(dateFormatString);
-      }
-    },
-    periodLengthMoment: function () {
-      return periodLengthConvertMoment(this.periodLength);
+      const startOfWeek = periodStart.format(dateFormatString);
+      const endOfWeek = periodStart.add(1, this.periodLength).format(dateFormatString);
+      return `${startOfWeek}—${endOfWeek}`;
     },
   },
   watch: {

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -220,6 +220,36 @@ export default {
     timeperiod: function () {
       return { start: get_day_start_with_offset(this._date), length: [1, this.periodLength] };
     },
+    dateformat: function () {
+      if (this.periodLength === 'day') {
+        return 'YYYY-MM-DD';
+      } else if (this.periodLength === 'week') {
+        return 'YYYY-MM-DD';
+      } else if (this.periodLength === 'month') {
+        return 'YYYY-MM';
+      } else if (this.periodLength === 'year') {
+        return 'YYYY';
+      } else {
+        return 'YYYY-MM-DD';
+      }
+    },
+    periodReadable: function () {
+      const periodStart = moment(this.timeperiod.start);
+      const dateFormatString = this.dateformat;
+
+      if (this.periodLength === 'week') {
+        // it's helpful to render a range for the week as opposed to just the start of the week
+        // or the number of the week so users can easily determine (a) if we are using monday/sunday as the week
+        // start and exactly when the week ends. The formatting code ends up being a bit more wonky, but it's
+        // worth the tradeoff.
+
+        const startOfWeek = periodStart.format(dateFormatString);
+        const endOfWeek = periodStart.add(1, 'week').format(dateFormatString);
+        return `${startOfWeek} — ${endOfWeek}`;
+      } else {
+        return periodStart.format(dateFormatString);
+      }
+    },
     periodLengthMoment: function () {
       return periodLengthConvertMoment(this.periodLength);
     },


### PR DESCRIPTION
This makes it much more explicit what range of data you are viewing. A week number isn't very helpful—I have no idea what range of days a number corresponds to. 

Here's what it looks like:

<img width="690" alt="image" src="https://user-images.githubusercontent.com/150855/117072612-f0ac9180-aced-11eb-9c8b-dd834425f220.png">
