### PR TITLE
Compatibility patch for aw-import-screentime

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -33,6 +33,11 @@ div
                  :namefunc="e => e.data.title",
                  :colorfunc="e => e.data.title",
                  with_limit)
+    div(v-if="type == 'top_bundle_ids'")
+      aw-summary(:fields="activityStore.window.top_titles",
+                 :namefunc="e => e.data.classname",
+                 :colorfunc="e => e.data.app",
+                 with_limit)
     div(v-if="type == 'top_domains'")
       aw-summary(:fields="activityStore.browser.top_domains",
                  :namefunc="e => e.data.$domain",
@@ -143,6 +148,7 @@ export default {
       types: [
         'top_apps',
         'top_titles',
+        'top_bundle_ids',
         'top_domains',
         'top_urls',
         'top_browser_titles',
@@ -189,7 +195,11 @@ export default {
         },
         top_titles: {
           title: 'Top Window Titles',
-          available: this.activityStore.window.available,
+          available: this.activityStore.window.available || this.activityStore.android.available,
+        },
+        top_bundle_ids: {
+          title: 'Bundle IDs',
+          available: this.activityStore.window.available || this.activityStore.android.available,
         },
         top_domains: {
           title: 'Top Browser Domains',

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -33,7 +33,7 @@ div
                  :namefunc="e => e.data.title",
                  :colorfunc="e => e.data.title",
                  with_limit)
-    div(v-if="type == 'top_bundle_ids'")
+    div(v-if="type == 'top_bundle_ids' && activityStore.android.available")
       aw-summary(:fields="activityStore.window.top_titles",
                  :namefunc="e => e.data.classname",
                  :colorfunc="e => e.data.app",

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -118,7 +118,7 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
     // Fetch window/app events
     `events = flood(query_bucket(find_bucket("${bid_window}")));`,
     // On Android, merge events to avoid overload of events
-    isAndroidParams(params) ? 'events = merge_events_by_keys(events, ["app"]);' : '',
+    isAndroidParams(params) ? 'events = merge_events_by_keys(events, ["app", "title"]);' : '',
     // Fetch not-afk events
     isDesktopParams(params)
       ? `not_afk = flood(query_bucket(find_bucket("${params.bid_afk}")));
@@ -200,7 +200,7 @@ export function appQuery(
   const code = `
     ${canonicalEvents(params)}
 
-    title_events = sort_by_duration(merge_events_by_keys(events, ["app", "classname"]));
+    title_events = sort_by_duration(merge_events_by_keys(events, ["app", "classname", "title"]));
     app_events   = sort_by_duration(merge_events_by_keys(title_events, ["app"]));
     cat_events   = sort_by_duration(merge_events_by_keys(events, ["$category"]));
 

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -98,10 +98,15 @@ export const useBucketsStore = defineStore('buckets', {
         );
     },
     bucketsAndroid(): (host: string) => string[] {
-      return host =>
-        this.bucketsByType(host, 'currentwindow').filter((id: string) =>
+      return host => {
+        const android = this.bucketsByType(host, 'currentwindow').filter((id: string) =>
           id.startsWith('aw-watcher-android')
         );
+        const ios = this.bucketsByType(host, 'app').filter((id: string) =>
+          id.startsWith('aw-import-screentime')
+        );
+        return [...android, ...ios];
+      };
     },
     bucketsEditor(): (host: string) => string[] {
       // fallback to a bucket with 'unknown' host, if one exists.


### PR DESCRIPTION
Feature: 
I modified the codebase to enable better compatibility out of the box with IOS imports using the aw-import-screentime utility. I also added a new visualization called BundleIDs to view the "app" attribute of the bucket.

Changes
1. Bucket Detection (
src/stores/buckets.ts
)
Updated 
bucketsAndroid
 getter to recognize buckets starting with aw-import-screentime.
2. Query Logic (
src/queries.ts
)
Fix: Modified 
canonicalEvents
 to merge Android events by ["app", "title"] instead of just ["app"].
Reason: Previous logic stripped the title attribute during the initial query, preventing us from accessing the Human Readable Name present in iOS exports.
3. Attribute Mapping (
src/stores/activity.ts
)
Added post-processing in 
query_android
.
Detects iOS buckets and maps attributes to align with WebUI expectations:
App Name (
app
): Set to the Human Readable Name (from title).
Bundle ID (classname): Set to the Bundle ID (from original 
app
).
Original Title (title): Kept as Human Readable Name.
4. Visualization (
src/components/SelectableVisualization.vue
)
Enabled top_titles ("Top Window Titles") for Android sources.
New Visualization: Added "Bundle IDs" (top_bundle_ids).
Displays the raw Bundle ID (classname) for technical detail.
Added to the configuration menu (gear icon).
Verification
Import iPhone data.
Top Applications: Should show readable names (e.g., "YouTube") instead of bundle IDs.
Top Window Titles: Should show readable titles.
Bundle IDs: Select this new view to see the underlying com.google.ios.youtube style IDs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance iOS import compatibility and add Bundle IDs visualization in `SelectableVisualization.vue`.
> 
>   - **Bucket Detection**:
>     - Update `bucketsAndroid` getter in `buckets.ts` to recognize iOS buckets starting with `aw-import-screentime`.
>   - **Query Logic**:
>     - Modify `canonicalEvents` in `queries.ts` to merge Android events by `['app', 'title']`.
>     - Update `appQuery` in `queries.ts` to merge events by `['app', 'classname', 'title']`.
>   - **Attribute Mapping**:
>     - Add post-processing in `query_android` in `activity.ts` to swap `app` and `title` for iOS buckets.
>   - **Visualization**:
>     - Add "Bundle IDs" visualization in `SelectableVisualization.vue` to display raw Bundle IDs.
>     - Enable `top_titles` for Android sources in `SelectableVisualization.vue`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for d18d09f42bdf128d13f1ebd48a521abd589e4d81. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->