### PR TITLE
Fix filtering of chromium-browser

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -224,6 +224,7 @@ const browser_appnames = {
     // Chromium
     'Chromium',
     'Chromium-browser',
+    'chromium-browser',
     'Chromium-browser-chromium',
     'chromium.exe',
 


### PR DESCRIPTION
In the following configuration:
- sway 1.10
- chromium 132.0.6834.110 through wayland and not xwayland
- aw-awatcher 0.3.1
- ActivityWatch Web Watcher 0.4.3

the window is stored as chromium-browser instead of Chromium-browser. That causes "No data" on the browser tab. This patch intends to fix it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `chromium-browser` to `browser_appnames` in `queries.ts` to fix Chromium window name recognition.
> 
>   - **Behavior**:
>     - Add `chromium-browser` to `browser_appnames` in `queries.ts` to handle cases where Chromium is stored as `chromium-browser` instead of `Chromium-browser`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 5fa78467fb1f52007244bf5ebe93d13d9c6db740. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->