### PR TITLE
fix: ci and e2e test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,7 +47,7 @@ jobs:
         node-version: [16]
         python-version: ['3.9']
         aw-server: ["aw-server", "aw-server-rust"]
-        aw-version: ["v0.12.1", "master"]
+        aw-version: ["v0.12.1"]
         #include:
         #- node-version: '16'
         #  python-version: '3.9'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -124,11 +124,14 @@ jobs:
           npm run serve &
           sleep 3  # give a few seconds
     - name: Run e2e tests with testcafe
+      id: e2e
       uses: DevExpress/testcafe-action@latest
       with:
         # NOTE: --skip-js-errors should be removed when things work properly
         args: "--skip-js-errors chrome test/e2e/"
     - name: Move screenshots to subdir
+      # Run this step even if e2e tests flag failure
+      if: ${{ success() || steps.e2e.conclusion == 'failure'}}
       env:
         aw_server: ${{ matrix.aw-server }}
         aw_version: ${{ matrix.aw-version }}
@@ -136,6 +139,7 @@ jobs:
         mkdir -p screenshots/dist/$aw_server/$aw_version
         mv screenshots/*.png screenshots/dist/$aw_server/$aw_version
     - name: Upload screenshots
+      if: ${{ success() || steps.e2e.conclusion == 'failure'}}
       uses: actions/upload-artifact@v2-preview
       with:
         name: screenshots

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,11 +48,11 @@ jobs:
         python-version: ['3.9']
         aw-server: ["aw-server-rust"]
         aw-version: ["v0.12.0"]
-        #include:
-        #- node-version: '16'
-        #  python-version: '3.9'
-        #  aw-server: "aw-server-rust"
-        #  aw-version: "master"
+        include:
+        - node-version: '16'
+         python-version: '3.9'
+         aw-server: "aw-server-rust"
+         aw-version: "master"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         node-version: [16]
         python-version: ['3.9']
-        aw-server: ["aw-server-rust"]
-        aw-version: ["v0.12.0", "master"]
+        aw-server: ["aw-server", "aw-server-rust"]
+        aw-version: ["v0.12.1", "master"]
         #include:
         #- node-version: '16'
         #  python-version: '3.9'
@@ -80,7 +80,7 @@ jobs:
       if: ${{ matrix.aw-server == 'aw-server-rust' && matrix.aw-version == 'master' }}
       uses: dawidd6/action-download-artifact@v2
       with:
-        repo: ShootingKing-AM/aw-server-rust
+        repo: ActivityWatch/aw-server-rust
         # Required, workflow file name or ID
         workflow: build.yml
         # Optional, the status or conclusion of a completed workflow to search for
@@ -102,7 +102,7 @@ jobs:
     - name: Install and run aw-server-rust nightly
       if: ${{ matrix.aw-server == 'aw-server-rust' && matrix.aw-version == 'master' }}
       run: |
-        chmod +x ./aw-server-rust/debug/aw-server        
+        chmod +x ./aw-server-rust/debug/aw-server
         LOG_LEVEL=debug ./aw-server-rust/debug/aw-server --testing &
 
     - name: Insert fake data into aw-server
@@ -147,8 +147,6 @@ jobs:
         path: screenshots/dist/*
     - name: Print server logs to console
       if: ${{ always() }}
-      # env:
-      #   aw_server: ${{ matrix.aw-server }}
       shell: bash
       run:
         for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -102,9 +102,8 @@ jobs:
     - name: Install and run aw-server-rust nightly
       if: ${{ matrix.aw-server == 'aw-server-rust' && matrix.aw-version == 'master' }}
       run: |
-        chmod +x ./aw-server-rust/debug/aw-server
-        set LOG_LEVEL=debug
-        ./aw-server-rust/debug/aw-server --testing &
+        chmod +x ./aw-server-rust/debug/aw-server        
+        LOG_LEVEL=debug ./aw-server-rust/debug/aw-server --testing &
 
     - name: Insert fake data into aw-server
       run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,11 +48,11 @@ jobs:
         python-version: ['3.9']
         aw-server: ["aw-server", "aw-server-rust"]
         aw-version: ["v0.12.1"]
-        #include:
-        #- node-version: '16'
-        #  python-version: '3.9'
-        #  aw-server: "aw-server-rust"
-        #  aw-version: "master"
+        include:
+        - node-version: '16'
+          python-version: '3.9'
+          aw-server: "aw-server-rust"
+          aw-version: "master"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -111,7 +111,8 @@ jobs:
         wget --no-verbose -O fakedata.py https://raw.githubusercontent.com/ActivityWatch/aw-fakedata/master/aw_fakedata.py
         GITDATE=$(git show -s --format=%ci HEAD | sed -r 's/ .+//g')
         STARTDATE=$(date --date="${GITDATE} -30 day" +%Y-%m-%d)
-        python3 fakedata.py --since $STARTDATE --until $GITDATE
+        ENDDATE=$(date --date="${GITDATE} +1 day" +%Y-%m-%d)
+        python3 fakedata.py --since $STARTDATE --until $ENDDATE
 
     - name: Install
       run: npm ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -80,7 +80,7 @@ jobs:
       if: ${{ matrix.aw-server == 'aw-server-rust' && matrix.aw-version == 'master' }}
       uses: dawidd6/action-download-artifact@v2
       with:
-        repo: ActivityWatch/aw-server-rust
+        repo: ShootingKing-AM/aw-server-rust
         # Required, workflow file name or ID
         workflow: build.yml
         # Optional, the status or conclusion of a completed workflow to search for
@@ -103,6 +103,7 @@ jobs:
       if: ${{ matrix.aw-server == 'aw-server-rust' && matrix.aw-version == 'master' }}
       run: |
         chmod +x ./aw-server-rust/debug/aw-server
+        set LOG_LEVEL=debug
         ./aw-server-rust/debug/aw-server --testing &
 
     - name: Insert fake data into aw-server
@@ -136,7 +137,7 @@ jobs:
       #   aw_server: ${{ matrix.aw-server }}
       shell: bash
       run:
-        cat ~/.cache/activitywatch/log/*
+        for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done
     
     - name: Move screenshots to subdir
       # Run this step even if e2e tests flag failure

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,12 +47,12 @@ jobs:
         node-version: [16]
         python-version: ['3.9']
         aw-server: ["aw-server-rust"]
-        aw-version: ["v0.12.0"]
-        include:
-        - node-version: '16'
-         python-version: '3.9'
-         aw-server: "aw-server-rust"
-         aw-version: "master"
+        aw-version: ["v0.12.0", "master"]
+        #include:
+        #- node-version: '16'
+        #  python-version: '3.9'
+        #  aw-server: "aw-server-rust"
+        #  aw-version: "master"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,7 +47,7 @@ jobs:
         node-version: [16]
         python-version: ['3.9']
         aw-server: ["aw-server", "aw-server-rust"]
-        aw-version: ["v0.12.0"]
+        aw-version: ["v0.12.0", "v0.12.1"]
         #include:
         #- node-version: '16'
         #  python-version: '3.9'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -132,9 +132,10 @@ jobs:
         args: "--skip-js-errors chrome test/e2e/"
     - name: Print server logs to console
       if: ${{ always() }}
-      enc:
-        aw_server: ${{ matrix.aw-server }}
-      bash:
+      # env:
+      #   aw_server: ${{ matrix.aw-server }}
+      shell: bash
+      run:
         cat ~/.cache/activitywatch/log/*
     
     - name: Move screenshots to subdir

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -131,14 +131,6 @@ jobs:
       with:
         # NOTE: --skip-js-errors should be removed when things work properly
         args: "--skip-js-errors chrome test/e2e/"
-    - name: Print server logs to console
-      if: ${{ always() }}
-      # env:
-      #   aw_server: ${{ matrix.aw-server }}
-      shell: bash
-      run:
-        for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done
-    
     - name: Move screenshots to subdir
       # Run this step even if e2e tests flag failure
       if: ${{ success() || steps.e2e.conclusion == 'failure'}}
@@ -154,3 +146,25 @@ jobs:
       with:
         name: screenshots
         path: screenshots/dist/*
+    - name: Print server logs to console
+      if: ${{ always() }}
+      # env:
+      #   aw_server: ${{ matrix.aw-server }}
+      shell: bash
+      run:
+        for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done
+    - name: Move logs to subdir
+      # Run this step even if e2e tests flag failure
+      if: ${{ always() }}
+      env:
+        aw_server: ${{ matrix.aw-server }}
+        aw_version: ${{ matrix.aw-version }}
+      run: |
+        mkdir -p logs/dist/$aw_server/$aw_version
+        mv ~/.cache/activitywatch/log/*/*.log logs/dist/$aw_server/$aw_version
+    - name: Upload logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2-preview
+      with:
+        name: logs
+        path: logs/dist/*

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         node-version: [16]
         python-version: ['3.9']
-        aw-server: ["aw-server", "aw-server-rust"]
-        aw-version: ["v0.12.0", "v0.12.1"]
+        aw-server: ["aw-server-rust"]
+        aw-version: ["v0.12.0"]
         #include:
         #- node-version: '16'
         #  python-version: '3.9'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -130,6 +130,13 @@ jobs:
       with:
         # NOTE: --skip-js-errors should be removed when things work properly
         args: "--skip-js-errors chrome test/e2e/"
+    - name: Print server logs to console
+      if: ${{ always() }}
+      enc:
+        aw_server: ${{ matrix.aw-server }}
+      bash:
+        cat ~/.cache/activitywatch/log/*
+    
     - name: Move screenshots to subdir
       # Run this step even if e2e tests flag failure
       if: ${{ success() || steps.e2e.conclusion == 'failure'}}

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	npm test
 
 test-e2e:
-	npx testcafe firefox test/e2e/ -s takeOnFails=true
+	npx testcafe chrome test/e2e/ -s takeOnFails=true
 
 typing-coverage:
 	npx typescript-coverage-report

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -37,7 +37,7 @@ div
 <script>
 import moment from 'moment';
 import _ from 'lodash';
-import { loadClassesForQuery } from '~/util/classes';
+import { useCategoryStore } from '~/stores/categories';
 
 const today = moment().startOf('day');
 const tomorrow = moment(today).add(24, 'hours');
@@ -54,9 +54,9 @@ afk_events = query_bucket(find_bucket("aw-watcher-afk_"));
 window_events = query_bucket(find_bucket("aw-watcher-window_"));
 window_events = filter_period_intersect(window_events, filter_keyvals(afk_events, "status", ["not-afk"]));
 merged_events = merge_events_by_keys(window_events, ["app", "title"]);
-merged_events = categorize(events, __CATEGORIES__);
+merged_events = categorize(merged_events, __CATEGORIES__);
 RETURN = sort_by_duration(merged_events);
-`;
+`.trim();
     }
 
     return {
@@ -82,7 +82,7 @@ RETURN = sort_by_duration(merged_events);
 
       // replace magic string `__CATEGORIES__` in query text with latest category rule
       if (_.includes(query, '__CATEGORIES__')) {
-        const categoryRules = loadClassesForQuery();
+        const categoryRules = useCategoryStore().classes_for_query;
         // const classes_str = JSON.stringify(params.classes).replace(/\\\\/g, '\\');
         query = query.replace('__CATEGORIES__', JSON.stringify(categoryRules));
       }

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -28,7 +28,9 @@ async function waitForLoading(t) {
     // Useful for debugging:
     matches = await $loading.count;
     if (matches > 0) {
-      console.log(`Found ${matches} loading element with contents`); //: ${await $loading.innerText}`);
+      console.log(
+        `Found ${matches} loading element with contents - "${await $loading.textContent}"`
+      ); //: ${await $loading.innerText}`);
 
       // If taking >20s, throw an error
       if (new Date() - start > 20000) {
@@ -101,6 +103,10 @@ const durationOption = durationSelect.find('option');
 
 test('Screenshot the timeline view', async t => {
   await hide_devonly(t);
+  await t.takeScreenshot({
+    path: 'timeline-initial.png',
+    fullPage: true,
+  });
   await waitForLoading(t);
   await t
     .click(durationSelect)
@@ -109,7 +115,7 @@ test('Screenshot the timeline view', async t => {
     .eql('43200');
 
   await t.takeScreenshot({
-    path: 'timeline.png',
+    path: 'timeline-12h.png',
     fullPage: true,
   });
   await checkNoError(t);

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -85,11 +85,11 @@ fixture(`Activity view`).page(`${baseURL}/#/activity/fakedata`);
 test('Screenshot the activity view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'activity.png',
     fullPage: true,
   });
+  await checkNoError(t);
 
   // TODO: resize to mobile size and take another screenshot
 });
@@ -102,7 +102,6 @@ const durationOption = durationSelect.find('option');
 test('Screenshot the timeline view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t
     .click(durationSelect)
     .click(durationOption.withText('12h'))
@@ -113,6 +112,7 @@ test('Screenshot the timeline view', async t => {
     path: 'timeline.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Buckets view`).page(`${baseURL}/#/buckets/`);
@@ -120,22 +120,22 @@ fixture(`Buckets view`).page(`${baseURL}/#/buckets/`);
 test('Screenshot the buckets view', async t => {
   await hide_devonly(t);
   await t.wait(1000);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'buckets.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Setting view`).page(`${baseURL}/#/settings/`);
 
 test('Screenshot the settings view', async t => {
   await hide_devonly(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'settings.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });
 
 fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`);
@@ -143,9 +143,9 @@ fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`);
 test('Screenshot the stopwatch view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
-  await checkNoError(t);
   await t.takeScreenshot({
     path: 'stopwatch.png',
     fullPage: true,
   });
+  await checkNoError(t);
 });

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -18,17 +18,15 @@ async function waitForLoading(t) {
   // Waits for all "Loading..." texts to disappear from page.
   // If it takes longer than 10s, it will fail.
   let $loading;
-  let matches = 1;
 
   console.log('Waiting for loading to disappear...');
   const start = new Date();
   do {
-    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
+    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g)();
 
     // Useful for debugging:
-    matches = $loading.count;
-    if (matches > 0) {
-      console.log(`Found ${matches} loading element with contents - "${$loading.textContent}"`); //: ${await $loading.innerText}`);
+    if ($loading) {
+      console.log(`Found loading element with contents - "${$loading.textContent}"`);
 
       // If taking >20s, throw an error
       if (new Date() - start > 20000) {
@@ -36,7 +34,7 @@ async function waitForLoading(t) {
       }
       await t.wait(500);
     }
-  } while (matches >= 1);
+  } while ($loading);
 
   await t.wait(500); // wait an extra 500ms, just in case a visualization is still rendering
   console.log('Loading is gone!');
@@ -45,23 +43,18 @@ async function waitForLoading(t) {
 async function waitIndefinitelyForLoading(t) {
   // Waits for all "Loading..." texts to disappear from page, indefinitely
   let $loading;
-  let matches = 1;
 
   console.log('Waiting indefinitely for loading to disappear...');
   const start = new Date();
   do {
-    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
+    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g)();
 
     // Useful for debugging:
-    matches = $loading.count;
-    if (matches > 0) {
-      // console.log(
-      //   `Found ${matches} loading element with contents - "${await $loading.textContent}"`
-      // );
+    if ($loading) {
       process.stdout.write('.');
       await t.wait(500);
     }
-  } while (matches >= 1);
+  } while ($loading);
   const end = new Date();
 
   await t.wait(500); // wait an extra 500ms, just in case a visualization is still rendering

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -23,14 +23,12 @@ async function waitForLoading(t) {
   console.log('Waiting for loading to disappear...');
   const start = new Date();
   do {
-    $loading = Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
+    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
 
     // Useful for debugging:
-    matches = await $loading.count;
+    matches = $loading.count;
     if (matches > 0) {
-      console.log(
-        `Found ${matches} loading element with contents - "${await $loading.textContent}"`
-      ); //: ${await $loading.innerText}`);
+      console.log(`Found ${matches} loading element with contents - "${$loading.textContent}"`); //: ${await $loading.innerText}`);
 
       // If taking >20s, throw an error
       if (new Date() - start > 20000) {
@@ -52,10 +50,10 @@ async function waitIndefinitelyForLoading(t) {
   console.log('Waiting indefinitely for loading to disappear...');
   const start = new Date();
   do {
-    $loading = Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
+    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
 
     // Useful for debugging:
-    matches = await $loading.count;
+    matches = $loading.count;
     if (matches > 0) {
       // console.log(
       //   `Found ${matches} loading element with contents - "${await $loading.textContent}"`

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -126,6 +126,10 @@ test('Screenshot the timeline view', async t => {
     fullPage: true,
   });
   await checkNoError(t);
+
+  // Debugging
+  console.log(await t.getBrowserConsoleMessages());
+  console.log(JSON.stringify(HTTPLogger.requests, null, '\t'));
 });
 
 fixture(`Buckets view`).page(`${baseURL}/#/buckets/`).requestHooks(HTTPLogger);

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -44,6 +44,32 @@ async function waitForLoading(t) {
   console.log('Loading is gone!');
 }
 
+async function waitIndefinitelyForLoading(t) {
+  // Waits for all "Loading..." texts to disappear from page, indefinitely
+  let $loading;
+  let matches = 1;
+
+  console.log('Waiting indefinitely for loading to disappear...');
+  const start = new Date();
+  do {
+    $loading = Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g);
+
+    // Useful for debugging:
+    matches = await $loading.count;
+    if (matches > 0) {
+      // console.log(
+      //   `Found ${matches} loading element with contents - "${await $loading.textContent}"`
+      // );
+      process.stdout.write('.');
+      await t.wait(500);
+    }
+  } while (matches >= 1);
+  const end = new Date();
+
+  await t.wait(500); // wait an extra 500ms, just in case a visualization is still rendering
+  console.log(`Loading is gone! Total wait time = ${(end - start).toString()}ms`);
+}
+
 async function checkNoError(t) {
   const $error = Selector('div.alert').withText(/[Ee]rror/g);
   try {
@@ -107,7 +133,7 @@ test('Screenshot the timeline view', async t => {
     path: 'timeline-initial.png',
     fullPage: true,
   });
-  await waitForLoading(t);
+  await waitIndefinitelyForLoading(t);
   await t
     .click(durationSelect)
     .click(durationOption.withText('12h'))

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -37,6 +37,11 @@ async function waitForLoading(t) {
     if ($loading) {
       console.log(`Found loading element with contents - "${$loading.textContent}"`);
 
+      if (new Date() - start > 10000) {
+        console.log('Refreshing page....');
+        await t.eval(() => location.reload(true));
+      }
+
       // If taking >20s, throw an error
       if (new Date() - start > 20000) {
         console.log(await t.getBrowserConsoleMessages());
@@ -93,7 +98,9 @@ test('Screenshot the home view', async t => {
 
 fixture(`Activity view`).page(`${baseURL}/#/activity/fakedata`).requestHooks(HTTPLogger);
 
-test('Screenshot the activity view', async t => {
+test.clientScripts({
+  content: logJsErrorCode,
+})('Screenshot the activity view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
   await t.takeScreenshot({
@@ -132,13 +139,15 @@ test.clientScripts({
   await checkNoError(t);
 
   // Debugging
-  console.log(await t.getBrowserConsoleMessages());
-  console.log(JSON.stringify(HTTPLogger.requests, null, '\t'));
+  // console.log(await t.getBrowserConsoleMessages());
+  // console.log(JSON.stringify(HTTPLogger.requests, null, '\t'));
 });
 
 fixture(`Buckets view`).page(`${baseURL}/#/buckets/`).requestHooks(HTTPLogger);
 
-test('Screenshot the buckets view', async t => {
+test.clientScripts({
+  content: logJsErrorCode,
+})('Screenshot the buckets view', async t => {
   await hide_devonly(t);
   await t.wait(1000);
   await t.takeScreenshot({
@@ -150,7 +159,9 @@ test('Screenshot the buckets view', async t => {
 
 fixture(`Setting view`).page(`${baseURL}/#/settings/`).requestHooks(HTTPLogger);
 
-test('Screenshot the settings view', async t => {
+test.clientScripts({
+  content: logJsErrorCode,
+})('Screenshot the settings view', async t => {
   await hide_devonly(t);
   await t.takeScreenshot({
     path: 'settings.png',
@@ -161,7 +172,9 @@ test('Screenshot the settings view', async t => {
 
 fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`).requestHooks(HTTPLogger);
 
-test('Screenshot the stopwatch view', async t => {
+test.clientScripts({
+  content: logJsErrorCode,
+})('Screenshot the stopwatch view', async t => {
   await hide_devonly(t);
   await waitForLoading(t);
   await t.takeScreenshot({

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -43,11 +43,11 @@ async function waitForLoading(t) {
 }
 
 async function checkNoError(t) {
-  const $error = Selector('div').withText(/[Ee]rror/g);
+  const $error = Selector('div.alert').withText(/[Ee]rror/g);
   try {
     await t.expect(await $error.count).eql(0);
   } catch (e) {
-    console.log('Errors found: ' + $error);
+    console.log('Errors found: ' + (await $error.textContent));
     throw e;
   }
 }

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -61,15 +61,17 @@ async function checkNoError(t) {
   }
 }
 
+const logJsErrorCode = `
+  window.addEventListener('error', function (e) {
+      console.error(e.message);
+  });`;
+
 fixture(`Home view`).page(baseURL);
 
 // Log JS errors even if --skip-js-errors is given
 // From: https://stackoverflow.com/a/59856422/965332
 test.clientScripts({
-  content: `
-        window.addEventListener('error', function (e) {
-            console.error(e.message);
-        });`,
+  content: logJsErrorCode,
 })(`Skip error but log it`, async t => {
   console.log(await t.getBrowserConsoleMessages());
 });
@@ -108,7 +110,9 @@ fixture(`Timeline view`).page(`${baseURL}/#/timeline`).requestHooks(HTTPLogger);
 const durationSelect = Selector('select#duration');
 const durationOption = durationSelect.find('option');
 
-test('Screenshot the timeline view', async t => {
+test.clientScripts({
+  content: logJsErrorCode,
+})('Screenshot the timeline view', async t => {
   await hide_devonly(t);
   await t.takeScreenshot({
     path: 'timeline-initial.png',

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -33,7 +33,7 @@ async function waitForLoading(t) {
       ); //: ${await $loading.innerText}`);
 
       // If taking >20s, throw an error
-      if (new Date() - start > 20000) {
+      if (new Date() - start > 40000) {
         throw new Error('Timeout while waiting for loading to disappear');
       }
       await t.wait(500);

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -33,7 +33,7 @@ async function waitForLoading(t) {
       ); //: ${await $loading.innerText}`);
 
       // If taking >20s, throw an error
-      if (new Date() - start > 40000) {
+      if (new Date() - start > 20000) {
         throw new Error('Timeout while waiting for loading to disappear');
       }
       await t.wait(500);

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -51,27 +51,6 @@ async function waitForLoading(t) {
   console.log('Loading is gone!');
 }
 
-/* async function waitIndefinitelyForLoading(t) {
-  // Waits for all "Loading..." texts to disappear from page, indefinitely
-  let $loading;
-
-  console.log('Waiting indefinitely for loading to disappear...');
-  const start = new Date();
-  do {
-    $loading = await Selector('.aw-loading, text', { timeout: 500 }).withText(/Loading[.]{3}/g)();
-
-    // Useful for debugging:
-    if ($loading) {
-      process.stdout.write('.');
-      await t.wait(500);
-    }
-  } while ($loading);
-  const end = new Date();
-
-  await t.wait(500); // wait an extra 500ms, just in case a visualization is still rendering
-  console.log(`Loading is gone! Total wait time = ${(end - start).toString()}ms`);
-} */
-
 async function checkNoError(t) {
   const $error = Selector('div.alert').withText(/[Ee]rror/g);
   try {
@@ -110,7 +89,7 @@ test('Screenshot the home view', async t => {
   });
 });
 
-fixture(`Activity view`).page(`${baseURL}/#/activity/fakedata`);
+fixture(`Activity view`).page(`${baseURL}/#/activity/fakedata`).requestHooks(HTTPLogger);
 
 test('Screenshot the activity view', async t => {
   await hide_devonly(t);
@@ -149,7 +128,7 @@ test('Screenshot the timeline view', async t => {
   await checkNoError(t);
 });
 
-fixture(`Buckets view`).page(`${baseURL}/#/buckets/`);
+fixture(`Buckets view`).page(`${baseURL}/#/buckets/`).requestHooks(HTTPLogger);
 
 test('Screenshot the buckets view', async t => {
   await hide_devonly(t);
@@ -161,7 +140,7 @@ test('Screenshot the buckets view', async t => {
   await checkNoError(t);
 });
 
-fixture(`Setting view`).page(`${baseURL}/#/settings/`);
+fixture(`Setting view`).page(`${baseURL}/#/settings/`).requestHooks(HTTPLogger);
 
 test('Screenshot the settings view', async t => {
   await hide_devonly(t);
@@ -172,7 +151,7 @@ test('Screenshot the settings view', async t => {
   await checkNoError(t);
 });
 
-fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`);
+fixture(`Stopwatch view`).page(`${baseURL}/#/stopwatch/`).requestHooks(HTTPLogger);
 
 test('Screenshot the stopwatch view', async t => {
   await hide_devonly(t);

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -122,7 +122,7 @@ test('Screenshot the timeline view', async t => {
     .eql('43200');
 
   await t.takeScreenshot({
-    path: 'timeline-12h.png',
+    path: 'timeline.png',
     fullPage: true,
   });
   await checkNoError(t);


### PR DESCRIPTION
- e2e test
  - use chrome in local e2e tests as being done in CI
  - Narrow down `Selector` to div with `alert` class else larger vue app dialog will be matched
  - Actually show the Error content instead of function (https://github.com/ActivityWatch/aw-webui/actions/runs/3325513704/jobs/5498275035#step:12:41)
  - Now takes screenshots first and then check and throw errors, so that errors can be visualized in CI itself
  - Now takes two screenshot for timeline view since >95% CI errors are on this test and all such errors pertain to timeouts (now even emits the content of `Selector`)
  - Fix reactive component missing even after `.count` is `>0` (https://github.com/ActivityWatch/aw-webui/actions/runs/3333810551/jobs/5516122757#step:12:58)
  - before throwing errors for debugging
    - Added HTTP request logger for dumping HTTP requests of non js,css,font,image requests
    - Added logging of browser console log, errros, warns, infos messages
  - Now even shows `Loading...` element content for debugging
  - Now refreshes if `Loading...` does not dissapear after sometime

- Update nodejs.yml test job in CI
  - to run upload-screenshot-step even when not all e2e-tests are successful (eg. https://github.com/ShootingKing-AM/aw-webui/actions/runs/3333119816/jobs/5514746436 and even ci-runs for this pr)
  - Bumped version to v0.12.1
  - Now Prints Server logs to github actions console and uploads logs artifact (eg. https://github.com/ActivityWatch/aw-webui/actions/runs/3341759143/jobs/5533273819#step:15:29)
  - fake_data.py to even add entries for current day