### PR TITLE
Update app name for Vivaldi browser

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -281,7 +281,7 @@ const browser_appnames = {
   arc: [
     'Arc', // macOS
   ],
-  vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe'],
+  vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi'],
   orion: ['Orion'],
   yandex: ['Yandex'],
 };


### PR DESCRIPTION
On MacOS, the Vivaldi browser app name is only "Vivaldi". Therefore, the UI cannot filter the browser event for Vivaldi correctly.