### PR TITLE
Add another name for Zen Browser

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -301,7 +301,7 @@ const browser_appnames = {
     'zen browser',
     'zen-browser',
     'zen.exe',
-    'app.zen_browser.zen'
+    'app.zen_browser.zen',
   ],
 };
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -293,7 +293,7 @@ const browser_appnames = {
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi', 'com.vivaldi.Vivaldi'],
   orion: ['Orion'],
   yandex: ['Yandex', 'ru.yandex.Browser'],
-  zen: ['Zen', 'Zen Browser', 'zen', 'zen browser', 'zen.exe', 'app.zen_browser.zen'],
+  zen: ['Zen', 'Zen Browser', 'Zen-browser', 'zen', 'zen browser', 'zen-browser', 'zen.exe', 'app.zen_browser.zen'],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -293,7 +293,16 @@ const browser_appnames = {
   vivaldi: ['Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi', 'com.vivaldi.Vivaldi'],
   orion: ['Orion'],
   yandex: ['Yandex', 'ru.yandex.Browser'],
-  zen: ['Zen', 'Zen Browser', 'Zen-browser', 'zen', 'zen browser', 'zen-browser', 'zen.exe', 'app.zen_browser.zen'],
+  zen: [
+    'Zen',
+    'Zen Browser',
+    'Zen-browser',
+    'zen',
+    'zen browser',
+    'zen-browser',
+    'zen.exe',
+    'app.zen_browser.zen'
+  ],
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets


### PR DESCRIPTION
Based on screenshot from `@renyuneyun` in https://github.com/ActivityWatch/aw-watcher-web/issues/102#issuecomment-2925325856
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Zen-browser` and `zen-browser` as aliases for Zen Browser in `browser_appnames` in `queries.ts`.
> 
>   - **Behavior**:
>     - Add `Zen-browser` and `zen-browser` as aliases for Zen Browser in `browser_appnames` in `queries.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for ab3480daf0002bfcc1dcaddb73e70b7ba394d5c0. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->