### PR TITLE
feat: added support for query caching in aw-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^12.20.37",
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
-        "aw-client": "^0.3.2",
+        "aw-client": "^0.3.7",
         "bootstrap": "^4.6.1",
         "bootstrap-vue": "^2.15.0",
         "chart.js": "^3.8.0",
@@ -8038,17 +8038,17 @@
       }
     },
     "node_modules/aw-client": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/aw-client/-/aw-client-0.3.6.tgz",
-      "integrity": "sha512-nFosUt2DP5n1WNyyVpCgAaa36AmtgLC9c2Dsb1vMUVcbn0TfGvWLbgXnQzzJriylPoEyp3LrGOhVQTBBXBNSFA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/aw-client/-/aw-client-0.3.7.tgz",
+      "integrity": "sha512-cY7NB06FSUFR1pvz1dnKbqasK5vf96VxjQBhEXG3//52hn87Hk3vfw79rYh2/izYe9eopgMGhn8JTUhvWT7Lkw==",
       "dependencies": {
         "axios": "*"
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -32300,17 +32300,17 @@
       "dev": true
     },
     "aw-client": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/aw-client/-/aw-client-0.3.6.tgz",
-      "integrity": "sha512-nFosUt2DP5n1WNyyVpCgAaa36AmtgLC9c2Dsb1vMUVcbn0TfGvWLbgXnQzzJriylPoEyp3LrGOhVQTBBXBNSFA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/aw-client/-/aw-client-0.3.7.tgz",
+      "integrity": "sha512-cY7NB06FSUFR1pvz1dnKbqasK5vf96VxjQBhEXG3//52hn87Hk3vfw79rYh2/izYe9eopgMGhn8JTUhvWT7Lkw==",
       "requires": {
         "axios": "*"
       }
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^12.20.37",
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
-    "aw-client": "^0.3.2",
+    "aw-client": "^0.3.7",
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.15.0",
     "chart.js": "^3.8.0",

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -306,6 +306,7 @@ export default {
   },
   methods: {
     getTimelineBuckets: async function () {
+      if (this.type != 'vis_timeline') return;
       if (!this.timeline_daterange) return;
 
       await useBucketsStore().ensureLoaded();


### PR DESCRIPTION
Builds on https://github.com/ActivityWatch/aw-client-js/pull/44

Also fixed so that we don't fetch bucket events if vis_timeline is not in the Activity view. (big perf improvement, major decrease in requests!)

For now there will be some verbose logs to make it easy to debug if something is not working, but it can easily be removed in the future.

For now the cache is cleared on page reload.