### PR TITLE
fix: fixed category modification

### DIFF
--- a/src/store/modules/categories.js
+++ b/src/store/modules/categories.js
@@ -80,19 +80,20 @@ const mutations = {
   },
   updateClass(state, new_class) {
     console.log('Updating class:', new_class);
-    const old_class = _.cloneDeep(state.classes[new_class.id]);
+    const old_class = state.classes.find(c => c.id === new_class.id);
+    const old_name = old_class.name;
+    const parent_depth = old_class.name.length;
 
     if (new_class.id === undefined || new_class.id === null) {
       new_class.id = _.max(_.map(state.classes, 'id')) + 1;
       state.classes.push(new_class);
     } else {
-      Object.assign(state.classes[new_class.id], new_class);
+      Object.assign(old_class, new_class);
     }
 
     // When a parent category is renamed, we also need to rename the children
-    const parent_depth = old_class.name.length;
     _.map(state.classes, c => {
-      if (_.isEqual(old_class.name, c.name.slice(0, parent_depth))) {
+      if (_.isEqual(old_name, c.name.slice(0, parent_depth))) {
         c.name = new_class.name.concat(c.name.slice(parent_depth));
         console.log('Renamed child:', c.name);
       }

--- a/test/unit/store/categories.test.node.js
+++ b/test/unit/store/categories.test.node.js
@@ -106,7 +106,10 @@ test('modify a category after deleting another', () => {
   expect(video_2_cat.data.test).toBe(true);
 
   // Check that the category named "Video" no longer exists, and the category named "Video2" exists
-  const video_2s = store.getters['categories/all_categories'];
-  expect(store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video']))).toHaveLength(0);
-  expect(store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video2']))).toHaveLength(1);
+  expect(
+    store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video']))
+  ).toHaveLength(0);
+  expect(
+    store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video2']))
+  ).toHaveLength(1);
 });

--- a/test/unit/store/categories.test.node.js
+++ b/test/unit/store/categories.test.node.js
@@ -1,4 +1,5 @@
 import store from '~/store';
+import _ from 'lodash';
 import { createMissingParents, defaultCategories } from '~/util/classes';
 
 beforeEach(() => {
@@ -71,4 +72,41 @@ test('update implicit parent category', () => {
 
   // Check that defaultCategories haven't mutated
   expect(defaultCategories.map(c => c.name)).toContainEqual(['Media', 'Music']);
+});
+
+test('modify a category after deleting another', () => {
+  // Deleting a category, then modifying another with an ID subsequent to it, should not
+  // cause the changes to be applied to unintended classes.
+  // Test against:
+  // https://github.com/ActivityWatch/activitywatch/issues/361#issuecomment-970707045
+  store.commit('categories/restoreDefaultClasses');
+
+  // Check that Image category is available
+  expect(store.getters['categories/all_categories']).toContainEqual(['Work', 'Image']);
+
+  // Delete Image category
+  const image_cat = store.getters['categories/get_category'](['Work', 'Image']);
+  const image_cat_id = image_cat.id;
+  expect(image_cat_id).not.toBeUndefined();
+  store.commit('categories/removeClass', image_cat_id);
+
+  // Check that Image category no longer exists
+  expect(store.getters['categories/all_categories']).not.toContainEqual(['Work', 'Image']);
+
+  // Get Video category (whose ID succeeds to that of Image) and modify it
+  const video_cat = store.getters['categories/get_category'](['Work', 'Video']);
+  const video_cat_id = video_cat.id;
+  expect(video_cat_id).not.toBeUndefined();
+  expect(video_cat_id).toBeGreaterThan(image_cat_id);
+  const new_video_cat = { ...video_cat, name: ['Work', 'Video2'], data: { test: true } };
+  store.commit('categories/updateClass', new_video_cat);
+
+  // Check that modification on Video was applied
+  const video_2_cat = store.getters['categories/get_category_by_id'](video_cat_id);
+  expect(video_2_cat.data.test).toBe(true);
+
+  // Check that the category named "Video" no longer exists, and the category named "Video2" exists
+  const video_2s = store.getters['categories/all_categories'];
+  expect(store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video']))).toHaveLength(0);
+  expect(store.getters['categories/all_categories'].filter(c => _.isEqual(c, ['Work', 'Video2']))).toHaveLength(1);
 });


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/361#issuecomment-970707045
Deleting a category, then modifying another with an ID subsequent to it, caused  the changes to be applied to unintended classes. This commit fixes it.