### PR TITLE
adds Microsoft-edge to list of browser names

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -264,6 +264,7 @@ const browser_appnames = {
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS
     'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
+    'Microsoft-edge',
   ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
   orion: ['Orion'],


### PR DESCRIPTION
that's the name for the package on NIx, 
I fell like generating all variations of browser name should be a better option than what's currently done