### PR TITLE
enable horizontal scroll on timeline

### DIFF
--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -70,6 +70,7 @@ export default {
           overflowMethod: 'cap',
           delay: 0,
         },
+        horizontalScroll: true
       },
       editingEvent: null,
       editingEventBucket: null,


### PR DESCRIPTION
right now when you scroll horizontally, to the left or right, it zooms on the timeline and does not scroll the timeline. it should scroll the timeline when you scroll horizontally. 


option used, `horizontalScroll?: boolean`: 
https://github.com/visjs/vis-timeline/blob/698f7ebfbe0ed93c6b4b1928ea9a39c5182d275f/types/index.d.ts#L268

the option's usage in the vis-timeline repo:
https://github.com/search?q=repo%3Avisjs%2Fvis-timeline%20horizontalScroll&type=code