### PR TITLE
fix: add Zen Browser to browser list

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -284,6 +284,11 @@ const browser_appnames = {
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi'],
   orion: ['Orion'],
   yandex: ['Yandex'],
+  zen: [
+    'Zen Browser',
+    'zen browser',
+    'zen.exe'
+  ],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -287,7 +287,8 @@ const browser_appnames = {
   zen: [
     'Zen Browser',
     'zen browser',
-    'zen.exe'
+    'zen.exe',
+    'app.zen_browser.zen'
   ],
 };
 


### PR DESCRIPTION
Since i'm using Zen as my primary browser and Zen is not on the list, I can't see detail activity on "Browser" tab even though Zen is a Firefox fork. So i add Zen Browser to browser list.

[Zen Browser website](https://zen-browser.app/)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Zen Browser to `browser_appnames` in `queries.ts` to enable activity tracking.
> 
>   - **Behavior**:
>     - Add Zen Browser to `browser_appnames` in `queries.ts` with identifiers: 'Zen Browser', 'zen browser', 'zen.exe'.
>     - Enables activity tracking for Zen Browser in the "Browser" tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for ce17f9df59cab7bdbe97a55f6a08ac0171acddd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->