### PR TITLE
chore: add macos browser app name for Zen

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -293,7 +293,7 @@ const browser_appnames = {
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi', 'com.vivaldi.Vivaldi'],
   orion: ['Orion'],
   yandex: ['Yandex', 'ru.yandex.Browser'],
-  zen: ['Zen Browser', 'zen browser', 'zen.exe', 'app.zen_browser.zen'],
+  zen: ['Zen', 'Zen Browser', 'zen', 'zen browser', 'zen.exe', 'app.zen_browser.zen'],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
Hi, thanks for the great work on this project!

I found that I needed to add these entries to get the Browser activity detail tab to play nicely with (1) firefox watcher extension (2) Zen Browser (3) macOS.

This is a tiny follow-up on #625.

I'm not confident I built from source entirely correctly, so looking forward to the next release (and hoping it has this change).

Thanks again!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'Zen' and 'zen' identifiers for Zen browser in `queries.ts` to improve macOS compatibility.
> 
>   - **Behavior**:
>     - Adds 'Zen' and 'zen' to the list of identifiers for the Zen browser in the `browser_appnames` object in `queries.ts`.
>     - Ensures compatibility with macOS for Zen browser detection.
>   - **Misc**:
>     - Follow-up on previous changes in #625.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for d8043afc4b10cd0d55979e8fc48d0ba233f7061d. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->