### PR TITLE
fix: showing of `UncategorizedNotification`

### DIFF
--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -30,7 +30,7 @@ export default {
     isVisible() {
       // TODO: make configurable?
       // if total duration is less than 1 hour, don't show it
-      const overTotal = this.total > 60 * 60 * 1000;
+      const overTotal = this.total > 60 * 60;
       // if ratio is > 0.3, show it
       const overRatio = this.ratio > 0.3;
       // if there's a category filter (url has category query param), don't show it


### PR DESCRIPTION
`this.total` is in seconds, not milliseconds

---

- Fixes https://github.com/ActivityWatch/activitywatch/issues/1044

---

<p align=center>
<img width="70%" alt="Screenshot 2024-05-09 at 06 02 52" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/7cf28052-1170-4e25-817c-8e0346ba3528">
</p>