### PR TITLE
fix(perf): don't query periods without known activity for timeline barchart

### DIFF
--- a/src/store/modules/activity.ts
+++ b/src/store/modules/activity.ts
@@ -13,6 +13,7 @@ import {
   timeperiodToStr,
   timeperiodsHoursOfPeriod,
   timeperiodsDaysOfPeriod,
+  timeperiodsMonthsOfPeriod,
   timeperiodsAroundTimeperiod,
 } from '~/util/timeperiod';
 
@@ -92,6 +93,10 @@ function timeperiodsStrsHoursOfPeriod(timeperiod: TimePeriod): string[] {
 
 function timeperiodsStrsDaysOfPeriod(timeperiod: TimePeriod): string[] {
   return timeperiodsDaysOfPeriod(timeperiod).map(timeperiodToStr);
+}
+
+function timeperiodsStrsMonthsOfPeriod(timeperiod: TimePeriod): string[] {
+  return timeperiodsMonthsOfPeriod(timeperiod).map(timeperiodToStr);
 }
 
 function timeperiodStrsAroundTimeperiod(timeperiod: TimePeriod): string[] {
@@ -288,6 +293,8 @@ const actions = {
       periods = timeperiodsStrsHoursOfPeriod(timeperiod);
     } else if (timeperiod.length[1] == 'week' || timeperiod.length[1] == 'month') {
       periods = timeperiodsStrsDaysOfPeriod(timeperiod);
+    } else if (timeperiod.length[1] == 'year') {
+      periods = timeperiodsStrsMonthsOfPeriod(timeperiod);
     } else {
       console.error('Unknown timeperiod');
     }

--- a/src/util/timeperiod.ts
+++ b/src/util/timeperiod.ts
@@ -72,7 +72,6 @@ export function timeperiodsHoursOfPeriod(timeperiod: TimePeriod): TimePeriod[] {
       .format();
     periods.push({ start, length: _length });
   }
-  // const periods = _.range(24).map(i => [TimePeriod(moment(i * 1 + dayOffset), [1, 'hour'])]);
   return periods;
 }
 
@@ -93,6 +92,19 @@ export function timeperiodsDaysOfPeriod(timeperiod: TimePeriod): TimePeriod[] {
       .format();
     periods.push({ start, length: _length });
   }
-  // const periods = _.range(24).map(i => [TimePeriod(moment(i * 1 + dayOffset), [1, 'hour'])]);
+  return periods;
+}
+
+export function timeperiodsMonthsOfPeriod(timeperiod: TimePeriod): TimePeriod[] {
+  const periods = [];
+  const _length: [number, string] = [1, 'month'];
+
+  const count = 12;
+  for (let i = 0; i < count; i++) {
+    const start = moment(timeperiod.start)
+      .add(i * _length[0], _length[1] as moment.unitOfTime.DurationConstructor)
+      .format();
+    periods.push({ start, length: _length });
+  }
   return periods;
 }

--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -55,11 +55,14 @@ export default class ChartTimelineBars extends Vue<Bar> {
     if (this.resolution == 'day') {
       return _.range(0, 24).map(h => `${(h + hourOffset) % 24}`);
     } else if (this.resolution == 'week') {
+      // FIXME: In the future this will depend on a 'start of week' setting
       return ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
     } else if (this.resolution == 'month') {
       // FIXME: Needs access to the timeperiod start to know which month
       const daysInMonth = 31;
       return ['1st', '2nd', '3rd'].concat(_.range(4, daysInMonth + 1).map(d => `${d}th`));
+    } else if (this.resolution == 'year') {
+      return ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     } else {
       console.error('Invalid resolution');
     }


### PR DESCRIPTION
This roughly halved the total loading time of the activity view for me (from ~10s to ~5s).

Should drastically improve performance on sparse days/weeks/months.