### PR TITLE
Add Yandex Browser to browsers

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -277,6 +277,7 @@ const browser_appnames = {
   ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
   orion: ['Orion'],
+  yandex: ['Yandex']
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
This is a popular Chromium-based browser in Russia
`CFBundleDisplayName` is `Yandex` for me on MacOS for app∂ version 23.9.0.2296