### PR TITLE
refactor: make the score result message account for the selected query period

### DIFF
--- a/src/visualizations/Score.vue
+++ b/src/visualizations/Score.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 div
   div(style="text-align: center")
-    | Your total score today is:
+    | Your total score {{selected_timeperiod}} is:
     div(:style="'font-size: 2em; color: ' + (score >= 0 ? '#0A0' : '#F00')")
       | {{score >= 0 ? '+' : ''}}{{ (Math.round(score * 10) / 10).toFixed(1) }}
     div.small.text-muted
@@ -75,6 +75,45 @@ export default {
         _.filter(this.categories_with_score, cat => cat.data.$total_score < -0.1),
         c => c.data.$total_score
       );
+    },
+    selected_timeperiod: function () {
+      const [duration, span] = useActivityStore().query_options.timeperiod.length;
+      let relative_period = "";
+
+      // Default case, keep the existing behaviour
+      if (span.startsWith("day")) {
+        if (duration > 1) {
+          relative_period = `${duration} days`;
+        } else {
+          return "today";
+        }
+      }
+
+      if (span.startsWith("week")) {
+        if (duration > 1) {
+          relative_period = `${duration} weeks`;
+        } else {
+          return "this week";
+        }
+      }
+
+      if (span.startsWith("month")) {
+        if (duration > 1) {
+          relative_period = `${duration} months`;
+        } else {
+          return "this month";
+        }
+      }
+
+      if (span.startsWith("year")) {
+        if (duration > 1) {
+          relative_period = `${duration} years`;
+        } else {
+          return "this year";
+        }
+      }
+
+      return `in the past ${relative_period}`
     },
   },
 };


### PR DESCRIPTION
Previously the score visualization always said "total score today" regardless of what the period selected was. This PR adjusts the message text with a relative time expression where reasonable (e.g. past 30 days.) 

The current behaviour remains but is extended with support for "this week", "this month" and "this year".
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates score message in `Score.vue` to reflect selected time period, supporting various durations like 'this week' and 'past 30 days'.
> 
>   - **Behavior**:
>     - Updates score message in `Score.vue` to reflect selected time period instead of always 'today'.
>     - Supports 'this week', 'this month', 'this year', and relative periods like 'past 30 days'.
>   - **Functions**:
>     - Adds `selected_timeperiod` computed property in `Score.vue` to determine time period description based on `useActivityStore().query_options.timeperiod`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 47420d20df2dab56718364737cd17f9304d3f566. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->