### PR TITLE
fix: update github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: make build
     - name: Upload build
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         name: build-webpack
         path: dist/*
@@ -58,7 +58,7 @@ jobs:
     - name: Build
       run: make build-vite
     - name: Upload build
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         name: build-vite
         path: dist/*
@@ -192,7 +192,7 @@ jobs:
         mv ~/.cache/activitywatch/log/*/*.log logs/dist/$aw_server/$aw_version
     - name: Upload logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: logs/dist/*

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -194,5 +194,5 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: logs
+        name: logs-${{ matrix.aw-server }}-${{ matrix.aw-version }}
         path: logs/dist/*


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update GitHub Actions to use `actions/upload-artifact@v4` and modify log artifact naming in `nodejs.yml`.
> 
>   - **GitHub Actions**:
>     - Update `actions/upload-artifact` from `v3.1.2` to `v4` in `build-webpack`, `build-vite`, and `test` jobs in `nodejs.yml`.
>     - Change log artifact name to `logs-${{ matrix.aw-server }}-${{ matrix.aw-version }}` in `test` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 241f9cf49e6efdbb07bd0338978c39f64ef67e20. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->