### PR TITLE
fix: add librewolf support

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -252,6 +252,12 @@ const browser_appnames = {
     'firefox-aurora',
     'firefox-trunk-dev',
 
+    // Librewolf
+    'Librewolf',
+    'Librewolf.exe',
+    'librewolf',
+    'librewolf.exe',
+
     // Waterfox
     'Waterfox',
     'Waterfox.exe',


### PR DESCRIPTION
I've noticed that data from my Librewolf bucket is not appended to the browser activity.

I've tested changes locally on my NixOS instance and it works for me.