### PR TITLE
feat: Add 'app' and 'title' fields to CSV export in Reports

### DIFF
--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -175,9 +175,11 @@ export default {
 
     export_csv() {
       const data = this.events.map(e => {
-        return [e.timestamp, e.duration, e.data['$category']];
+        return [e.timestamp, e.duration, e.data['$category'], e.data['app'], e.data['title']];
       });
-      const csv = Papa.unparse(data, { columns: ['timestamp', 'duration', 'category'] });
+      const csv = Papa.unparse(data, {
+        columns: ['timestamp', 'duration', 'category', 'app', 'title'],
+      });
       const blob = new Blob([csv], { type: 'text/csv' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');


### PR DESCRIPTION
Closes https://github.com/ActivityWatch/activitywatch/issues/1010

Enhanced the CSV export functionality in the Reports view by including two additional fields: `app` and `title`. This allows users to export more detailed information about their activities.