### PR TITLE
Set delay to 0 for faster timeline tooltips

### DIFF
--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -55,6 +55,7 @@ export default {
         tooltip: {
           followMouse: true,
           overflowMethod: 'cap',
+          delay: 0,
         },
       },
     };


### PR DESCRIPTION
Closes following feature request:  
https://forum.activitywatch.net/t/make-tooltip-hover-in-timeline-view-show-instantly/1560

Before:

![before](https://user-images.githubusercontent.com/1264761/141695227-0c078fe8-386c-4e69-b644-4a13c8194e27.gif)

After:

![after](https://user-images.githubusercontent.com/1264761/141695228-01092517-5e2e-4ecf-8a3a-78fb00cc3672.gif)

