### PR TITLE
feat: started working on force-directed graph for visualizing category-transitions

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -74,6 +74,10 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
           b-dropdown-item(to="/query")
             icon(name="code")
             | Query
+          b-dropdown-item(to="/graph" v-if="devmode")
+            // TODO: use circle-nodes instead in the future
+            icon(name="project-diagram")
+            | Graph
 
         b-nav-item(to="/buckets")
           div.px-2.px-lg-1
@@ -106,6 +110,10 @@ import 'vue-awesome/icons/stopwatch';
 import 'vue-awesome/icons/cog';
 import 'vue-awesome/icons/tools';
 import 'vue-awesome/icons/history';
+
+// TODO: use circle-nodes instead in the future
+import 'vue-awesome/icons/project-diagram';
+//import 'vue-awesome/icons/cicle-nodes';
 
 import 'vue-awesome/icons/ellipsis-h';
 

--- a/src/route.js
+++ b/src/route.js
@@ -19,6 +19,7 @@ const Search = () => import('./views/Search.vue');
 const Report = () => import('./views/Report.vue');
 const TimespiralView = () => import('./views/TimespiralView.vue');
 const Dev = () => import('./views/Dev.vue');
+const Graph = () => import('./views/Graph.vue');
 const NotFound = () => import('./views/NotFound.vue');
 
 Vue.use(VueRouter);
@@ -64,6 +65,7 @@ const router = new VueRouter({
     { path: '/settings', component: Settings },
     { path: '/stopwatch', component: Stopwatch },
     { path: '/search', component: Search },
+    { path: '/graph', component: Graph },
     { path: '/dev', component: Dev },
     // NOTE: Will break with Vue 3: https://stackoverflow.com/questions/40193634/vue-router-redirect-on-page-not-found-404/64186073#64186073
     {

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -6,7 +6,6 @@ import { IEvent } from '~/util/interfaces';
 
 import { window_events } from '~/util/fakedata';
 import queries from '~/queries';
-import { getColorFromCategory } from '~/util/color';
 import { get_day_start_with_offset } from '~/util/time';
 import {
   TimePeriod,
@@ -44,8 +43,7 @@ function colorCategories(events: IEvent[]): IEvent[] {
   // Set $color for categories
   const categoryStore = useCategoryStore();
   return events.map((e: IEvent) => {
-    const cat = categoryStore.get_category(e.data['$category']);
-    e.data['$color'] = getColorFromCategory(cat, categoryStore.classes);
+    e.data['$color'] = categoryStore.get_category_color(e.data['$category']);
     return e;
   });
 }

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -7,7 +7,6 @@ import { IEvent } from '~/util/interfaces';
 import { window_events } from '~/util/fakedata';
 import queries from '~/queries';
 import { getColorFromCategory } from '~/util/color';
-import { loadClassesForQuery } from '~/util/classes';
 import { get_day_start_with_offset } from '~/util/time';
 import {
   TimePeriod,
@@ -274,8 +273,12 @@ export const useActivityStore = defineStore('activity', {
 
     async query_android({ timeperiod, filter_categories }: QueryOptions) {
       const periods = [timeperiodToStr(timeperiod)];
-      const classes = loadClassesForQuery();
-      const q = queries.appQuery(this.buckets.android[0], classes, filter_categories);
+      const categoryStore = useCategoryStore();
+      const q = queries.appQuery(
+        this.buckets.android[0],
+        categoryStore.classes_for_query,
+        filter_categories
+      );
       const data = await getClient().query(periods, q).catch(this.errorHandler);
       this.query_window_completed(data[0]);
     },
@@ -293,7 +296,7 @@ export const useActivityStore = defineStore('activity', {
       hosts: string[]
     ) {
       const periods = [timeperiodToStr(timeperiod)];
-      const categories = loadClassesForQuery();
+      const categories = useCategoryStore().classes_for_query;
 
       const q = queries.multideviceQuery({
         hosts,
@@ -318,7 +321,7 @@ export const useActivityStore = defineStore('activity', {
       include_audible,
     }: QueryOptions) {
       const periods = [timeperiodToStr(timeperiod)];
-      const categories = loadClassesForQuery();
+      const categories = useCategoryStore().classes_for_query;
 
       const q = queries.fullDesktopQuery({
         bid_window: this.buckets.window[0],
@@ -419,7 +422,7 @@ export const useActivityStore = defineStore('activity', {
           }
         }
 
-        const categories = loadClassesForQuery();
+        const categories = useCategoryStore().classes_for_query;
         const result = await getClient().query(
           [period],
           // TODO: Clean up call, pass QueryParams in fullDesktopQuery as well

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -2,11 +2,13 @@ import _ from 'lodash';
 import {
   saveClasses,
   loadClasses,
+  cleanCategory,
   defaultCategories,
   build_category_hierarchy,
   createMissingParents,
   annotate,
   Category,
+  Rule,
 } from '~/util/classes';
 import { defineStore } from 'pinia';
 
@@ -23,9 +25,19 @@ export const useCategoryStore = defineStore('categories', {
 
   // getters
   getters: {
+    classes_clean(): Category[] {
+      return this.classes.map(cleanCategory);
+    },
     classes_hierarchy() {
       const hier = build_category_hierarchy(_.cloneDeep(this.classes));
       return _.sortBy(hier, [c => c.id || 0]);
+    },
+    classes_for_query(): [string[], Rule][] {
+      return this.classes
+        .filter(c => c.rule.type !== null)
+        .map(c => {
+          return [c.name, c.rule];
+        });
     },
     all_categories(): string[][] {
       // Returns a list of category names (a list of list of strings)

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -10,6 +10,7 @@ import {
   Category,
   Rule,
 } from '~/util/classes';
+import { getColorFromCategory } from '~/util/color';
 import { defineStore } from 'pinia';
 
 interface State {
@@ -72,6 +73,11 @@ export const useCategoryStore = defineStore('categories', {
     get_category_by_id(this: State) {
       return (id: number) => {
         return annotate(_.cloneDeep(this.classes.find((c: Category) => c.id == id)));
+      };
+    },
+    get_category_color() {
+      return (cat: string[]) => {
+        return getColorFromCategory(this.get_category(cat), this.classes);
       };
     },
     category_select() {

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -5,7 +5,7 @@ const level_sep = '>';
 const CLASSIFY_KEYS = ['app', 'title'];
 const UNCATEGORIZED = ['Uncategorized'];
 
-interface Rule {
+export interface Rule {
   type: 'regex' | 'none';
   regex?: string;
   ignore_case?: boolean;
@@ -165,25 +165,27 @@ export function saveClasses(classes: Category[]) {
     console.log('Not saving classes in test mode');
     return;
   }
-  localStorage.classes = JSON.stringify(classes);
+  localStorage.classes = JSON.stringify(classes.map(cleanCategory));
   console.log('Saved classes', localStorage.classes);
+}
+
+export function cleanCategory(cat: Category): Category {
+  cat = _.cloneDeep(cat);
+  delete cat.children;
+  delete cat.parent;
+  delete cat.subname;
+  delete cat.name_pretty;
+  delete cat.depth;
+  return cat;
 }
 
 export function loadClasses(): Category[] {
   const classes_json = localStorage.classes;
   if (classes_json && classes_json.length >= 1) {
-    return JSON.parse(classes_json);
+    return JSON.parse(classes_json).map(cleanCategory);
   } else {
     return defaultCategories;
   }
-}
-
-export function loadClassesForQuery(): [string[], Rule][] {
-  return loadClasses()
-    .filter(c => c.rule.type !== null)
-    .map(c => {
-      return [c.name, c.rule];
-    });
 }
 
 function pickDeepest(categories: Category[]) {

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -58,7 +58,6 @@ div
 import _ from 'lodash';
 import moment from 'moment';
 import { canonicalEvents } from '~/queries';
-import { loadClassesForQuery } from '~/util/classes';
 
 import 'vue-awesome/icons/plus';
 import 'vue-awesome/icons/check';
@@ -146,13 +145,11 @@ export default {
 
     // Check current time of alert goals
     check: async function () {
-      const classes = loadClassesForQuery();
-
       let query = canonicalEvents({
         bid_window: 'aw-watcher-window_' + this.hostname,
         bid_afk: 'aw-watcher-afk_' + this.hostname,
         filter_afk: this.filter_afk,
-        classes: classes,
+        classes: useCategoryStore().classes_for_query,
         filter_classes: null, // classes.map(c => c[0]),
       });
       query += '; RETURN = events;';

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -2,6 +2,9 @@
 div
   h3 Graph
 
+  b-alert(show variant="warning")
+    | This feature is still in early development. See PR #[a(href="https://github.com/ActivityWatch/aw-webui/pull/365") aw-webui#365] for more information.
+
   | Displays a graph of categories and their transitions.
 
   b-alert.mt-2(style="warning" show)

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -1,0 +1,197 @@
+<template lang="pug">
+div
+  h3 Graph
+
+  | Displays a graph of categories and their transitions.
+
+  b-alert.mt-2(style="warning" show)
+    | This feature is still in early development.
+
+  b-alert(v-if="error" show variant="danger")
+    | {{error}}
+
+  b-button(type="button", @click="generate()" variant="success")
+    icon(name="search")
+    | Generate
+
+  // Specify max category depth
+  b-form-group(label="Max category depth")
+    b-form-input(v-model="maxDepth" type="number" min="1")
+
+  div.d-flex.mt-1
+    span.mr-auto.small(style="color: #666") Hostname: {{queryOptions.hostname}}
+    b-button.border-0(size="sm", variant="outline-dark" @click="show_options = !show_options")
+      span(v-if="!show_options")
+        | #[icon(name="angle-double-down")] Show options
+      span(v-else)
+        | #[icon(name="angle-double-up")] Hide options
+
+  div(v-show="show_options")
+    h4 Options
+    aw-query-options(v-model="queryOptions")
+
+  div(v-if="status == 'searching'")
+    div #[icon(name="spinner" pulse)] Searching...
+
+
+  div(v-if="events != null")
+    hr
+
+    div
+        | Found {{ events.length }} events in {{ queryTime / 1000 }} seconds
+
+    hr
+
+    aw-force-graph(:data="graphdata")
+
+    div
+      | Didn't find what you were looking for?
+      br
+      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="start = start.subtract(1, 'week'); search()") +1 week]
+</template>
+
+<style scoped lang="scss"></style>
+
+<script lang="ts">
+import _ from 'lodash';
+import moment from 'moment';
+
+import 'vue-awesome/icons/search';
+import 'vue-awesome/icons/spinner';
+import 'vue-awesome/icons/angle-double-down';
+import 'vue-awesome/icons/angle-double-up';
+
+import { canonicalEvents } from '~/queries';
+
+import { useActivityStore } from '~/stores/activity';
+import { useCategoryStore } from '~/stores/categories';
+import { useBucketsStore } from '~/stores/buckets';
+
+import { getClient } from '~/util/awclient';
+
+export default {
+  name: 'Graph',
+  components: {
+    'aw-force-graph': () => import('~/visualizations/ForceGraph.vue'),
+  },
+  data() {
+    return {
+      activityStore: useActivityStore(),
+      categoryStore: useCategoryStore(),
+      bucketsStore: useBucketsStore(),
+
+      events: null,
+      graphdata: { nodes: [], links: [] },
+      maxDepth: 3,
+
+      status: null,
+      queryTime: null,
+      error: '',
+
+      // Options
+      show_options: false,
+      queryOptions: {},
+    };
+  },
+  watch: {
+    events() {
+      this.graphdata = this.generateGraphData();
+    },
+  },
+  mounted: async function () {
+    await this.categoryStore.load();
+    await this.bucketsStore.ensureLoaded();
+  },
+  methods: {
+    generate: async function () {
+      // TODO: use full query (one per day/timeperiod) instead of canonicalEvents
+      let query = canonicalEvents({
+        bid_window: 'aw-watcher-window_' + this.queryOptions.hostname,
+        bid_afk: 'aw-watcher-afk_' + this.queryOptions.hostname,
+        filter_afk: this.queryOptions.filter_afk,
+        categories: this.categoryStore.classes_for_query,
+        filter_categories: null,
+      });
+      query += '; RETURN = events;';
+
+      const query_array = query.split(';').map(s => s.trim() + ';');
+      const start = moment(this.queryOptions.start).format();
+      const end = moment(this.queryOptions.stop).format();
+      const timeperiods = [start + '/' + end];
+      try {
+        this.status = 'searching';
+        const time = moment();
+        const data = await getClient().query(timeperiods, query_array);
+        this.events = _.orderBy(data[0], ['timestamp'], ['desc']);
+        this.error = '';
+        this.queryTime = moment().diff(time);
+      } catch (e) {
+        console.error(e);
+        this.error = e.response.data.message;
+      } finally {
+        this.status = null;
+      }
+      console.log('done fetching events!');
+    },
+    generateGraphData() {
+      // generate graph data from events
+      // iterate through events, and count the number of category transitions
+      // for each category, add a node to the graphdata with the group of its parent category
+      // for each transition-pair, add a link to the graphdata with the number of transitions as weight
+      const SEP = '>';
+
+      // copy all events, slice off category depth deeper than maxDepth
+      const events = this.events.map(e => {
+        const $category = e.data.$category.slice(0, this.maxDepth);
+        return { ...e, data: { ...e.data, $category } };
+      });
+
+      const allCategories = new Set(events.map(e => e.data.$category).map(c => c.join(SEP)));
+      const groups = {};
+
+      // Generate groups
+      for (const category of allCategories) {
+        const rootcat = category.split(SEP)[0];
+        if (!Object.prototype.hasOwnProperty.call(groups, rootcat)) {
+          groups[rootcat] = Object.keys(groups).length;
+        }
+      }
+
+      // Generate nodes
+      // TODO: Size nodes depending on time spent
+      const nodes = [];
+      for (const category of allCategories) {
+        const rootcat = category.split(SEP)[0];
+        nodes.push({
+          id: category,
+          group: groups[rootcat],
+        });
+      }
+
+      // Generate links
+      const links = [];
+      for (let i = 0; i < events.length - 1; i++) {
+        const e1 = events[i];
+        const e2 = events[i + 1];
+        const e1cat = e1.data.$category;
+        const e2cat = e2.data.$category;
+        if (_.isEqual(e1cat, e2cat)) continue;
+
+        const link = links.find(l => l.source == e1cat.join(SEP) && l.target == e2cat.join(SEP));
+        if (link) {
+          link.value++;
+        } else {
+          links.push({
+            source: e1cat.join(SEP),
+            target: e2cat.join(SEP),
+            value: 1,
+          });
+        }
+      }
+
+      console.log('generated nodes & links');
+      return { nodes, links };
+    },
+  },
+};
+</script>

--- a/src/visualizations/ForceGraph.vue
+++ b/src/visualizations/ForceGraph.vue
@@ -1,0 +1,180 @@
+<template lang="pug">
+div#forcegraph
+</template>
+
+<script lang="ts">
+import * as d3 from 'd3';
+
+export default {
+  name: 'ForceGraph',
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  watch: {
+    // Watch for changes in the data and update the graph
+    data: {
+      handler: function () {
+        this.drawGraph(this.data);
+      },
+      deep: true,
+    },
+  },
+
+  methods: {
+    drawGraph({ nodes, links }) {
+      console.log('rendering...');
+      console.log(nodes, links);
+      const svgEl = ForceGraph({ nodes, links }, { nodeTitle: d => d.id });
+      console.log('appending...');
+      const svg = d3.select('#forcegraph');
+      //clear
+      svg.selectAll('*').remove();
+      //append
+      svg.node().appendChild(svgEl);
+      console.log('drawn!');
+    },
+  },
+};
+
+// Copyright 2021 Observable, Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/force-directed-graph
+function ForceGraph(
+  {
+    nodes, // an iterable of node objects (typically [{id}, …])
+    links, // an iterable of link objects (typically [{source, target}, …])
+  },
+  {
+    nodeId = d => d.id, // given d in nodes, returns a unique identifier (string)
+    nodeGroup = d => d.group, // given d in nodes, returns an (ordinal) value for color
+    nodeGroups, // an array of ordinal values representing the node groups
+    nodeTitle = d => d.id.split('>').slice(-1), // given d in nodes, a title string
+    nodeFill = 'currentColor', // node stroke fill (if not using a group color encoding)
+    nodeStroke = '#fff', // node stroke color
+    nodeStrokeWidth = 1.5, // node stroke width, in pixels
+    nodeStrokeOpacity = 1, // node stroke opacity
+    nodeRadius = 5, // node radius, in pixels
+    nodeStrength,
+    linkSource = ({ source }) => source, // given d in links, returns a node identifier string
+    linkTarget = ({ target }) => target, // given d in links, returns a node identifier string
+    linkStroke = '#999', // link stroke color
+    linkStrokeOpacity = 0.6, // link stroke opacity
+    linkStrokeWidth = d => 1.5 * Math.sqrt(d.value), // given d in links, returns a stroke width in pixels
+    linkStrokeLinecap = 'round', // link stroke linecap
+    linkStrength,
+    colors = d3.schemeTableau10, // an array of color strings, for the node groups
+    width = 640, // outer width, in pixels
+    height = 400, // outer height, in pixels
+    invalidation, // when this promise resolves, stop the simulation
+  } = {}
+) {
+  // Compute values.
+  const N = d3.map(nodes, nodeId).map(intern);
+  const LS = d3.map(links, linkSource).map(intern);
+  const LT = d3.map(links, linkTarget).map(intern);
+  if (nodeTitle === undefined) nodeTitle = (_, i) => N[i];
+  const T = nodeTitle == null ? null : d3.map(nodes, nodeTitle);
+  const G = nodeGroup == null ? null : d3.map(nodes, nodeGroup).map(intern);
+  const W = typeof linkStrokeWidth !== 'function' ? null : d3.map(links, linkStrokeWidth);
+  const L = typeof linkStroke !== 'function' ? null : d3.map(links, linkStroke);
+
+  // Replace the input nodes and links with mutable objects for the simulation.
+  nodes = d3.map(nodes, (_, i) => ({ id: N[i] }));
+  links = d3.map(links, (_, i) => ({ source: LS[i], target: LT[i] }));
+
+  // Compute default domains.
+  if (G && nodeGroups === undefined) nodeGroups = d3.sort(G);
+
+  // Construct the scales.
+  const color = nodeGroup == null ? null : d3.scaleOrdinal(nodeGroups, colors);
+
+  // Construct the forces.
+  const forceNode = d3.forceManyBody();
+  const forceLink = d3.forceLink(links).id(({ index: i }) => N[i]);
+  if (nodeStrength !== undefined) forceNode.strength(nodeStrength);
+  if (linkStrength !== undefined) forceLink.strength(linkStrength);
+
+  const simulation = d3
+    .forceSimulation(nodes)
+    .force('link', forceLink)
+    .force('charge', forceNode)
+    .force('center', d3.forceCenter())
+    .on('tick', ticked);
+
+  const svg = d3
+    .create('svg')
+    .attr('width', width)
+    .attr('height', height)
+    .attr('viewBox', [-width / 2, -height / 2, width, height])
+    .attr('style', 'max-width: 100%; height: auto; height: intrinsic;');
+
+  const link = svg
+    .append('g')
+    .attr('stroke', typeof linkStroke !== 'function' ? linkStroke : null)
+    .attr('stroke-opacity', linkStrokeOpacity)
+    .attr('stroke-width', typeof linkStrokeWidth !== 'function' ? linkStrokeWidth : null)
+    .attr('stroke-linecap', linkStrokeLinecap)
+    .selectAll('line')
+    .data(links)
+    .join('line');
+
+  const node = svg
+    .append('g')
+    .attr('fill', nodeFill)
+    .attr('stroke', nodeStroke)
+    .attr('stroke-opacity', nodeStrokeOpacity)
+    .attr('stroke-width', nodeStrokeWidth)
+    .selectAll('circle')
+    .data(nodes)
+    .join('circle')
+    .attr('r', nodeRadius)
+    .call(drag(simulation));
+
+  if (W) link.attr('stroke-width', ({ index: i }) => W[i]);
+  if (L) link.attr('stroke', ({ index: i }) => L[i]);
+  if (G) node.attr('fill', ({ index: i }) => color(G[i]));
+  if (T) node.append('title').text(({ index: i }) => T[i]);
+  if (invalidation != null) invalidation.then(() => simulation.stop());
+
+  function intern(value) {
+    return value !== null && typeof value === 'object' ? value.valueOf() : value;
+  }
+
+  function ticked() {
+    link
+      .attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y);
+
+    node.attr('cx', d => d.x).attr('cy', d => d.y);
+  }
+
+  function drag(simulation) {
+    function dragstarted(event) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      event.subject.fx = event.subject.x;
+      event.subject.fy = event.subject.y;
+    }
+
+    function dragged(event) {
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+    }
+
+    function dragended(event) {
+      if (!event.active) simulation.alphaTarget(0);
+      event.subject.fx = null;
+      event.subject.fy = null;
+    }
+
+    return d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended);
+  }
+
+  return Object.assign(svg.node(), { scales: { color } });
+}
+</script>


### PR DESCRIPTION
Generates a graph where:

 - node radius is based on the time spent in the category.
 - edge force & thickness is based on the number of transitions (not the best metric)

Uses category colors.

## TODO

 - [ ] What should count as a transition/context-switch?
    - Currently, even the briefest of transitions are counted as just as significant (could reduce this by merging/flooding category-events and removing short category-events)
    - Also shouldn't count transitions wider than x seconds apart (or fill such gaps with events that have an "afk" category, since that might also be interesting to see)
    - @casaout might have some ideas
 - [ ] Is there a way to get directed-graph behavior, with animated edges to see direction things are flowing?
    - Seems super overkill and hard, but maybe awesome?

## Screenshot (WIP)

![image](https://user-images.githubusercontent.com/1405370/188885631-4392c93d-8f92-49c5-8efa-4cadb845b1b2.png)
