### PR TITLE
Add browser names from Flathub

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -220,16 +220,19 @@ const browser_appnames = {
     'Google-chrome',
     'chrome.exe',
     'google-chrome-stable',
+    'com.google.Chrome',
 
     // Chromium
     'Chromium',
     'Chromium-browser',
     'Chromium-browser-chromium',
     'chromium.exe',
+    'org.chromium.Chromium',
 
     // Pre-releases
     'Google-chrome-beta',
     'Google-chrome-unstable',
+    'com.google.ChromeDev',
   ],
   firefox: [
     // Firefox
@@ -237,6 +240,7 @@ const browser_appnames = {
     'Firefox.exe',
     'firefox',
     'firefox.exe',
+    'org.mozilla.firefox',
 
     // Firefox Developer
     'Firefox Developer Edition',
@@ -258,15 +262,26 @@ const browser_appnames = {
     'librewolf',
     'librewolf.exe',
     'librewolf-default',
+    'io.gitlab.librewolf-community',
 
     // Waterfox
     'Waterfox',
     'Waterfox.exe',
     'waterfox',
     'waterfox.exe',
+    'net.waterfox.waterfox',
   ],
-  opera: ['opera.exe', 'Opera'],
-  brave: ['Brave-browser', 'Brave Browser', 'brave.exe'],
+  opera: [
+    'opera.exe',
+    'Opera',
+    'com.opera.Opera',
+  ],
+  brave: [
+    'Brave-browser',
+    'Brave Browser',
+    'brave.exe',
+    'com.brave.Browser',
+  ],
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS
@@ -276,14 +291,27 @@ const browser_appnames = {
     'microsoft-edge', // linux
     'microsoft-edge-beta', // linux beta
     'microsoft-edge-dev', // linux dev
+    'com.microsoft.Edge',
+    'com.microsoft.EdgeDev',
   ],
   arc: [
     'Arc.exe', // Windows
     'Arc', // macOS
   ],
-  vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi'],
-  orion: ['Orion'],
-  yandex: ['Yandex'],
+  vivaldi: [
+    'Vivaldi-stable',
+    'Vivaldi-snapshot',
+    'vivaldi.exe',
+    'Vivaldi',
+    'com.vivaldi.Vivaldi',
+  ],
+  orion: [
+    'Orion',
+  ],
+  yandex: [
+    'Yandex',
+    'ru.yandex.Browser',
+  ],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -271,17 +271,8 @@ const browser_appnames = {
     'waterfox.exe',
     'net.waterfox.waterfox',
   ],
-  opera: [
-    'opera.exe',
-    'Opera',
-    'com.opera.Opera',
-  ],
-  brave: [
-    'Brave-browser',
-    'Brave Browser',
-    'brave.exe',
-    'com.brave.Browser',
-  ],
+  opera: ['opera.exe', 'Opera', 'com.opera.Opera'],
+  brave: ['Brave-browser', 'Brave Browser', 'brave.exe', 'com.brave.Browser'],
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS
@@ -298,20 +289,9 @@ const browser_appnames = {
     'Arc.exe', // Windows
     'Arc', // macOS
   ],
-  vivaldi: [
-    'Vivaldi-stable',
-    'Vivaldi-snapshot',
-    'vivaldi.exe',
-    'Vivaldi',
-    'com.vivaldi.Vivaldi',
-  ],
-  orion: [
-    'Orion',
-  ],
-  yandex: [
-    'Yandex',
-    'ru.yandex.Browser',
-  ],
+  vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi', 'com.vivaldi.Vivaldi'],
+  orion: ['Orion'],
+  yandex: ['Yandex', 'ru.yandex.Browser'],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
Added browser names for all browsers from [`Flathub`](https://flathub.org`)
Based on a report from `@collapsing_cliff_01` on Discord

---

Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/148

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new browser names from Flathub to `browser_appnames` in `queries.ts` based on a community report.
> 
>   - **Enhancements**:
>     - Added new browser names from Flathub to `browser_appnames` in `queries.ts`.
>     - Updated entries for `chrome`, `firefox`, `librewolf`, `waterfox`, `opera`, `brave`, `edge`, `vivaldi`, and `yandex`.
>   - **Community**:
>     - Based on a report from `@collapsing_cliff_01` on Discord.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for c05bd4669ebb95f72d7de97d1746d41a60513ff8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->