### PR TITLE
fix: changed many rules in browser-to-appname map to use case-insensitive regexes

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -222,9 +222,6 @@ const browser_appnames = {
 
     // Chromium
     /chromium\w?(browser)?(-chromium)?(.exe)?/i,
-
-    // Brave (should this be merged with the brave entry?)
-    'Brave-browser',
   ],
   firefox: [
     // Firefox
@@ -245,7 +242,7 @@ const browser_appnames = {
     /Waterfox(.exe)?/i,
   ],
   opera: [/opera(.exe)?/i],
-  brave: [/brave(.exe)?/i],
+  brave: [/brave\w?(browser)?(.exe)?/i],
   edge: [
     'msedge.exe', // Windows
     /microsoft edge/i, // macOS

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -213,75 +213,47 @@ export function appQuery(
   return querystr_to_array(code);
 }
 
+// To see actual app names as discovered by users, see older pre-regex commits.
 const browser_appnames = {
   chrome: [
     // Chrome
-    'Google Chrome',
-    'Google-chrome',
+    /google\w?chrome(-beta|-stable|-unstable)?/i,
     'chrome.exe',
-    'google-chrome-stable',
 
     // Chromium
-    'Chromium',
-    'Chromium-browser',
-    'Chromium-browser-chromium',
-    'chromium.exe',
-
-    // Pre-releases
-    'Google-chrome-beta',
-    'Google-chrome-unstable',
+    /chromium\w?(browser)?(-chromium)?(.exe)?/i,
 
     // Brave (should this be merged with the brave entry?)
     'Brave-browser',
   ],
   firefox: [
     // Firefox
-    'Firefox',
-    'Firefox.exe',
-    'firefox',
-    'firefox.exe',
+    /firefox(.exe)?/i,
 
     // Firefox Developer
-    'Firefox Developer Edition',
-    'firefoxdeveloperedition',
+    /firefox\w?developer\w?edition/i,
 
     // Pre-releases https://github.com/ActivityWatch/aw-watcher-web/issues/87
-    'Firefox-esr',
-    'Firefox Beta',
+    /firefox\w?(beta|esr|aurora|trunk-dev)?/i,
     'Nightly',
-    'firefox-aurora',
-    'firefox-trunk-dev',
 
     // Librewolf
-    'LibreWolf-Portable.exe',
-    'LibreWolf',
-    'LibreWolf.exe',
-    'Librewolf',
-    'Librewolf.exe',
-    'librewolf',
-    'librewolf.exe',
+    /LibreWolf(-Portable)?(.exe)?/i,
 
     // Waterfox
-    'Waterfox',
-    'Waterfox.exe',
-    'waterfox',
-    'waterfox.exe',
+    /Waterfox(.exe)?/i,
   ],
-  opera: ['opera.exe', 'Opera'],
-  brave: ['brave.exe'],
+  opera: [/opera(.exe)?/i],
+  brave: [/brave(.exe)?/i],
   edge: [
     'msedge.exe', // Windows
-    'Microsoft Edge', // macOS
-    'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
-    'Microsoft-edge',
-    'microsoft-edge', // linux
-    'microsoft-edge-beta', // linux beta
-    'microsoft-edge-dev', // linux dev
+    /microsoft edge/i, // macOS
+    /microsoft\wedge\w?(stable|beta|dev)?/i, // linux, Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
   ],
   arc: [
     'Arc', // macOS
   ],
-  vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi'],
+  vivaldi: [/Vivaldi\w?(stable|snapshot)?(.exe)?/i],
   orion: ['Orion'],
   yandex: ['Yandex'],
 };

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -238,7 +238,8 @@ const browser_appnames = {
     'Nightly',
 
     // Librewolf
-    /LibreWolf(-Portable)?(.exe)?/i,
+    // Sometimes "librewolf-default" (https://discord.com/channels/755040852727955476/755334543891759194/1237102962241704038)
+    /LibreWolf(-Portable|-default)?(.exe)?/i,
 
     // Waterfox
     /Waterfox(.exe)?/i,


### PR DESCRIPTION
Replaces https://github.com/ActivityWatch/aw-webui/pull/283

<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f53f8b8b2afdbf3447b4156bb1d25686ddf0f77a  | 
|--------|

### Summary:
Enhanced the `browser_appnames` mapping in `/src/queries.ts` with improved regex patterns for flexible, case-insensitive browser identification, including updates for `LibreWolf`, `Brave`, and other browsers.

**Key points**:
- Updated `browser_appnames` in `/src/queries.ts` to use regex for flexible, case-insensitive matching.
- Regex patterns handle variations in browser names across platforms and versions.
- Enhanced matching for `LibreWolf` with new variant `librewolf-default`.
- Improved regex patterns for `Brave` and other browsers.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
