### PR TITLE
ci: fixed if-statement always evaluating to true in comment.yml

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -13,7 +13,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     if: >
-      ${{ github.event.workflow_run.conclusion == 'success' }}  # && github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.conclusion == 'success'  # && github.event.workflow_run.event == 'pull_request'
 
     steps:
     - uses: iterative/setup-cml@v1


### PR DESCRIPTION
The expression was treated as a string and always evaluated as true.