### PR TITLE
Warn against semicolons in categorisation rules editor

### DIFF
--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -2,6 +2,10 @@ export function validateRegex(re: string) {
   // validates if pattern is a valid regex
   // returns true if regex is valid
   if (re === '') return false;
+ 
+  // semicolons are valid regex, but they break aw-server
+  if (/[;]/.test(re)) return false;
+
   try {
     new RegExp(re);
   } catch (e) {

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -4,7 +4,7 @@ export function validateRegex(re: string) {
   if (re === '') return false;
  
   // semicolons are valid regex, but they break aw-server
-  if (/[;]/.test(re)) return false;
+  if (re.includes(';')) return false;
 
   try {
     new RegExp(re);


### PR DESCRIPTION
Workaround to attempt to prevent creating rules that break aw-server like this https://forum.activitywatch.net/t/invalid-syntax-for-value-to-assign-out-of-nowhere/4627/3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `validateRegex` to flag semicolons in regex as invalid to prevent server errors.
> 
>   - **Behavior**:
>     - Update `validateRegex` in `validate.ts` to return `false` if regex contains semicolons, preventing server errors.
>   - **Validation**:
>     - Semicolons in regex patterns are now flagged as invalid to avoid breaking `aw-server`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 93f44842378ddeac9addb7f3d3949644649427cd. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->