### PR TITLE
Dark mod support for hovering StopwatchEntry

### DIFF
--- a/src/components/StopwatchEntry.vue
+++ b/src/components/StopwatchEntry.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  div.row.px-3.py-2#root
+  div.row.px-3.py-2.stopwatch-entry#root
     div.flex-fill
       span #[b {{event.data.label || 'No label'}}]
       span(style="color: #888") &nbsp;|&nbsp;

--- a/static/dark.css
+++ b/static/dark.css
@@ -207,3 +207,7 @@ div[style="background-color: rgb(238, 238, 238);"] {
 div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: #e9ebf0 !important;
 }
+
+#root.stopwatch-entry:hover{
+  background-color: #282c32 !important;
+}

--- a/static/dark.css
+++ b/static/dark.css
@@ -211,3 +211,7 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
 #root.stopwatch-entry:hover{
   background-color: #282c32 !important;
 }
+
+.bg-light {
+  background-color: #1a1d24 !important;
+}


### PR DESCRIPTION
Hover color for StopwatchEntry component was same for dark and light mode, so it was impossible to see something when hovering in dark mode.
