### PR TITLE
fix: correctly invert colors of alerts in dark mode

### DIFF
--- a/static/dark.css
+++ b/static/dark.css
@@ -8,7 +8,7 @@ a, button, span, div, select {
   outline: none;
 }
 
-body, button, html, table {
+body, button:not(.close), html, table {
   color: #e9ebf0 !important;
 }
 

--- a/static/dark.css
+++ b/static/dark.css
@@ -8,7 +8,7 @@ a, button, span, div, select {
   outline: none;
 }
 
-body, button:not(.close), html, table {
+body, button, html, table {
   color: #e9ebf0 !important;
 }
 
@@ -240,4 +240,28 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
 
 [aria-sort="descending"] {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='101' height='101' preserveAspectRatio='none' fill='white'%3E%3Cpath opacity='.4' d='m51 1 25 23 24 22H1l25-22z'/%3E%3Cpath opacity='.8' d='m51 101 25-23 24-22H1l25 22z'/%3E%3C/svg%3E") !important;
+}
+
+.alert-success {
+  color: hsl(135, 70%, 90%);
+  background-color: hsl(135, 60%, 30%);
+  border-color: hsl(135, 60%, 25%);
+}
+
+.alert-info {
+  color: hsl(190, 70%, 90%);
+  background-color: hsl(190, 60%, 30%);
+  border-color: hsl(190, 60%, 25%);
+}
+
+.alert-warning {
+  color: hsl(45, 70%, 90%);
+  background-color: hsl(45, 60%, 30%);
+  border-color: hsl(45, 60%, 25%);
+}
+
+.alert-danger {
+  color: hsl(355, 70%, 90%);
+  background-color: hsl(355, 60%, 30%);
+  border-color: hsl(355, 60%, 25%);
 }


### PR DESCRIPTION
Before:
<p align=center>
<img width="80%" alt="Screenshot" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/743880b8-3791-4f0b-9ece-f702a590b511">
</p>

---

After:
<p align=center>
<img width="80%" alt="Screenshot" src="https://github.com/ActivityWatch/aw-webui/assets/66956532/458bf2d2-570e-47e2-b4e8-35bed18dbf2d">
</p>
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 67db254af716ca4d584056430078dd5c194f84ba  | 
|--------|--------|

### Summary:
Exclude the close button from color changes in dark mode by updating `static/dark.css`.

**Key points**:
- Update `static/dark.css` to exclude `.close` button from color changes
- Modify `body, button, html, table` selector to `body, button:not(.close), html, table`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->