### PR TITLE
fix: handle ^ and $ in rules

### DIFF
--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -214,7 +214,8 @@ export function matchString(str: string, categories: Category[] | null): Categor
   const regexes: [Category, RegExp][] = categories
     .filter(c => c.rule.type == 'regex')
     .map(c => {
-      const re = RegExp(c.rule.regex, c.rule.ignore_case ? 'i' : '');
+      // using 'm' flag to make `$` and `^` in rules work
+      const re = RegExp(c.rule.regex, (c.rule.ignore_case ? 'i' : '') + 'm');
       return [c, re];
     });
 
@@ -227,6 +228,7 @@ export function matchString(str: string, categories: Category[] | null): Categor
   return null;
 }
 
+// this is used only in tests
 export function classifyEvents(events: IEvent[], categories: Category[]): IEvent[] {
   // Compile regexes
   const regexes: [Category, RegExp][] = categories

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -129,11 +129,11 @@ export function getTitleAttr(bucket: { type?: string }, e: IEvent) {
 
 export function getCategoryColorFromEvent(bucket: IBucket, e: IEvent) {
   if (bucket.type == 'currentwindow') {
-    // NOTE: this will not work/break category rules which reference `$` or `^`
-    return getCategoryColorFromString(e.data.app + ' ' + e.data.title);
+    // using linebreak and "m" regex flag to make `$` and `^` work
+    return getCategoryColorFromString(e.data.app + '\n' + e.data.title);
   } else if (bucket.type == 'web.tab.current') {
-    // NOTE: same as above
-    return getCategoryColorFromString(e.data.title + ' ' + e.data.url);
+    // same as above
+    return getCategoryColorFromString(e.data.title + '\n' + e.data.url);
   } else if (bucket.type == 'afkstatus') {
     return getColorFromString(e.data.status);
   } else if (bucket.type?.startsWith('app.editor')) {


### PR DESCRIPTION
Fix https://github.com/ActivityWatch/activitywatch/issues/1148
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of `^` and `$` in regex rules by adding 'm' flag and adjusting string concatenation in `classes.ts` and `color.ts`.
> 
>   - **Behavior**:
>     - Fixes handling of `^` and `$` in regex rules by adding 'm' flag in `matchString` in `classes.ts` and `getCategoryColorFromEvent` in `color.ts`.
>     - Concatenates `app` and `title` with line breaks in `getCategoryColorFromEvent` for `currentwindow` and `web.tab.current` buckets.
>   - **Misc**:
>     - Adds comment in `classifyEvents` in `classes.ts` indicating it's used only in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for b4f50604b5a3ee9bc9897ceaec1e196a231db123. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->