### PR TITLE
ci: updated to actions/upload-artifact v4

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -30,6 +30,8 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
+          var fs = require('fs');
+          var child_process = require('child_process');
           var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
@@ -46,11 +48,12 @@ jobs:
                artifact_id: artifact.id,
                archive_format: 'zip',
             });
-            var fs = require('fs');
             fs.writeFileSync(`${{github.workspace}}/${artifact.name}.zip`, Buffer.from(download.data));
+            // Unzip the artifact
+            child_process.execSync(`unzip -d screenshots ${artifact.name}.zip`, {cwd: process.env.GITHUB_WORKSPACE});
+            // Remove the zip file
+            fs.unlinkSync(`${{github.workspace}}/${artifact.name}.zip`);
           }
-
-    - run: unzip -d screenshots screenshots.zip
 
     - name: Compose comment
       env:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -35,17 +35,20 @@ jobs:
              repo: context.repo.repo,
              run_id: ${{ github.event.workflow_run.id }},
           });
-          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == "screenshots"
-          })[0];
-          var download = await github.rest.actions.downloadArtifact({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             artifact_id: matchArtifact.id,
-             archive_format: 'zip',
+          var matchingArtifacts = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name.startsWith("screenshots-");
           });
-          var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/screenshots.zip', Buffer.from(download.data));
+
+          for (const artifact of matchingArtifacts) {
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: artifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync(`${{github.workspace}}/${artifact.name}.zip`, Buffer.from(download.data));
+          }
 
     - run: unzip -d screenshots screenshots.zip
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -172,9 +172,9 @@ jobs:
         mv screenshots/*.png screenshots/dist/$aw_server/$aw_version
     - name: Upload screenshots
       if: ${{ success() || steps.e2e.conclusion == 'failure'}}
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
-        name: screenshots
+        name: screenshots-${{ matrix.aw-server }}-${{ matrix.aw-version }}
         path: screenshots/dist/*
     - name: Print server logs to console
       if: ${{ always() }}


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/aw-webui/pull/560

Works around https://github.com/actions/upload-artifact/issues/478

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 57c378bbc04215f3855c2023d0122b7d6b7b0d74  | 
|--------|

### Summary:
Updated GitHub Actions workflows to use `actions/upload-artifact@v4`, enhancing artifact management and naming in CI processes.

**Key points**:
- Updated `actions/upload-artifact` to `v4` in `/github/workflows/comment.yml` and `/github/workflows/nodejs.yml`.
- Modified artifact handling in `comment.yml` to include unzipping and cleanup within the script.
- Introduced dynamic naming of artifacts in `nodejs.yml` based on matrix variables.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
