### PR TITLE
add a default color for Media category

### DIFF
--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -51,7 +51,7 @@ export const defaultCategories: Category[] = [
   { name: ['Work', '3D'], rule: { type: 'regex', regex: 'Blender' } },
   {
     name: ['Media'],
-    rule: { type: null },
+    rule: { type: 'none' },
     data: { color: '#F33' },
   },
   {
@@ -84,7 +84,7 @@ export const defaultCategories: Category[] = [
   },
   {
     name: ['Comms'],
-    rule: { type: null },
+    rule: { type: 'none' },
     data: { color: '#9FF' },
   },
   {

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -50,6 +50,11 @@ export const defaultCategories: Category[] = [
   { name: ['Work', 'Audio'], rule: { type: 'regex', regex: 'Audacity' } },
   { name: ['Work', '3D'], rule: { type: 'regex', regex: 'Blender' } },
   {
+    name: ['Media'],
+    rule: { type: null },
+    data: { color: '#F33' },
+  },
+  {
     name: ['Media', 'Games'],
     rule: { type: 'regex', regex: 'Minecraft|RimWorld' },
     data: { color: '#F80' },


### PR DESCRIPTION
The color value is a placeholder, should you choose to change it :smile: 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9fd6513aa4c3ecbeb4ccc8e7f80c72e6781dc532  | 
|--------|--------|

### Summary:
Added default color `#F33` for 'Media' category in `defaultCategories` array in `src/util/classes.ts`.

**Key points**:
- Added default color `#F33` for 'Media' category in `defaultCategories` array.
- Modified `src/util/classes.ts` to include the color in the `data` field of the 'Media' category object.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->