### PR TITLE
fix: fixed NewReleaseNotification couldn't be hidden/disabled

### DIFF
--- a/src/components/NewReleaseNotification.vue
+++ b/src/components/NewReleaseNotification.vue
@@ -40,7 +40,7 @@ export default {
     };
   },
   computed: {
-    ...mapWritableState(useSettingsStore, { data: 'newReleaseNotification' }),
+    ...mapWritableState(useSettingsStore, { data: 'newReleaseCheckData' }),
   },
   async mounted() {
     await useSettingsStore().ensureLoaded();


### PR DESCRIPTION
- Typo is settingStore data name
- component NewReleaseNotification cannot be permanently disabled or hidden since state data is not in sync with settingStore's state

https://github.com/ActivityWatch/aw-webui/blob/1980a403dfc2a9f54c0700c202d20e17ccf8bba6/src/stores/settings.ts#L43-L49

https://github.com/ActivityWatch/aw-webui/blob/1980a403dfc2a9f54c0700c202d20e17ccf8bba6/src/components/NewReleaseNotification.vue#L42-L44

![1](https://user-images.githubusercontent.com/4137788/194953446-4c052d3a-cc57-4929-9ca1-97157166e5e8.PNG)
![2](https://user-images.githubusercontent.com/4137788/194953457-453ff11b-35f4-4196-b2fc-0c05d0889688.PNG)
