### PR TITLE
fix: add uppercase names for some browsers

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -281,7 +281,7 @@ const browser_appnames = {
     'Brave Browser',
     'brave.exe',
     'Brave.exe',
-    'com.brave.Browser'
+    'com.brave.Browser',
   ],
   edge: [
     'msedge.exe', // Windows
@@ -306,7 +306,7 @@ const browser_appnames = {
     'vivaldi.exe',
     'Vivaldi.exe',
     'Vivaldi',
-    'com.vivaldi.Vivaldi'
+    'com.vivaldi.Vivaldi',
   ],
   orion: ['Orion'],
   yandex: ['Yandex', 'ru.yandex.Browser'],


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/1166
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds uppercase browser names to `browser_appnames` in `queries.ts` for case-insensitive detection, fixing issue #1166.
> 
>   - **Behavior**:
>     - Adds uppercase browser names to `browser_appnames` in `queries.ts` for Chrome, Chromium, Opera, Brave, Arc, Vivaldi, Zen, and Floorp.
>     - Ensures case-insensitive detection of browser applications.
>   - **Misc**:
>     - Fixes issue #1166 by improving browser name matching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 989c41d07cafd9043363a1c7473ef557a7f71129. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->