### PR TITLE
fix: fixes bug in category builder when word 'constructor' exists

### DIFF
--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -220,7 +220,7 @@ export default {
       );
 
       const events = data[0];
-      const words = {};
+      const words = new Map<string, { word: string; duration: number; events: any[] }>();
       for (const event of events) {
         const words_in_event = event.data.title.split(/[\s\-,:()[\]/]/);
         for (const word of words_in_event) {


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/1054

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6d10c192e074ea4ffb17031980a5681be0a604df  | 
|--------|

### Summary:
This PR fixes a bug in `CategoryBuilder.vue` by changing the storage of words from an object to a `Map`, ensuring all words, including JavaScript property names like 'constructor', are treated uniformly.

**Key points**:
- Fixes bug in `CategoryBuilder.vue` related to handling of the word 'constructor'
- Changes `words` from an object to a `Map` to avoid prototype issues
- Ensures words like 'constructor' are treated as regular strings
- Ensures all words, including JavaScript property names, are treated uniformly


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
