### PR TITLE
feat(timeline): swimlanes, duration filter, and filter desc to timeline

### DIFF
--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -12,7 +12,7 @@ div
         th.pr-2
           label(for="mode") Interval mode:
         td
-          select(id="mode", v-model="mode")
+          select(id="mode", v-model="mode", @change="valueChanged")
             option(value='last_duration') Last duration
             option(value='range') Date range
       tr(v-if="mode == 'last_duration'")

--- a/src/util/swimlane.js
+++ b/src/util/swimlane.js
@@ -1,0 +1,28 @@
+import moment from 'moment';
+import { seconds_to_duration } from './time';
+import DOMPurify from 'dompurify';
+import _ from 'lodash';
+
+const sanitize = DOMPurify.sanitize;
+
+export function getSwimlane(bucket, color, groupBy, e) {
+  // WARNING: XSS risk, make sure to sanitize properly
+  // FIXME: Not actually tested against XSS attacks, implementation needs to be verified in tests.
+  let subgroup = 'unknown';
+
+  if (groupBy == 'category') {
+    subgroup = sanitize(color);
+  } else if (groupBy == 'bucketType') {
+    if (bucket.type == 'currentwindow') {
+      subgroup = sanitize(e.data.app);
+    } else if (bucket.type == 'web.tab.current') {
+      subgroup = sanitize((new URL(e.data.url)).hostname.replace('www.',''));
+    } else if (bucket.type.startsWith('app.editor')) {
+      subgroup = sanitize(e.data.language);
+    } else if (bucket.type.startsWith('general.stopwatch')) {
+      subgroup = sanitize(e.data.label);
+    } 
+  }
+
+  return subgroup;
+}

--- a/src/util/swimlane.js
+++ b/src/util/swimlane.js
@@ -13,7 +13,7 @@ export function getSwimlane(bucket, color, groupBy, e) {
     if (bucket.type == 'currentwindow') {
       subgroup = sanitize(e.data.app);
     } else if (bucket.type == 'web.tab.current') {
-      subgroup = sanitize((new URL(e.data.url)).hostname.replace('www.', ''));
+      subgroup = sanitize(new URL(e.data.url).hostname.replace('www.', ''));
     } else if (bucket.type.startsWith('app.editor')) {
       subgroup = sanitize(e.data.language);
     } else if (bucket.type.startsWith('general.stopwatch')) {

--- a/src/util/swimlane.js
+++ b/src/util/swimlane.js
@@ -1,7 +1,4 @@
-import moment from 'moment';
-import { seconds_to_duration } from './time';
 import DOMPurify from 'dompurify';
-import _ from 'lodash';
 
 const sanitize = DOMPurify.sanitize;
 
@@ -16,12 +13,12 @@ export function getSwimlane(bucket, color, groupBy, e) {
     if (bucket.type == 'currentwindow') {
       subgroup = sanitize(e.data.app);
     } else if (bucket.type == 'web.tab.current') {
-      subgroup = sanitize((new URL(e.data.url)).hostname.replace('www.',''));
+      subgroup = sanitize((new URL(e.data.url)).hostname.replace('www.', ''));
     } else if (bucket.type.startsWith('app.editor')) {
       subgroup = sanitize(e.data.language);
     } else if (bucket.type.startsWith('general.stopwatch')) {
       subgroup = sanitize(e.data.label);
-    } 
+    }
   }
 
   return subgroup;

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -107,7 +107,7 @@ export default {
       if (desc.length > 0) {
         return desc.join(', ');
       }
-      return 'none'
+      return 'none';
     },
   },
   watch: {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -54,7 +54,7 @@ div
 
   div(v-if="buckets !== null")
     div(style="clear: both")
-    vis-timeline(:buckets="buckets", :showRowLabels='true', :queriedInterval="daterange", :swimlane="swimlane")
+    vis-timeline(:buckets="buckets", :showRowLabels='true', :queriedInterval="daterange", :swimlane="swimlane", :updateTimelineWindow='updateTimelineWindow')
 
     aw-devonly(reason="Not ready for production, still experimenting")
       aw-calendar(:buckets="buckets")
@@ -82,6 +82,7 @@ export default {
       filter_client: null,
       filter_duration: null,
       swimlane: null,
+      updateTimelineWindow: true,
     };
   },
   computed: {
@@ -112,18 +113,23 @@ export default {
   },
   watch: {
     daterange() {
+      this.updateTimelineWindow = true;
       this.getBuckets();
     },
     filter_hostname() {
+      this.updateTimelineWindow = false;
       this.getBuckets();
     },
     filter_client() {
+      this.updateTimelineWindow = false;
       this.getBuckets();
     },
     filter_duration() {
+      this.updateTimelineWindow = false;
       this.getBuckets();
     },
     swimlane() {
+      this.updateTimelineWindow = false;
       this.getBuckets();
     },
   },

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -93,7 +93,7 @@ export default {
       return _.sumBy(this.buckets, 'events.length');
     },
     filter_summary() {
-      let desc = [];
+      const desc = [];
       if (this.filter_hostname) {
         desc.push(this.filter_hostname);
       }
@@ -102,13 +102,13 @@ export default {
       }
       if (this.filter_duration > 0) {
         desc.push(seconds_to_duration(this.filter_duration));
-      } 
+      }
 
       if (desc.length > 0) {
-        return desc.join(", ");
+        return desc.join(', ');
       }
-      return "none"
-    }
+      return 'none'
+    },
   },
   watch: {
     daterange() {
@@ -152,7 +152,7 @@ export default {
       if (this.filter_client) {
         buckets = _.filter(buckets, b => b.client == this.filter_client);
       }
-      
+
       if (this.filter_duration > 0) {
         for (const bucket of buckets) {
           bucket.events = _.filter(bucket.events, e => e.duration >= this.filter_duration);

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -10,7 +10,7 @@ div
   div.d-inline-block.border.rounded.p-2.mr-2
     | Swimlanes:  
     select(v-model="swimlane")
-      option(value='null') None
+      option(:value='null') None
       option(value='category') Categories
       option(value='bucketType') Bucket Specific
   details.d-inline-block.bg-light.small.border.rounded.mr-2.px-2
@@ -37,18 +37,18 @@ div
             label Duration:
           td
             select(v-model="filter_duration")
-              option(value='null') All
-              option(value='2') 2+ secs
-              option(value='5') 5+ secs
-              option(value='10') 10+ secs
-              option(value='30') 30+ sec
-              option(value='60') 1+ mins
-              option(value='120') 2+ mins
-              option(value='180') 3+ mins
-              option(value='600') 10+ mins
-              option(value='1800') 30+ mins
-              option(value='3600') 1+ hrs
-              option(value='7200') 2+ hrs
+              option(:value='null') All
+              option(:value='2') 2+ secs
+              option(:value='5') 5+ secs
+              option(:value='10') 10+ secs
+              option(:value='30') 30+ sec
+              option(:value='1 * 60') 1+ mins
+              option(:value='2 * 60') 2+ mins
+              option(:value='3 * 60') 3+ mins
+              option(:value='10 * 60') 10+ mins
+              option(:value='30 * 60') 30+ mins
+              option(:value='1 * 60 * 60') 1+ hrs
+              option(:value='2 * 60 * 60') 2+ hrs
   div(style="float: right; color: #999").d-inline-block.pt-3
     | Drag to pan and scroll to zoom
 

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -7,9 +7,15 @@ div
   // blocks
   div.d-inline-block.border.rounded.p-2.mr-2
     | Events shown:  {{ num_events }}
+  div.d-inline-block.border.rounded.p-2.mr-2
+    | Swimlanes:  
+    select(v-model="swimlane")
+      option(value='null') None
+      option(value='category') Categories
+      option(value='bucketType') Bucket Specific
   details.d-inline-block.bg-light.small.border.rounded.mr-2.px-2
     summary.p-2
-      b Filters
+      b Filters: {{ filter_summary }}
     div.p-2.bg-light
       table
         tr
@@ -26,12 +32,29 @@ div
             select(v-model="filter_client")
               option(:value='null') All
               option(v-for="client in clients", :value="client") {{ client }}
+        tr
+          th.pt-2.pr-3
+            label Duration:
+          td
+            select(v-model="filter_duration")
+              option(value='null') All
+              option(value='2') 2+ secs
+              option(value='5') 5+ secs
+              option(value='10') 10+ secs
+              option(value='30') 30+ sec
+              option(value='60') 1+ mins
+              option(value='120') 2+ mins
+              option(value='180') 3+ mins
+              option(value='600') 10+ mins
+              option(value='1800') 30+ mins
+              option(value='3600') 1+ hrs
+              option(value='7200') 2+ hrs
   div(style="float: right; color: #999").d-inline-block.pt-3
     | Drag to pan and scroll to zoom
 
   div(v-if="buckets !== null")
     div(style="clear: both")
-    vis-timeline(:buckets="buckets", :showRowLabels='true', :queriedInterval="daterange")
+    vis-timeline(:buckets="buckets", :showRowLabels='true', :queriedInterval="daterange", :swimlane="swimlane")
 
     aw-devonly(reason="Not ready for production, still experimenting")
       aw-calendar(:buckets="buckets")
@@ -43,6 +66,7 @@ div
 import _ from 'lodash';
 import { useSettingsStore } from '~/stores/settings';
 import { useBucketsStore } from '~/stores/buckets';
+import { seconds_to_duration } from '~/util/time';
 
 export default {
   name: 'Timeline',
@@ -56,6 +80,8 @@ export default {
       maxDuration: 31 * 24 * 60 * 60,
       filter_hostname: null,
       filter_client: null,
+      filter_duration: null,
+      swimlane: null,
     };
   },
   computed: {
@@ -66,6 +92,23 @@ export default {
     num_events() {
       return _.sumBy(this.buckets, 'events.length');
     },
+    filter_summary() {
+      let desc = [];
+      if (this.filter_hostname) {
+        desc.push(this.filter_hostname);
+      }
+      if (this.filter_client) {
+        desc.push(this.filter_client);
+      }
+      if (this.filter_duration > 0) {
+        desc.push(seconds_to_duration(this.filter_duration));
+      } 
+
+      if (desc.length > 0) {
+        return desc.join(", ");
+      }
+      return "none"
+    }
   },
   watch: {
     daterange() {
@@ -75,6 +118,12 @@ export default {
       this.getBuckets();
     },
     filter_client() {
+      this.getBuckets();
+    },
+    filter_duration() {
+      this.getBuckets();
+    },
+    swimlane() {
       this.getBuckets();
     },
   },
@@ -103,6 +152,13 @@ export default {
       if (this.filter_client) {
         buckets = _.filter(buckets, b => b.client == this.filter_client);
       }
+      
+      if (this.filter_duration > 0) {
+        for (const bucket of buckets) {
+          bucket.events = _.filter(bucket.events, e => e.duration >= this.filter_duration);
+        }
+      }
+
       this.buckets = buckets;
     },
   },

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -39,6 +39,7 @@ import moment from 'moment';
 import Color from 'color';
 import { buildTooltip } from '../util/tooltip.js';
 import { getColorFromString, getTitleAttr } from '../util/color';
+import { getSwimlane } from '../util/swimlane.js';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
@@ -54,6 +55,7 @@ export default {
     showRowLabels: { type: Boolean },
     queriedInterval: { type: Array },
     showQueriedInterval: { type: Boolean },
+    swimlane: { type: String },
   },
   data() {
     return {
@@ -110,13 +112,15 @@ export default {
         }
         events.sort((a, b) => a.timestamp.valueOf() - b.timestamp.valueOf());
         _.each(events, e => {
+          let color = getColorFromString(getTitleAttr(bucket, e));
           data.push([
             bucket.id,
             getTitleAttr(bucket, e),
             buildTooltip(bucket, e),
             new Date(e.timestamp),
             new Date(moment(e.timestamp).add(e.duration, 'seconds').valueOf()),
-            getColorFromString(getTitleAttr(bucket, e)),
+            color,
+            getSwimlane(bucket, color, this.swimlane, e),
             e,
           ]);
         });
@@ -223,6 +227,7 @@ export default {
           start: moment(row[3]),
           end: moment(row[4]),
           style: `background-color: ${bgColor}; border-color: ${borderColor}`,
+          subgroup: row[6],
         };
       });
 
@@ -245,6 +250,7 @@ export default {
             start: this.queriedInterval[0],
             end: this.queriedInterval[1],
             style: 'background-color: #aaa; height: 10px',
+            subgroup: ``,
           });
         }
 

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -44,6 +44,7 @@ import { getSwimlane } from '../util/swimlane.js';
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
 import EventEditor from '~/components/EventEditor.vue';
+import { Console } from 'console';
 
 export default {
   components: {
@@ -56,6 +57,7 @@ export default {
     queriedInterval: { type: Array },
     showQueriedInterval: { type: Boolean },
     swimlane: { type: String },
+    updateTimelineWindow: { type: Boolean },
   },
   data() {
     return {
@@ -254,16 +256,19 @@ export default {
           });
         }
 
-        const start =
-          (this.queriedInterval && this.queriedInterval[0]) ||
-          _.min(_.map(items, item => item.start));
-        const end =
-          (this.queriedInterval && this.queriedInterval[1]) ||
-          _.max(_.map(items, item => item.end));
-        this.options.min = start;
-        this.options.max = end;
-        this.timeline.setOptions(this.options);
-        this.timeline.setWindow(start, end);
+        if (this.updateTimelineWindow)
+        {
+          const start =
+            (this.queriedInterval && this.queriedInterval[0]) ||
+            _.min(_.map(items, item => item.start));
+          const end =
+            (this.queriedInterval && this.queriedInterval[1]) ||
+            _.max(_.map(items, item => item.end));
+          this.options.min = start;
+          this.options.max = end;
+          this.timeline.setOptions(this.options);
+          this.timeline.setWindow(start, end);
+        }
 
         // Hide buckets with no events in the queried range
         const count = _.countBy(items, i => i.group);

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -112,7 +112,7 @@ export default {
         }
         events.sort((a, b) => a.timestamp.valueOf() - b.timestamp.valueOf());
         _.each(events, e => {
-          let color = getColorFromString(getTitleAttr(bucket, e));
+          const color = getColorFromString(getTitleAttr(bucket, e));
           data.push([
             bucket.id,
             getTitleAttr(bucket, e),

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -275,6 +275,18 @@ export default {
         this.items = items;
         this.groups = groups;
       }
+      else {
+        // update the timeline range
+        this.options.min = this.queriedInterval[0];
+        this.options.max = this.queriedInterval[1];
+        this.timeline.setOptions(this.options);
+        this.timeline.setWindow(this.queriedInterval[0], this.queriedInterval[1]);
+
+        // clear the data 
+        this.timeline.setData({ groups: [], items: [] });
+        this.items = [];
+        this.groups = [];
+      }
     },
   },
 };


### PR DESCRIPTION
### Background

I've used AW for some time and found it very useful. However, the timeline view can be hard to understand when switching windows and tabs quickly throughout the day. For example:

![Timeline Original](https://github.com/ActivityWatch/aw-webui/assets/12869442/c0a200fa-b71d-4b22-91a3-3633c828ab88)

I wanted the ability to separate the timeline into swim lanes based on various event attributes. 

### New Features

**Feature 1:** I've added 2 different swimlane options to this PR:

* Categories: swimlane per category color displayed
* Bucket Specific: swinlane specific to bucket type (e.g., app name for `currentwindow`, domain name for `web.tab.current`)

**Feature 2:** I added a filter summary description when the filter is closed.
 
![Timeline Improved](https://github.com/ActivityWatch/aw-webui/assets/12869442/2e4e1b16-1529-4bb3-af72-743f53f4a51c)

**Feature 3:** To reduce the number of swimlanes and confusion in the timeline I also added a filter to only include events that are a minimum duration as well.

![Timeline Min Duration Filter](https://github.com/ActivityWatch/aw-webui/assets/12869442/e2cca704-085f-4815-90b2-66db54ae5631)

### Implementation Notes

* The swimlanes are implemented by specifying a `subgroup` on the vizjs timeline in `Timeline.vue`.
* A `util/swimlane.js` file is added to calculate the swimlane/subgroup value.
* The swimlane selection is passed through to the `viz-timeline` component for filtering the events.

### Further Improvement Ideas

Some ideas on where this could still go for improvement:

* It would be nice to have some sort of artificial event added to the left side of the swimlane that shows the entire name (e.g., category or application name).
* Persisting the filter and swimlane settings to the user store, possibly with an optional restore timeline settings option on the Settings page. Possibly add a reset button on the page to reset all the settings/filters if they are saved.
* Sorting the swimlanes consistently: the swimlanes don't appear to be ordered by the subgroup alphabetically. Would like them to consistently be sorted.
* Ability to filter swimlanes where all the time for the given swimlane filter is less than x time (i.e., hide swimlanes that only have a few short entries to reduce the vertical scrolling added due to the swimlanes).
* Add additional support for different types of watchers (I only supported the ones in `util/tooltip.js`).

@ErikBjare, this is my first PR for the project. If I've missed something obvious, please let me know and I'll try to submit a fix. Thanks for all your time and the other contributors. 
