### PR TITLE
fix: add browser-queries support for waterfox and orion

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -222,18 +222,28 @@ const browser_appnames = {
     'Brave-browser',
   ],
   firefox: [
+    // Firefox
     'Firefox',
     'Firefox.exe',
     'firefox',
     'firefox.exe',
+
+    // Firefox Developer
     'Firefox Developer Edition',
     'firefoxdeveloperedition',
+
+    // Pre-releases https://github.com/ActivityWatch/aw-watcher-web/issues/87
     'Firefox-esr',
     'Firefox Beta',
     'Nightly',
-    // From: https://github.com/ActivityWatch/aw-watcher-web/issues/87
     'firefox-aurora',
     'firefox-trunk-dev',
+
+    // Waterfox
+    'Waterfox',
+    'Waterfox.exe',
+    'waterfox',
+    'waterfox.exe',
   ],
   opera: ['opera.exe', 'Opera'],
   brave: ['brave.exe'],
@@ -243,6 +253,7 @@ const browser_appnames = {
     'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
   ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
+  orion: ['Orion'],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
Small edit to appnames list under queries.ts to address issue/request expressed in ActivityWatch/aw-watcher-web#88. I did not add 'Min' browser to the list, as it does not currently have extension support. 

I tested with waterfox on a windows machine and it worked. I am unable to test Orion, as I do not have an OSX machine readily available. 