### PR TITLE
feat: pull default query from query param

### DIFF
--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -36,6 +36,7 @@ div
 
 <script>
 import moment from 'moment';
+import _ from 'lodash';
 
 const today = moment().startOf('day');
 const tomorrow = moment(today).add(24, 'hours');
@@ -43,12 +44,21 @@ const tomorrow = moment(today).add(24, 'hours');
 export default {
   name: 'QueryExplorer',
   data() {
-    return {
-      query_code: `afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
+    // allow queries to be saved in a URL parameter
+    let queryCode = this.$route.query.q;
+
+    if(_.isEmpty(this.$route.query.q)) {
+      queryCode = `
+afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
 window_events = query_bucket(find_bucket("aw-watcher-window_"));
 window_events = filter_period_intersect(window_events, filter_keyvals(afk_events, "status", ["not-afk"]));
 merged_events = merge_events_by_keys(window_events, ["app", "title"]);
-RETURN = sort_by_duration(merged_events);`,
+RETURN = sort_by_duration(merged_events);
+`;
+    }
+
+    return {
+      query_code: queryCode,
       event_type: 'currentwindow',
       events: [],
       today: today.format(),

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -20,7 +20,7 @@ div
         input.form-control(type="date", :max="tomorrow", v-model="enddate")
 
     div.form-group
-      textarea.form-control(v-model="query_code", @keypress.ctrl.enter="query()" style="font-family: monospace", rows=4)
+      textarea.form-control(v-model="query_code", @keypress.ctrl.enter="query()" style="font-family: monospace", rows=10)
     div.form-inline
       div.form-group
         button.btn.btn-success(type="button", @click="query()") Query

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -47,7 +47,7 @@ export default {
     // allow queries to be saved in a URL parameter
     let queryCode = this.$route.query.q;
 
-    if(_.isEmpty(this.$route.query.q)) {
+    if (_.isEmpty(this.$route.query.q)) {
       queryCode = `
 afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
 window_events = query_bucket(find_bucket("aw-watcher-window_"));


### PR DESCRIPTION
- Load default query from `q` param in url. This allows users to have bookmarks with various queries.
- Expand default query input area. For my taste, it was a bit too small.
