### PR TITLE
Minor label fixes to TimelineBarChart

### DIFF
--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -69,6 +69,8 @@ export default {
           return date.toLocaleDateString('en-US', { weekday: 'short' });
         });
       } else if (resolution.startsWith('month')) {
+        // FIXME: Needs access to the timeperiod start to know which month
+        // How many days are in the given month?
         const date = new Date(start);
         const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
         const ordinalsEnUS = {
@@ -83,11 +85,7 @@ export default {
           const pluralRules = new Intl.PluralRules(locale, { type: 'ordinal' });
           return `${num}${ordinals[pluralRules.select(num)]}`;
         };
-        // FIXME: Needs access to the timeperiod start to know which month
-        // How many days are in the given month?
         return _.range(1, daysInMonth + 1).map(d => toOrdinalSuffix(d));
-
-
       } else if (resolution == 'year') {
         return ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
       } else {
@@ -115,12 +113,16 @@ export default {
             mode: 'point',
             intersect: false,
             callbacks: {
-              label: function(context) {
-                let value = context.parsed.y
-                let hours = Math.floor(value)
-                let minutes = Math.round((value - hours) * 60)
-                let minutes_str = minutes.toString().padStart(2, "0")
-                return `${hours}:${minutes_str}`
+              label: function (context) {
+                let value = context.parsed.y;
+                let hours = Math.floor(value);
+                let minutes = Math.round((value - hours) * 60);
+                if (minutes == 60) {
+                  minutes = 0;
+                  hours += 1;
+                }
+                let minutes_str = minutes.toString().padStart(2, "0");
+                return `${hours}:${minutes_str}`;
               }
             }
           },


### PR DESCRIPTION
This PR implements two small labeling fixes to the TimelineBarChart component:

1. Format the mouseover labels as "HH:MM" strings.  They are currently displayed a decimals in units of hours, which is not particularly readable especially for a single day time period.
2. Fixes a small bug in the X-axis label generation for the month time period that generated ordinals like "21th", "22th", etc.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes mouseover label format to "HH:MM" and corrects ordinal suffixes for month day labels in `TimelineBarChart.vue`.
> 
>   - **Behavior**:
>     - Mouseover labels in `TimelineBarChart.vue` now display time as "HH:MM" instead of decimal hours.
>     - Fixes ordinal suffixes for day labels in month view to correctly display "1st", "2nd", "3rd", etc.
>   - **Functions**:
>     - Adds `toOrdinalSuffix()` function in `TimelineBarChart.vue` to generate correct ordinal suffixes.
>     - Updates tooltip `label` callback in `chartOptions()` to format time as "HH:MM".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 29a3af4a45fd8f7a2184d6b810ef41c2e60be12d. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->