### PR TITLE
fix: Correct encoding in category filter links on summary view

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -64,7 +64,7 @@ div
       aw-summary(:fields="activityStore.category.top",
                  :namefunc="e => e.data['$category'].join(' > ')",
                  :colorfunc="e => e.data['$category'].join(' > ')",
-                 :linkfunc="e => '#' + $route.path + '?category=' + e.data['$category'].join('>')",
+                 :linkfunc="e => '#' + $route.path + '?category=' + encodeURIComponent(e.data['$category'].join('>'))",
                  with_limit)
     div(v-if="type == 'category_tree'")
       aw-categorytree(:events="activityStore.category.top")


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/1051

This change ensures category names in the summary view URLs are web-compatible by encoding them with `encodeURIComponent`.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 91e418fba209651773ecfa7ceef7b4aa30d55ba2  | 
|--------|

### Summary:
Updated the `linkfunc` in `aw-summary` for 'top_categories' to encode category names using `encodeURIComponent` for URL compatibility in `/src/components/SelectableVisualization.vue`.

**Key points**:
- Updated `linkfunc` in `aw-summary` for 'top_categories' in `/src/components/SelectableVisualization.vue`.
- Encoded category names using `encodeURIComponent` for URL compatibility.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
