### PR TITLE
fix: better librewolf browser support

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -253,6 +253,8 @@ const browser_appnames = {
     'firefox-trunk-dev',
 
     // Librewolf
+    'LibreWolf',
+    'LibreWolf.exe',
     'Librewolf',
     'Librewolf.exe',
     'librewolf',

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -253,6 +253,7 @@ const browser_appnames = {
     'firefox-trunk-dev',
 
     // Librewolf
+    'LibreWolf-Portable.exe',
     'LibreWolf',
     'LibreWolf.exe',
     'Librewolf',


### PR DESCRIPTION
No stats about librewolf were shown in Activity->Browser tab. Not so sure about windows portable version, because i can't build this program in windows, but stats were empty too, so i simply copied the process name from task manager.