### PR TITLE
fix: hopefully actually fixes bug in category builder for 'constructor' word (and other prototype stuff)

### DIFF
--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -227,15 +227,15 @@ export default {
           if (word.length <= 2 || this.ignored_words.includes(word)) {
             continue;
           }
-          if (word in words) {
-            words[word].duration += event.duration;
-            words[word].events.push(event);
+          if (words.has(word)) {
+            words.get(word).duration += event.duration;
+            words.get(word).events.push(event);
           } else {
-            words[word] = {
+            words.set(word, {
               word: word,
               duration: event.duration,
               events: [event],
-            };
+            });
           }
         }
       }


### PR DESCRIPTION
Follow up on https://github.com/ActivityWatch/aw-webui/pull/564

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b5e9eb076de836d10421de37531a98540c025de5  | 
|--------|

### Summary:
Updated `CategoryBuilder.vue` to use `Map` for storing words, replacing object structure to handle prototype-related issues correctly.

**Key points**:
- Changed data structure for storing words from object to `Map` in `CategoryBuilder.vue`.
- Replaced `in` keyword with `Map` methods (`has`, `get`, `set`) to avoid prototype pollution.
- Ensures words like 'constructor' are handled correctly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
