### PR TITLE
fix: add another name for Brave

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -273,7 +273,7 @@ const browser_appnames = {
     'net.waterfox.waterfox',
   ],
   opera: ['opera.exe', 'Opera', 'com.opera.Opera'],
-  brave: ['Brave-browser', 'Brave Browser', 'brave.exe', 'com.brave.Browser'],
+  brave: ['Brave-browser', 'brave-browser', 'Brave Browser', 'brave.exe', 'com.brave.Browser'],
   edge: [
     'msedge.exe', // Windows
     'Microsoft Edge', // macOS


### PR DESCRIPTION
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/165
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `brave-browser` to `browser_appnames` in `src/queries.ts` to fix issue #165 by recognizing an alternative name for the Brave browser.
> 
>   - **Behavior**:
>     - Adds `brave-browser` to the `brave` array in `browser_appnames` in `src/queries.ts` to recognize an alternative name for the Brave browser.
>   - **Issue Fix**:
>     - Fixes issue #165 in `aw-watcher-web` where `brave-browser` was not recognized.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 0a5ca4f7eeefd58a8b5f798741aeeb0926690aa5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->