### PR TITLE
Fix URL matching

### DIFF
--- a/src/views/settings/Theme.vue
+++ b/src/views/settings/Theme.vue
@@ -41,7 +41,7 @@ export default {
         // Append Dark Theme Element If Selected Mode Is Dark
         value === 'dark'
           ? document.querySelector('head').appendChild(themeLink)
-          : document.querySelector(`link[href="${themeLink.href}"]`).remove();
+          : document.querySelector(`link[href="${new URL(themeLink.href).pathname}"]`).remove();
       },
     },
   },


### PR DESCRIPTION
This PR addresses an issue in theme switching functionality. Previously, the theme switcher was not correctly removing the link to the dark theme CSS file due to a mismatch between absolute and relative URLs.

The issue arose because when setting `themeLink.href = '/dark.css';`, the browser automatically converted this relative URL to an absolute URL, which includes the protocol and domain. As a result, `themeLink.href` became `http://localhost:5600/dark.css` instead of the expected `/dark.css`.

To resolve this, I've updated the code to use the URL object to extract the pathname (the relative URL) from `themeLink.href`. This ensures that we're correctly targeting the link element to remove when switching themes.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit af16694818ff8528be2576cde6e336016e11c94c  | 
|--------|

### Summary:
This PR fixes the theme switching by using the `URL` object to correctly target the link element for removal in `Theme.vue`.

**Key points**:
- Fixes theme switching in `Theme.vue`
- Uses `URL` object to parse `themeLink.href`
- Correctly targets link element for removal


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
