### PR TITLE
fix: remove router guard for unsaved category settings

### DIFF
--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -61,6 +61,7 @@ export default {
   data: () => ({
     categoryStore: useCategoryStore(),
     editingId: null,
+    routerGuardRemover: null,
   }),
   computed: {
     ...mapState(useCategoryStore, ['classes_unsaved_changes']),
@@ -75,8 +76,7 @@ export default {
     // beforeEach hook
     window.addEventListener('beforeunload', this.beforeUnload);
 
-    // TODO: How to remove this listener?
-    router.beforeEach((to, from, next) => {
+    this.routerGuardRemover = router.beforeEach((to, from, next) => {
       try {
         if (this.classes_unsaved_changes) {
           if (confirm(confirmationMessage)) {
@@ -95,6 +95,9 @@ export default {
   },
   beforeDestroy() {
     window.removeEventListener('beforeunload', this.beforeUnload);
+    if (this.routerGuardRemover) {
+      this.routerGuardRemover();
+    }
   },
   methods: {
     addClass: function () {


### PR DESCRIPTION
In the file [CategorizationSettings.vue](https://github.com/ActivityWatch/aw-webui/blob/cb9a7ecc58de8f4ffcc674deb44a52e10b2c6225/src/views/settings/CategorizationSettings.vue#L78), there is a note stating // TODO: How to remove this listener?.

This unresolved listener issue leads to an unintended behavior where the confirmation popup reappears every time the route changes, even if the initial confirmation popup was ignored. 

This PR addresses the problem to ensure proper removal of the listener and prevent repeated popups during route changes.

| Before:  repeated popup | After: popup only once |
|---|---|
| ![repeated popup](https://github.com/user-attachments/assets/558b6c9b-6419-4b79-9f5e-f928c1f890c5) | ![popup only once](https://github.com/user-attachments/assets/7ac4947d-768e-49a5-ae37-38d19d95cbdb) |

_Thanks in advance._

---

**[BTW]** This PR does resolve the aforementioned issue. However, I noticed that in `src/stores/categories.ts`, the state of `classes_unsaved_changes` remains `true` even after the confirmation popup is ignored, until the store's `load()` action is called again.

This behavior might lead to potential issues, but in line with the principle of minimal changes, I have not addressed this in this PR.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes repeated confirmation popup issue in `CategorizationSettings.vue` by properly removing the router guard.
> 
>   - **Behavior**:
>     - Fixes repeated confirmation popup issue in `CategorizationSettings.vue` by properly removing the router guard.
>     - Stores the router guard remover function in `routerGuardRemover` and calls it in `beforeDestroy()`.
>   - **Misc**:
>     - Adds `routerGuardRemover` to `data` in `CategorizationSettings.vue`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 5d393f8be4b51f7e8961168a076c7f8988197a8a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->