### PR TITLE
feat: add top browser titles to activity visualization

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -43,6 +43,11 @@ div
                  :namefunc="e => e.data.url",
                  :colorfunc="e => e.data.$domain",
                  with_limit)
+    div(v-if="type == 'top_browser_titles'")
+      aw-summary(:fields="activityStore.browser.top_titles",
+                 :namefunc="e => e.data.title",
+                 :colorfunc="e => e.data.$domain",
+                 with_limit)
     div(v-if="type == 'top_editor_files'")
       aw-summary(:fields="activityStore.editor.top_files",
                  :namefunc="top_editor_files_namefunc",
@@ -135,6 +140,7 @@ export default {
         'top_titles',
         'top_domains',
         'top_urls',
+        'top_browser_titles',
         'top_categories',
         'category_tree',
         'category_sunburst',
@@ -185,6 +191,10 @@ export default {
         },
         top_urls: {
           title: 'Top Browser URLs',
+          available: this.activityStore.browser.available,
+        },
+        top_browser_titles: {
+          title: 'Top Browser Titles',
           available: this.activityStore.browser.available,
         },
         top_editor_files: {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -352,6 +352,9 @@ export function fullDesktopQuery(params: DesktopQueryParams): string[] {
     browser_domains = merge_events_by_keys(browser_events, ["$domain"]);
     browser_domains = sort_by_duration(browser_domains);
     browser_domains = limit_events(browser_domains, ${default_limit});
+    browser_titles = merge_events_by_keys(browser_events, ["title"]);
+    browser_titles = sort_by_duration(browser_titles);
+    browser_titles = limit_events(browser_titles, ${default_limit});
     browser_duration = sum_durations(browser_events);
 
     RETURN = {
@@ -365,6 +368,7 @@ export function fullDesktopQuery(params: DesktopQueryParams): string[] {
         "browser": {
             "domains": browser_domains,
             "urls": browser_urls,
+            "titles": browser_titles,
             "duration": browser_duration
         }
     };`

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -673,7 +673,7 @@ export const useActivityStore = defineStore('activity', {
       this.browser.duration = 0;
       this.browser.top_domains = null;
       this.browser.top_urls = null;
-      this.browser.top_domains = null;
+      this.browser.top_titles = null;
 
       this.editor.duration = 0;
       this.editor.top_files = null;

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -84,6 +84,7 @@ interface State {
     duration: number;
     top_urls: IEvent[];
     top_domains: IEvent[];
+    top_titles: IEvent[];
   };
 
   editor: {
@@ -148,6 +149,7 @@ export const useActivityStore = defineStore('activity', {
       duration: 0,
       top_domains: [],
       top_urls: [],
+      top_titles: [],
     },
 
     editor: {
@@ -598,6 +600,11 @@ export const useActivityStore = defineStore('activity', {
       const domain_events = groupSumEventsBy(window_events, '$domain', (e: any) =>
         e.data.url === undefined ? '' : new URL(e.data.url).host
       );
+      const browser_title_events = groupSumEventsBy(
+        window_events.filter((e: any) => e.data.url),
+        'title',
+        (e: any) => e.data.title
+      );
 
       this.query_window_completed({
         duration: _.sumBy(window_events, 'duration'),
@@ -618,6 +625,7 @@ export const useActivityStore = defineStore('activity', {
         duration: _.sumBy(url_events, 'duration'),
         domains: domain_events,
         urls: url_events,
+        titles: browser_title_events,
       });
 
       this.buckets.editor = ['aw-watcher-vim'];
@@ -665,6 +673,7 @@ export const useActivityStore = defineStore('activity', {
       this.browser.duration = 0;
       this.browser.top_domains = null;
       this.browser.top_urls = null;
+      this.browser.top_domains = null;
 
       this.editor.duration = 0;
       this.editor.top_files = null;
@@ -701,9 +710,13 @@ export const useActivityStore = defineStore('activity', {
       this.active.events = data.active_events;
     },
 
-    query_browser_completed(this: State, data = { domains: [], urls: [], duration: 0 }) {
+    query_browser_completed(
+      this: State,
+      data = { domains: [], urls: [], titles: [], duration: 0 }
+    ) {
       this.browser.top_domains = data.domains;
       this.browser.top_urls = data.urls;
+      this.browser.top_titles = data.titles;
       this.browser.duration = data.duration;
     },
 

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -40,6 +40,7 @@ const desktopViews: View[] = [
     elements: [
       { type: 'top_domains', size: 3 },
       { type: 'top_urls', size: 3 },
+      { type: 'top_browser_titles', size: 3 },
     ],
   },
   {


### PR DESCRIPTION
<p align=center>
<img width="300" src="https://github.com/user-attachments/assets/0ad5fe22-3d6b-41b3-bee3-544d0516ed20" />
</p>

---

- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/117

---
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add visualization for top browser titles in activity visualization, updating components, queries, and state management.
> 
>   - **Behavior**:
>     - Adds `top_browser_titles` visualization in `SelectableVisualization.vue`.
>     - Updates `desktopViews` in `views.ts` to include `top_browser_titles`.
>   - **Queries**:
>     - Modifies `fullDesktopQuery` in `queries.ts` to include `browser_titles`.
>   - **State Management**:
>     - Updates `State` interface in `activity.ts` to include `top_titles` for `browser`.
>     - Modifies `query_browser_completed()` in `activity.ts` to handle `top_titles`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 00d0bc7daba1167da926877b114eb19810c5b22e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->