### PR TITLE
fix: enforce unix-style newlines through .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
- Is recommended by Prettier itself - https://prettier.io/docs/en/options.html#end-of-line
- If this not set, git itself converts the EOLs(by default, to OS specifc EOLs), when code is pulled from repo, so Windows devs will by default will have CRLF files in their working directory
- git will also recognize its own auto-eol-conversions (normalization) as code changes - polluting commit changes
- When comitting code EOLs which is inconflict with .editerconfig or .prettier.yml, which will cause issues in CI as well as local build warns

Ref:
- https://prettier.io/docs/en/options.html#end-of-line
- https://stackoverflow.com/a/2825829/4957939
- https://stackoverflow.com/a/37057962/4957939