### PR TITLE
fix: use settings store to retrieve useColorFallback setting

### DIFF
--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -99,10 +99,8 @@ export function getCategoryColorFromString(str: string): string {
 
 function fallbackColor(str: string): string {
   // Get fallback color
-  // TODO: Fetch setting from somewhere better, where defaults are respected
-  const useColorFallback =
-    localStorage !== undefined ? localStorage.useColorFallback === 'true' : true;
-  if (useColorFallback) {
+  const settings = useSettingsStore();
+  if (settings.useColorFallback) {
     return getColorFromString(str);
   } else {
     return COLOR_UNCAT;


### PR DESCRIPTION
Continuing on https://github.com/ActivityWatch/aw-webui/commit/9896601cc8145c99123194f8b555feb914b67681

There are more bad uses of localStorage in the code that should be cleaned up.