### PR TITLE
fix ActivityWatch/activitywatch#600 timeline cut off

### DIFF
--- a/src/util/tooltip.js
+++ b/src/util/tooltip.js
@@ -34,7 +34,7 @@ export function buildTooltip(bucket, e) {
       <tr><td>Data:</td><td>${sanitize(JSON.stringify(e.data))}</td></tr>
       `;
   }
-  return `<table style="z-index: 999;">
+  return `<table>
     <tr></tr>
     <tr><th>Start:</th><td>${moment(e.timestamp).format()}</td></tr>
     <tr><th>Stop:</th><td>${moment(e.timestamp).add(e.duration, 'seconds').format()}</td></tr>

--- a/src/util/tooltip.js
+++ b/src/util/tooltip.js
@@ -34,7 +34,7 @@ export function buildTooltip(bucket, e) {
       <tr><td>Data:</td><td>${sanitize(JSON.stringify(e.data))}</td></tr>
       `;
   }
-  return `<table>
+  return `<table style="z-index: 999;">
     <tr></tr>
     <tr><th>Start:</th><td>${moment(e.timestamp).format()}</td></tr>
     <tr><th>Stop:</th><td>${moment(e.timestamp).add(e.duration, 'seconds').format()}</td></tr>

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -9,7 +9,7 @@ div#visualization {
   margin-bottom: 0.5em;
   overflow: visible;
 
-  .vis-timeline{
+  .vis-timeline {
     overflow: visible;
   }
 

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -7,6 +7,11 @@ div
 div#visualization {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
+  overflow: visible;
+
+  .vis-timeline{
+    overflow: visible;
+  }
 
   .timeline-timeline {
     font-family: sans-serif !important;


### PR DESCRIPTION
fix  ActivityWatch/activitywatch#600

added overflow: visible; to VisTimeline.vue to allow tooltip to overflow the container