### PR TITLE
Timeline category colors

### DIFF
--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -129,8 +129,10 @@ export function getTitleAttr(bucket: IBucket, e: IEvent) {
 
 export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
   if (bucket.type == 'currentwindow') {
+    // NOTE: this will not work/break category rules which reference `$` or `^`
     return getCategoryColorFromString(e.data.app + ' ' + e.data.title);
   } else if (bucket.type == 'web.tab.current') {
+    // NOTE: same as above
     return getCategoryColorFromString(e.data.title + ' ' + e.data.url);
   } else if (bucket.type == 'afkstatus') {
     return getColorFromString(e.data.status);

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -126,3 +126,19 @@ export function getTitleAttr(bucket: IBucket, e: IEvent) {
     return e.data.title;
   }
 }
+
+export function getStringForCategorization(bucket: IBucket, e: IEvent) {
+  if (bucket.type == 'currentwindow') {
+    return e.data.app + " " + e.data.title;
+  } else if (bucket.type == 'web.tab.current') {
+    return e.data.title + " " + e.data.url;
+  } else if (bucket.type == 'afkstatus') {
+    return e.data.status;
+  } else if (bucket.type?.startsWith('app.editor')) {
+    return e.data.file;
+  } else if (bucket.type?.startsWith('general.stopwatch')) {
+    return e.data.label;
+  } else {
+    return e.data.title;
+  }
+}

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -88,11 +88,14 @@ export function getColorFromCategory(c: Category, allCats: Category[]): string {
 // TODO: Move into vuex?
 export function getCategoryColorFromString(str: string): string {
   // TODO: Don't load classes on every call
+  console.log("getCategoryColorFromString", str)
   const allCats = loadClasses();
   const c = matchString(str, allCats);
   if (c !== null) {
+    console.log("found category", c);
     return getColorFromCategory(c, allCats);
   } else {
+    console.log("Uncategorized");
     return fallbackColor(str);
   }
 }
@@ -128,6 +131,7 @@ export function getTitleAttr(bucket: IBucket, e: IEvent) {
 }
 
 export function getStringForCategorization(bucket: IBucket, e: IEvent) {
+  console.log("get string for categorization:", bucket, e.data)
   if (bucket.type == 'currentwindow') {
     return e.data.app + " " + e.data.title;
   } else if (bucket.type == 'web.tab.current') {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -146,3 +146,19 @@ export function getStringForCategorization(bucket: IBucket, e: IEvent) {
     return e.data.title;
   }
 }
+
+export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
+  if (bucket.type == 'currentwindow') {
+    return getCategoryColorFromString(e.data.app + " " + e.data.title);
+  } else if (bucket.type == 'web.tab.current') {
+    return getCategoryColorFromString(e.data.title + " " + e.data.url);
+  } else if (bucket.type == 'afkstatus') {
+    return getColorFromString(e.data.status);
+  } else if (bucket.type?.startsWith('app.editor')) {
+    return getCategoryColorFromString(e.data.file);
+  } else if (bucket.type?.startsWith('general.stopwatch')) {
+    return getCategoryColorFromString(e.data.label);
+  } else {
+    return getCategoryColorFromString(e.data.title);
+  }
+}

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -129,9 +129,9 @@ export function getTitleAttr(bucket: IBucket, e: IEvent) {
 
 export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
   if (bucket.type == 'currentwindow') {
-    return getCategoryColorFromString(e.data.app + " " + e.data.title);
+    return getCategoryColorFromString(e.data.app + ' ' + e.data.title);
   } else if (bucket.type == 'web.tab.current') {
-    return getCategoryColorFromString(e.data.title + " " + e.data.url);
+    return getCategoryColorFromString(e.data.title + ' ' + e.data.url);
   } else if (bucket.type == 'afkstatus') {
     return getColorFromString(e.data.status);
   } else if (bucket.type?.startsWith('app.editor')) {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -88,14 +88,11 @@ export function getColorFromCategory(c: Category, allCats: Category[]): string {
 // TODO: Move into vuex?
 export function getCategoryColorFromString(str: string): string {
   // TODO: Don't load classes on every call
-  console.log("getCategoryColorFromString", str)
   const allCats = loadClasses();
   const c = matchString(str, allCats);
   if (c !== null) {
-    console.log("found category", c);
     return getColorFromCategory(c, allCats);
   } else {
-    console.log("Uncategorized");
     return fallbackColor(str);
   }
 }

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -130,23 +130,6 @@ export function getTitleAttr(bucket: IBucket, e: IEvent) {
   }
 }
 
-export function getStringForCategorization(bucket: IBucket, e: IEvent) {
-  console.log("get string for categorization:", bucket, e.data)
-  if (bucket.type == 'currentwindow') {
-    return e.data.app + " " + e.data.title;
-  } else if (bucket.type == 'web.tab.current') {
-    return e.data.title + " " + e.data.url;
-  } else if (bucket.type == 'afkstatus') {
-    return e.data.status;
-  } else if (bucket.type?.startsWith('app.editor')) {
-    return e.data.file;
-  } else if (bucket.type?.startsWith('general.stopwatch')) {
-    return e.data.label;
-  } else {
-    return e.data.title;
-  }
-}
-
 export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
   if (bucket.type == 'currentwindow') {
     return getCategoryColorFromString(e.data.app + " " + e.data.title);

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -38,7 +38,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import Color from 'color';
 import { buildTooltip } from '../util/tooltip.js';
-import { getColorFromString, getCategoryColorFromString, getTitleAttr, getStringForCategorization, getCategoryColorFromEvent } from '../util/color';
+import { getTitleAttr, getCategoryColorFromEvent } from '../util/color';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -38,7 +38,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import Color from 'color';
 import { buildTooltip } from '../util/tooltip.js';
-import { getColorFromString, getCategoryColorFromString, getTitleAttr, getStringForCategorization } from '../util/color';
+import { getColorFromString, getCategoryColorFromString, getTitleAttr, getStringForCategorization, getCategoryColorFromEvent } from '../util/color';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
@@ -116,7 +116,7 @@ export default {
             buildTooltip(bucket, e),
             new Date(e.timestamp),
             new Date(moment(e.timestamp).add(e.duration, 'seconds').valueOf()),
-            getCategoryColorFromString(getStringForCategorization(bucket, e)),
+            getCategoryColorFromEvent(bucket, e),
             e,
           ]);
         });

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -38,7 +38,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import Color from 'color';
 import { buildTooltip } from '../util/tooltip.js';
-import { getColorFromString, getTitleAttr } from '../util/color';
+import { getColorFromString, getCategoryColorFromString, getTitleAttr, getStringForCategorization } from '../util/color';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
@@ -116,7 +116,7 @@ export default {
             buildTooltip(bucket, e),
             new Date(e.timestamp),
             new Date(moment(e.timestamp).add(e.duration, 'seconds').valueOf()),
-            getColorFromString(getTitleAttr(bucket, e)),
+            getCategoryColorFromString(getStringForCategorization(bucket, e)),
             e,
           ]);
         });


### PR DESCRIPTION
This is a first draft of supporting using category colors for the main Timeline view.
It still contains some verbose logging...

See ActivityWatch/activitywatch#573 which was a request for this which was closed stale, and #257 which listed it as follow-up work.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6f5581bf288b4bf3c8003884c25f2619144df6f0  | 
|--------|--------|

### Summary:
Introduced category-based coloring for timeline events in `src/util/color.ts` and updated `src/visualizations/VisTimeline.vue` to apply these colors.

**Key points**:
- Added `getCategoryColorFromEvent` in `src/util/color.ts` for category-based event coloring.
- Updated `src/visualizations/VisTimeline.vue` to use `getCategoryColorFromEvent` for event colors.
- Handles bucket types: `currentwindow`, `web.tab.current`, `afkstatus`, `app.editor`, `general.stopwatch`.
- Introduced verbose logging in `getCategoryColorFromString` for debugging.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->