### PR TITLE
fix: correctly convert `words` from map to array

### DIFF
--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -153,8 +153,8 @@ export default {
   computed: {
     ...mapState(useCategoryStore, ['allCategoriesSelect']),
     words_by_duration: function () {
-      const words: { [key: string]: { word: string; duration: number } } = this.words;
-      return Object.values(words)
+      const words: { word: string; duration: number }[] = [...this.words.values()];
+      return words
         .sort((a, b) => b.duration - a.duration)
         .filter(word => word.duration > 60)
         .filter(word => !this.ignored_words.includes(word.word));


### PR DESCRIPTION
Manually tested, works :)

---

- https://github.com/ActivityWatch/aw-webui/pull/564
- https://github.com/ActivityWatch/aw-webui/pull/565
- https://github.com/ActivityWatch/activitywatch/issues/1054

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ae0957035ff1c0eb9c2b66d30309cd49ae3a7e39  | 
|--------|

### Summary:
Fixes the conversion of `words` from `Map` to array in `CategoryBuilder.vue` to ensure correct UI functionality.

**Key points**:
- Updated `words_by_duration` in `CategoryBuilder.vue` to correctly convert `Map` to array using spread operator.
- Ensures correct functionality for sorting and filtering words by duration in UI.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
