### PR TITLE
fix: split category_time_by_period query into one for each period to avoid timeout

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>ActivityWatch</title>
     <link rel="icon" type="image/png" href="/static/logo.png">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 127.0.0.1:5666 *:27180 ws://*:27180 https://api.github.com/repos/ActivityWatch/activitywatch/releases/latest; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; child-src 'none'; object-src 'none'; script-src 'self' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 127.0.0.1:5600 127.0.0.1:5666 *:27180 ws://*:27180 https://api.github.com/repos/ActivityWatch/activitywatch/releases/latest; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; child-src 'none'; object-src 'none'; script-src 'self' 'unsafe-eval'">
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
While working on https://github.com/ActivityWatch/aw-core/pull/102 I made this change to work around the timeout from the slow query...