### PR TITLE
feat: revert to the default Coloring for all other watchers

### DIFF
--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -141,6 +141,6 @@ export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
   } else if (bucket.type?.startsWith('general.stopwatch')) {
     return getCategoryColorFromString(e.data.label);
   } else {
-    return getCategoryColorFromString(e.data.title);
+    return getColorFromString(getTitleAttr(bucket, e));
   }
 }


### PR DESCRIPTION
This reverts to the previous coloring pattern for all watchers except window, afk, web, editor and stopwatch. 
![image](https://github.com/user-attachments/assets/0f480a03-2a62-480a-8390-6e6e05edc28e)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts default coloring logic for non-specific event categories in `getCategoryColorFromEvent()` in `color.ts`.
> 
>   - **Behavior**:
>     - Reverts default coloring logic for events in `getCategoryColorFromEvent()` in `color.ts`.
>     - Uses `getColorFromString(getTitleAttr(bucket, e))` for non-specific categories (not window, afk, web, editor, stopwatch).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 0a83764a39b674d62934836e9dba1ef682fff838. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->