### PR TITLE
fix: dark mode (Timeline, Activity, Raw Data)

### DIFF
--- a/static/dark.css
+++ b/static/dark.css
@@ -185,6 +185,10 @@ svg.appsummary g rect[style="fill: rgb(204, 204, 204);"] {
   fill: #666666 !important;
 }
 
+svg.appsummary g rect[style="fill: rgb(184, 184, 184);"] {
+  fill: #555555 !important;
+}
+
 svg path[style="fill: rgb(255, 255, 255);"] {
   fill: #23272d !important;
 }

--- a/static/dark.css
+++ b/static/dark.css
@@ -229,3 +229,15 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
 .bg-light {
   background-color: #1a1d24 !important;
 }
+
+[aria-sort="none"] {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='101' height='101' preserveAspectRatio='none' fill='white' opacity='.4'%3E%3Cpath d='m51 1 25 23 24 22H1l25-22zm0 100 25-23 24-22H1l25 22z'/%3E%3C/svg%3E") !important;
+}
+
+[aria-sort="ascending"] {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='101' height='101' preserveAspectRatio='none' fill='white'%3E%3Cpath opacity='.8' d='m51 1 25 23 24 22H1l25-22z'/%3E%3Cpath opacity='.4' d='m51 101 25-23 24-22H1l25 22z'/%3E%3C/svg%3E") !important;
+}
+
+[aria-sort="descending"] {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='101' height='101' preserveAspectRatio='none' fill='white'%3E%3Cpath opacity='.4' d='m51 1 25 23 24 22H1l25-22z'/%3E%3Cpath opacity='.8' d='m51 101 25-23 24-22H1l25 22z'/%3E%3C/svg%3E") !important;
+}

--- a/static/dark.css
+++ b/static/dark.css
@@ -166,6 +166,10 @@ hr {
   color: #e9ebf0 !important;
 }
 
+.vis-tooltip {
+  background-color: #282c32 !important;
+}
+
 #visualization *, svg,
 .nav.nav-tabs,
 .btn-outline-secondary {


### PR DESCRIPTION
<p align=center>
<img width="70%" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/2b7c17ec-9fb2-482c-9766-70f9bcdc08f1">
<img width="70%" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/f4286526-ca8a-445d-ad2b-6fcf49b8f40d">
<img width="70%" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/3be8ca82-f3fc-4d74-b161-b836a05d26ab">
</p>

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 031505b75f8461c9d07661e115a4aba7362d359d  | 
|--------|

### Summary:
This PR enhances dark mode in the ActivityWatch web UI by updating styles for better visual consistency and readability.

**Key points**:
- Update dark mode styles in `/static/dark.css`
- Adjust background colors and fills for better visibility
- Modify sort icons for clarity in dark mode


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
