### PR TITLE
feat: enhance colorisation for Top Window Titles

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -31,7 +31,7 @@ div
     div(v-if="type == 'top_titles'")
       aw-summary(:fields="activityStore.window.top_titles",
                  :namefunc="e => e.data.title",
-                 :colorfunc="e => e.data.title",
+                 :colorfunc="e => e.data['$category']",
                  with_limit)
     div(v-if="type == 'top_domains'")
       aw-summary(:fields="activityStore.browser.top_domains",
@@ -68,7 +68,7 @@ div
     div(v-if="type == 'top_categories'")
       aw-summary(:fields="activityStore.category.top",
                  :namefunc="e => e.data['$category'].join(' > ')",
-                 :colorfunc="e => e.data['$category'].join(' > ')",
+                 :colorfunc="e => e.data['$category']",
                  :linkfunc="e => '#' + $route.path + '?category=' + encodeURIComponent(e.data['$category'].join('>'))",
                  with_limit)
     div(v-if="type == 'category_tree'")

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -97,6 +97,16 @@ export function getCategoryColorFromString(str: string): string {
   }
 }
 
+export function getCategoryColor(category_name: string[]): string {
+  // TODO: Don't load classes on every call
+  const allCats = loadClasses();
+  const c = allCats.find(cat => _.isEqual(cat.name, category_name));
+  if (c !== undefined) {
+    return getColorFromCategory(c, allCats);
+  }
+  return fallbackColor(category_name.join(' > '));
+}
+
 function fallbackColor(str: string): string {
   // Get fallback color
   // TODO: Fetch setting from somewhere better, where defaults are respected

--- a/src/visualizations/summary.ts
+++ b/src/visualizations/summary.ts
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 import Color from 'color';
 import _ from 'lodash';
 
-import { getCategoryColorFromString } from '~/util/color';
+import { getCategoryColor, getCategoryColorFromString } from '~/util/color';
 import { seconds_to_duration } from '~/util/time';
 import { IEvent } from '~/util/interfaces';
 
@@ -42,6 +42,7 @@ interface Entry {
   color?: string;
   colorKey?: string;
   link?: string;
+  category?: string;
 }
 
 function update(container: HTMLElement, apps: Entry[]) {
@@ -69,7 +70,14 @@ function update(container: HTMLElement, apps: Entry[]) {
     const width = (app.duration / longest_duration) * 100 + '%';
     const barHeight = 46;
     const textSize = 14;
-    const appcolor = app.color || getCategoryColorFromString(app.colorKey || app.name);
+
+    let appcolor: string;
+    if (Array.isArray(app.colorKey)) {
+      appcolor = getCategoryColor(app.colorKey);
+    } else {
+      appcolor = app.color || getCategoryColorFromString(app.colorKey || app.name);
+    }
+
     const hovercolor = Color(appcolor).darken(0.1).hex();
 
     // Add a parent <a> element if link is set
@@ -143,6 +151,7 @@ function updateSummedEvents(
       color: e.data['$color'],
       colorKey: colorKeyFunc(e),
       link: linkKeyFunc(e),
+      category: e.data['$category'],
     } as Entry;
   });
   update(container, apps);


### PR DESCRIPTION
Colorises **Top Window Titles** based on the category of the event rather than just the event title. Reduces confusion for new users who may see a lot of "uncategorised" rectangles even if they have categorised everything correctly.

---

This is the first time I'm doing something bigger in the Vue, so I'm open to any constructive criticism :)

---

<p align=center>
<img width="45%" src="https://github.com/user-attachments/assets/efc29457-5405-4fc0-bbbf-3555f58b894c">
   
<img width="45%" src="https://github.com/user-attachments/assets/efbf67ad-3db8-4871-a9a4-6e4ccb061547">
</p>