### PR TITLE
fix: timeline barchart y-axis shows more than 1h

### DIFF
--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -112,7 +112,7 @@ export default {
           y: {
             stacked: true,
             min: 0,
-            suggestedMax: resolution.startsWith('day') ? 1 : undefined,
+            max: resolution.startsWith('day') ? 1 : undefined,
             ticks: {
               callback: hourToTick,
               stepSize: resolution.startsWith('day') ? 0.25 : 1,


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/851
