### PR TITLE
feat: Add ability to better visualize value of custom events if not using title

### DIFF
--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -123,7 +123,20 @@ export function getTitleAttr(bucket: { type?: string }, e: IEvent) {
   } else if (bucket.type?.startsWith('general.stopwatch')) {
     return e.data.label;
   } else {
-    return e.data.title;
+    const title = e.data.title;
+    if (title && typeof title === 'string') {
+      return title;
+    }
+
+    const keys = Object.keys(e.data);
+    if (keys.length === 1) {
+      const val = e.data[keys[0]];
+      if (typeof val === 'string') {
+        return val.length > 50 ? val.slice(0, 50) : val;
+      }
+    }
+
+    return '';
   }
 }
 


### PR DESCRIPTION
For my virtual desktop name watcher (), I'm using custom event-type with custom key (which might be wrong?) which means the visualization doesn't pick up the events well. All events are just blue and don't have a title. The data is there in tooltip but that's not good for glancing. 

<img width="543" height="231" alt="image" src="https://github.com/user-attachments/assets/6e10d6c5-3bd1-44a1-bbca-aeb2b7924ec2" />


I think that if there's only one piece of data, and there's no title, we can extract the single piece of data as event. 

Happy to also be told that custom watchers should use title for that purse, if that's the design. And I can prepare PR for docs and abandon this one. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `getTitleAttr` in `color.ts` to extract a single data piece as title for custom events without a title.
> 
>   - **Behavior**:
>     - In `getTitleAttr` in `color.ts`, if `e.data.title` is missing, extract single data piece as title if only one key exists in `e.data` and its value is a string.
>     - Truncate extracted title to 50 characters if necessary.
>   - **Misc**:
>     - No changes to existing behavior for events with a valid `title` or multiple data keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for c528deb6b6dcfe54fee70f93a296467c0036cd21. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->