### PR TITLE
visualizations: queries: update microsoft edge name for linux

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -263,7 +263,9 @@ const browser_appnames = {
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS
-    'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
+    'microsoft-edge' // linux
+    'microsoft-edge-beta' // linux beta
+    'microsoft-edge-dev' // linux dev
   ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
   orion: ['Orion'],


### PR DESCRIPTION
add all 3 variants, name reference is arch Linux AUR https://aur.archlinux.org/packages/microsoft-edge-stable-bin

currently, edge tabs are not shown on the dashboard for both stable and dev channels. 
![2023-04-05_02-55](https://user-images.githubusercontent.com/10248473/229892303-5b183d4c-ce1c-4c54-8ed3-2d4b14a27c01.png)
