### PR TITLE
fix: dark mode (Stopwatch, Category Builder)

### DIFF
--- a/src/components/StopwatchEntry.vue
+++ b/src/components/StopwatchEntry.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  div.row.px-3.py-2#root
+  div.row.px-3.py-2.stopwatch-entry#root
     div.flex-fill
       span #[b {{event.data.label || 'No label'}}]
       span(style="color: #888") &nbsp;|&nbsp;

--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -43,7 +43,7 @@ div
     div(v-if="words_by_duration.length == 0")
       | No words with significant duration. You're good to go!
     div(v-else)
-      div.row(v-for="word in words_by_duration")
+      div.row.category-builder-word(v-for="word in words_by_duration")
         div.col.hover-highlight
           div.d-flex.flex-row.py-2
             div.flex-grow-1

--- a/static/dark.css
+++ b/static/dark.css
@@ -8,7 +8,7 @@ a, button, span, div, select {
   outline: none;
 }
 
-body, button, html {
+body, button, html, table {
   color: #e9ebf0 !important;
 }
 
@@ -208,8 +208,14 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: #e9ebf0 !important;
 }
 
-#root.stopwatch-entry:hover{
+#root.stopwatch-entry:hover,
+.category-builder-word:hover>* {
   background-color: #282c32 !important;
+}
+
+.category-builder-word .table td,
+.category-builder-word .table th {
+  border-color: #3d444d;
 }
 
 .bg-light {

--- a/static/dark.css
+++ b/static/dark.css
@@ -207,3 +207,7 @@ div[style="background-color: rgb(238, 238, 238);"] {
 div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: #e9ebf0 !important;
 }
+
+#root.stopwatch-entry:hover{
+  background-color: #282c32 !important;
+}

--- a/static/dark.css
+++ b/static/dark.css
@@ -211,3 +211,7 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
 #root.stopwatch-entry:hover{
   background-color: #282c32 !important;
 }
+
+.bg-light {
+  background-color: #1a1d24 !important;
+}

--- a/static/dark.css
+++ b/static/dark.css
@@ -208,7 +208,7 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: #e9ebf0 !important;
 }
 
-#root.stopwatch-entry:hover,
+.stopwatch-entry:hover,
 .category-builder-word:hover>* {
   background-color: #282c32 !important;
 }


### PR DESCRIPTION
<p align=center>
<img width="70%" alt="Screenshot 2024-05-09 at 05 16 42" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/a251ccfc-e532-4a4b-a81b-7e9b53a1ab0e">
<img width="70%" alt="Screenshot 2024-05-09 at 05 16 51" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/1723f9da-648c-4e27-afc3-d7d514539155">
</p>

---

<p align=center>
<img width="70%" alt="Screenshot 2024-05-09 at 05 17 17" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/bc6d4dd5-47d5-4893-8364-6206a39c2838">
<img width="70%" alt="Screenshot 2024-05-09 at 05 17 40" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/abc9c507-2c3b-40eb-b69d-83d607e59778">
</p>

---

- Fixes https://github.com/ActivityWatch/aw-webui/issues/519
- Closes https://github.com/ActivityWatch/aw-webui/pull/542

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 220d65a74057ebe019e1bc51d468e940da6201e5  | 
|--------|

### Summary:
This PR enhances dark mode support by fixing UI inconsistencies in the Stopwatch and Category Builder components.

**Key points**:
- Added `.stopwatch-entry` class in `StopwatchEntry.vue` for dark mode hover effect.
- Added `.category-builder-word` class in `CategoryBuilder.vue` for hover effect and table border color adjustments.
- Updated `dark.css` to include styles for new classes and adjusted existing styles for better dark mode support.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
