### PR TITLE
Add librewolf browser application name for linux

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -260,6 +260,7 @@ const browser_appnames = {
     'Librewolf.exe',
     'librewolf',
     'librewolf.exe',
+    'librewolf-default',
 
     // Waterfox
     'Waterfox',


### PR DESCRIPTION
The browser data showed up in raw data but not in the browser tab, so I added the application name to the list.

The detected name is defined here (StartupWMClass):
https://codeberg.org/librewolf/bsys5/src/branch/master/assets/linux.librewolf.desktop.in