### PR TITLE
Fix: arc doesn't count as a browser on windows

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -279,6 +279,7 @@ const browser_appnames = {
     'microsoft-edge-dev', // linux dev
   ],
   arc: [
+    'Arc.exe', // Windows
     'Arc', // macOS
   ],
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi'],


### PR DESCRIPTION
Added the windows arc appname (Arc.exe) to browser_appnames, allowing arc to register as a browser on windows.