### PR TITLE
fix: check for missing ID in New View modal

### DIFF
--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -327,6 +327,7 @@ export default {
       const checks = {
         // Check if view id is unique
         'ID is not unique': this.$store.state.views.views.map(v => v.id).includes(this.new_view.id),
+        'Missing ID': this.new_view.id === '',
         'Missing name': this.new_view.name === '',
       };
       const errors = Object.entries(checks)


### PR DESCRIPTION
Mitigates activitywatch/activitywatch#706

If there's any sort of migration or data integrity checks run when upgrading AW, maybe it should look for views with a null ID and set the ID to a slugified view name?