### PR TITLE
fix: correct duration formatting logic

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -12,9 +12,15 @@ export function seconds_to_duration(seconds: number) {
   const min = Math.floor((seconds / 60) % 60);
   const sec = Math.floor(seconds % 60);
   const l = [];
-  if (hrs != 0) l.push(hrs + 'h');
-  if (min != 0) l.push(min + 'm');
-  if (sec != 0 || l.length == 0) l.push(sec + 's');
+
+  if (hrs > 0) {
+    l.push(hrs + 'h');
+    l.push(min + 'm');
+  } else if (min > 0) {
+    l.push(min + 'm');
+  }
+  l.push(sec + 's');
+
   return l.join(' ');
 }
 

--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -9,6 +9,10 @@ describe('seconds_to_duration', () => {
     expect(seconds_to_duration(3630)).toBe('1h 0m 30s');
   });
 
+  test('should format 3600 seconds as "1h 0m 0s"', () => {
+    expect(seconds_to_duration(3630)).toBe('1h 0m 0s');
+  });
+
   test('should format 1830 seconds as "30m 30s"', () => {
     expect(seconds_to_duration(1830)).toBe('30m 30s');
   });

--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -10,7 +10,7 @@ describe('seconds_to_duration', () => {
   });
 
   test('should format 3600 seconds as "1h 0m 0s"', () => {
-    expect(seconds_to_duration(3630)).toBe('1h 0m 0s');
+    expect(seconds_to_duration(3600)).toBe('1h 0m 0s');
   });
 
   test('should format 1830 seconds as "30m 30s"', () => {

--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -1,0 +1,23 @@
+import { seconds_to_duration } from '~/util/time';
+
+describe('seconds_to_duration', () => {
+  test('should format 8145 seconds as "2h 15m 45s"', () => {
+    expect(seconds_to_duration(8145)).toBe('2h 15m 45s');
+  });
+
+  test('should format 3630 seconds as "1h 0m 30s"', () => {
+    expect(seconds_to_duration(3630)).toBe('1h 0m 30s');
+  });
+
+  test('should format 1830 seconds as "30m 30s"', () => {
+    expect(seconds_to_duration(1830)).toBe('30m 30s');
+  });
+
+  test('should format 60 seconds as "1m 0s"', () => {
+    expect(seconds_to_duration(60)).toBe('1m 0s');
+  });
+
+  test('should format 30 seconds as "30s"', () => {
+    expect(seconds_to_duration(30)).toBe('30s');
+  });
+});


### PR DESCRIPTION
<p align=center>
<img width="40%" src="https://github.com/user-attachments/assets/abda4239-2e7f-4ea0-ab06-e7d76fb2f4cd" />
  
<img width="40%" src="https://github.com/user-attachments/assets/d8910b25-ba6c-43d2-b138-584c41df1fcf" />
</p>

---

- Fixes https://github.com/ActivityWatch/activitywatch/issues/1090
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duration formatting in `seconds_to_duration` and adds unit tests for various cases.
> 
>   - **Behavior**:
>     - Fixes `seconds_to_duration` in `time.ts` to correctly format durations, ensuring minutes are included only when hours are present.
>   - **Tests**:
>     - Adds `time.test.js` with unit tests for `seconds_to_duration`, covering various cases like 8145, 3630, 1830, 60, and 30 seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 8c3f995f03a172fd5ea1f1658547573b48a36306. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->