### PR TITLE
Fix dark mode timeline borders

### DIFF
--- a/static/dark.css
+++ b/static/dark.css
@@ -170,7 +170,7 @@ hr {
   background-color: #282c32 !important;
 }
 
-#visualization *, svg,
+#visualization *:not([style*=border]), svg,
 .nav.nav-tabs,
 .btn-outline-secondary {
   border-color: #282c32 !important;

--- a/static/dark.css
+++ b/static/dark.css
@@ -170,7 +170,7 @@ hr {
   background-color: #282c32 !important;
 }
 
-#visualization *:not([style*=border]), svg,
+#visualization *:not([style*="border:"]):not([style*="border-color:"]), svg,
 .nav.nav-tabs,
 .btn-outline-secondary {
   border-color: #282c32 !important;


### PR DESCRIPTION
This PR fixes the dark mode's timeline colors as mentioned in #611 

before : 
<img width="1139" height="657" alt="image" src="https://github.com/user-attachments/assets/47a4f8fc-206d-4de0-aa9f-9c7a3fe2451a" />

after :
<img width="1139" height="657" alt="image" src="https://github.com/user-attachments/assets/34f14c19-60b7-4125-a6f7-093801699bd1" />

The fix itself is not the most beautiful css code, but the source of the issue is a quite old css rule that is too generic (`#visualization *` targets almost everything, this is bad) and that uses the `!important` keyword (this is bad too ! 😄😅) :

https://github.com/ActivityWatch/aw-webui/blame/f38b119f0ad628dd8af6ddfaaaf89700b9290c06/static/dark.css#L173-L177

A nicer solution would be to remove this rule and rework dark mode styling from the ground up but this quick fix should be sufficient for now I hope 🙏 