### PR TITLE
Add a browser app name for Microsoft Edge Beta on macOS

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -270,6 +270,7 @@ const browser_appnames = {
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS
+    'Microsoft Edge Beta', // macOS beta
     'Microsoft-Edge-Stable', // Arch Linux: https://github.com/ActivityWatch/activitywatch/issues/753
     'Microsoft-edge',
     'microsoft-edge', // linux


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/968