### PR TITLE
fix: support Arc browser on macOS

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -272,6 +272,9 @@ const browser_appnames = {
     'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
     'Microsoft-edge',
   ],
+  arc: [
+    "Arc" // macOS
+  ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
   orion: ['Orion'],
 };


### PR DESCRIPTION
Add [Arc](https://arc.net/) browser to macOS

resolve https://github.com/ActivityWatch/aw-watcher-web/issues/111