### PR TITLE
Add `firefox-nightly` to browser names

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -246,6 +246,7 @@ const browser_appnames = {
     'Firefox-esr',
     'Firefox Beta',
     'Nightly',
+    'firefox-nightly',
     'firefox-aurora',
     'firefox-trunk-dev',
 


### PR DESCRIPTION
Akin to #111, #120, #121, #204, et al.

I cannot tell you why there's so much variance in these names, but the extension has not worked for me until I added this line.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b9d75c9f05b132a89a31342b64e9b2b96c3aee11  | 
|--------|--------|

### Summary:
Add 'firefox-nightly' to recognized Firefox browser names in `src/queries.ts`.

**Key points**:
- Add 'firefox-nightly' to `browser_appnames` in `src/queries.ts`.
- Ensures compatibility with Firefox Nightly browser variant.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->