### PR TITLE
fix: fixed categories and views not being stored/loaded from server-side settings

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -73,7 +73,7 @@ jobs:
         node-version: [20]
         python-version: ['3.9']
         aw-server: ["aw-server", "aw-server-rust"]
-        aw-version: ["v0.12.3b11"]
+        aw-version: ["v0.12.3b18"]
         include:
         - node-version: '20'
           python-version: '3.9'

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia';
 import moment, { Moment } from 'moment';
 import { getClient } from '~/util/awclient';
+import { Category, defaultCategories } from '~/util/classes';
+import { View, defaultViews } from '~/stores/views';
 
 // Backoffs for NewReleaseNotification
 export const SHORT_BACKOFF_PERIOD = 24 * 60 * 60;
@@ -20,6 +22,8 @@ interface State {
   newReleaseCheckData: Record<string, any>;
   userSatisfactionPollData: Record<string, any>;
   always_active_pattern: string;
+  classes: Category[];
+  views: View[];
 
   // Whether to show certain WIP features
   devmode: boolean;
@@ -52,6 +56,8 @@ export const useSettingsStore = defineStore('settings', {
     userSatisfactionPollData: {},
 
     always_active_pattern: '',
+    classes: defaultCategories,
+    views: defaultViews,
 
     // Developer settings
     // NOTE: PRODUCTION might be undefined (in tests, for example)

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { IEvent } from './interfaces';
+import { useSettingsStore } from '~/stores/settings';
 
 const level_sep = '>';
 const CLASSIFY_KEYS = ['app', 'title'];
@@ -163,11 +164,13 @@ function areWeTesting() {
 
 export function saveClasses(classes: Category[]) {
   if (areWeTesting()) {
+    // TODO: move this into settings store?
     console.log('Not saving classes in test mode');
     return;
   }
-  localStorage.classes = JSON.stringify(classes.map(cleanCategory));
-  console.log('Saved classes', localStorage.classes);
+  const settingsStore = useSettingsStore();
+  settingsStore.update({ classes: classes.map(cleanCategory) });
+  console.log('Saved classes', settingsStore.classes);
 }
 
 export function cleanCategory(cat: Category): Category {
@@ -186,12 +189,8 @@ export function cleanCategory(cat: Category): Category {
 }
 
 export function loadClasses(): Category[] {
-  const classes_json = localStorage.classes;
-  if (classes_json && classes_json.length >= 1) {
-    return JSON.parse(classes_json).map(cleanCategory);
-  } else {
-    return defaultCategories;
-  }
+  const settingsStore = useSettingsStore();
+  return settingsStore.classes;
 }
 
 function pickDeepest(categories: Category[]) {

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -463,6 +463,7 @@ export default {
 
       const viewsStore = useViewsStore();
       viewsStore.addView({ id: this.new_view.id, name: this.new_view.name, elements: [] });
+      viewsStore.save();
 
       // Hide the modal manually
       this.$nextTick(() => {

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -122,9 +122,6 @@ export default {
     exportClasses: function () {
       console.log('Exporting categories...');
 
-      if (this.categoryStore.classes === undefined) {
-        alert('No classes saved, nothing to export!');
-      }
       const export_data = {
         categories: this.categoryStore.classes,
       };

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -122,11 +122,11 @@ export default {
     exportClasses: function () {
       console.log('Exporting categories...');
 
-      if (localStorage.classes === undefined) {
+      if (this.categoryStore.classes === undefined) {
         alert('No classes saved, nothing to export!');
       }
       const export_data = {
-        categories: JSON.parse(localStorage.classes),
+        categories: this.categoryStore.classes,
       };
       // Pretty-format it for easier reading
       const text = JSON.stringify(export_data, null, 2);

--- a/test/unit/store/views.test.node.ts
+++ b/test/unit/store/views.test.node.ts
@@ -9,9 +9,9 @@ describe('views store', () => {
     viewsStore.clearViews();
   });
 
-  test('load default views', () => {
+  test('load default views', async () => {
     expect(viewsStore.views).toHaveLength(0);
-    viewsStore.load();
+    await viewsStore.load();
     expect(viewsStore.views).not.toHaveLength(0);
   });
 


### PR DESCRIPTION
Did a grep of the codebase and found these.

Fixes https://github.com/ActivityWatch/aw-webui/issues/567

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit eb71af6e60813ff1bcd66b6af71ddf57633007e5  | 
|--------|

### Summary:
Centralized the storage of categories and views in the settings store, updated relevant methods, and made the `load` method asynchronous to enhance settings management.

**Key points**:
- Centralized storage of categories and views in `settingsStore`
- Updated `load` and `save` methods in `/src/stores/views.ts`
- Modified `saveClasses` and `loadClasses` in `/src/util/classes.ts`
- Adjusted Vue components to use updated store methods
- Made `load` method asynchronous in `views.test.node.ts`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
