### PR TITLE
Add Arc browser data in Timeline > Browser tab

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -288,9 +288,16 @@ const browser_appnames = {
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets
 function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
+  // Special case: Arc browser uses Chrome's bucket
+  const chrome_bucket = _.find(browserbuckets, bucket_id => _.includes(bucket_id, 'chrome'));
+  
   const browsername_to_bucketid: [string, string | undefined][] = _.map(
     Object.keys(browser_appnames),
     browserName => {
+      // If it's Arc and we found a Chrome bucket, use that
+      if (browserName ==='arc' && chrome_bucket) {
+        return [browserName, chrome_bucket];
+      }
       const bucketId = _.find(browserbuckets, bucket_id => _.includes(bucket_id, browserName));
       return [browserName, bucketId];
     }


### PR DESCRIPTION
Currently `/activity/Mac/view/browser` will not display Arc browser data, despite that data already appearing in the `/#/timeline` tab. This fixes the issue.

We fix this by just pushing all the Arc browser data to the chrome bucket for purposes of visualization. While not a perfect solution, it is an easy one, and far superior to not displaying that data at all.

This issue is known:

fixes https://github.com/ActivityWatch/activitywatch/issues/1094

This fix can be extended to support Brave/Vivaldi/etc, without relying on custom browser identification hacks. The tradeoff (obviously) is that all browsers' data based on chromium gets merged I guess.

@ErikBjare if you have time would love a quick look :)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Arc browser data display issue by associating it with Chrome's bucket in `queries.ts`.
> 
>   - **Behavior**:
>     - Fixes issue where Arc browser data was not displayed in `/activity/Mac/view/browser` by associating Arc with Chrome's bucket in `browsersWithBuckets()` in `queries.ts`.
>   - **Misc**:
>     - Adds Arc browser to `browser_appnames` in `queries.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for ef85adccba90b4aef03e85c37f5592a0502aa0dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->