### PR TITLE
fix: only save updated settings to server, store theme and landingpage in localStorage as well

### DIFF
--- a/src/components/UserSatisfactionPoll.vue
+++ b/src/components/UserSatisfactionPoll.vue
@@ -70,8 +70,6 @@ import moment from 'moment';
 import { useSettingsStore } from '~/stores/settings';
 
 const NUM_OPTIONS = 10;
-// INITIAL_WAIT_PERIOD is how long to wait from initialTimestamp to the first time that the poll shows up
-const INITIAL_WAIT_PERIOD = 7 * 24 * 60 * 60;
 // BACKOFF_PERIOD is how many seconds to wait to show the poll again if the user closed it
 const BACKOFF_PERIOD = 7 * 24 * 60 * 60;
 // The following may be used for testing
@@ -106,16 +104,6 @@ export default {
     },
   },
   async mounted() {
-    // Get the rest of the data
-    const settingsStore = useSettingsStore();
-    if (!this.data) {
-      this.data = {
-        isEnabled: true,
-        nextPollTime: settingsStore.initialTimestamp.add(INITIAL_WAIT_PERIOD, 'seconds'),
-        timesPollIsShown: 0,
-      };
-    }
-
     if (!this.data.isEnabled) {
       return;
     }
@@ -135,9 +123,7 @@ export default {
   methods: {
     submit() {
       this.isPollVisible = false;
-      const data = this.data;
-      data.isEnabled = false;
-      this.data = data;
+      this.data = { ...this.data, isEnabled: false };
 
       if (parseInt(this.rating) >= 6) {
         this.isPosFollowUpVisible = true;
@@ -147,9 +133,7 @@ export default {
     },
     dontShowAgain() {
       this.isPollVisible = false;
-      const data = this.data;
-      data.isEnabled = false;
-      this.data = data;
+      this.data = { ...this.data, isEnabled: false };
     },
   },
 };


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/aw-webui/issues/568

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fbe6019cbb61890d21690103ef0198dea1fbc71d  | 
|--------|

### Summary:
This PR optimizes settings handling by removing unused code, refactoring state management, and ensuring crucial settings are stored locally for immediate access.

**Key points**:
- Removed unused code and refactored state handling in `UserSatisfactionPoll.vue`.
- Added JSON comparison function `jsonEq` in `settings.ts` to optimize settings storage.
- Implemented conditions to prevent unnecessary saving of default or unchanged settings in `settings.ts`.
- Ensured theme and landing page settings are stored in localStorage for immediate access.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
