### PR TITLE
feat(categorization): add category sets — named rule profiles with multi-set combining

### DIFF
--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -2,12 +2,16 @@ import _ from 'lodash';
 import {
   saveClasses,
   loadClasses,
+  saveCategories,
+  loadCategories,
   cleanCategory,
   defaultCategories,
   build_category_hierarchy,
   createMissingParents,
+  mergeCategorySets,
   annotate,
   Category,
+  CategorySet,
   Rule,
 } from '~/util/classes';
 import { getColorFromCategory } from '~/util/color';
@@ -16,6 +20,10 @@ import { defineStore } from 'pinia';
 interface State {
   classes: Category[];
   classes_unsaved_changes: boolean;
+  // Category sets — named collections of category rules
+  category_sets: CategorySet[];
+  // Ordered list of active set IDs; first entry has highest priority when merging
+  active_set_ids: string[];
 }
 
 function getScoreFromCategory(c: Category, allCats: Category[]): number {
@@ -45,10 +53,34 @@ function normalizeSegments(cat: string[]): string[] {
   });
 }
 
+function assignIds(classes: Category[]): Category[] {
+  let i = 0;
+  return classes.map(c => Object.assign(c, { id: i++ }));
+}
+
+/** Recompute the effective `classes` list from the provided active sets. */
+function computeEffectiveClasses(categorySets: CategorySet[], activeSetIds: string[]): Category[] {
+  const activeSets = categorySets.filter(s => activeSetIds.includes(s.id));
+  const merged = mergeCategorySets(activeSets);
+  return assignIds(createMissingParents(merged));
+}
+
+/** Copy current effective classes back into the primary active set (no-op if no sets). */
+function syncToPrimarySet(state: State) {
+  if (state.active_set_ids.length === 0 || state.category_sets.length === 0) return;
+  const primaryId = state.active_set_ids[0];
+  const primarySet = state.category_sets.find(s => s.id === primaryId);
+  if (primarySet) {
+    primarySet.categories = state.classes.map(cleanCategory);
+  }
+}
+
 export const useCategoryStore = defineStore('categories', {
   state: (): State => ({
     classes: [],
     classes_unsaved_changes: false,
+    category_sets: [],
+    active_set_ids: ['default'],
   }),
 
   // getters
@@ -140,21 +172,121 @@ export const useCategoryStore = defineStore('categories', {
   },
 
   actions: {
-    load(this: State, classes: Category[] = null) {
-      if (classes === null) {
-        classes = loadClasses();
+    /**
+     * Load categories into the store.
+     *
+     * When called with an explicit `classes` array (e.g. in tests), those categories are loaded
+     * directly without touching category sets.
+     *
+     * When called without arguments, loads from the settings store — including multi-set support.
+     * Falls back to the legacy flat `classes` setting if no sets are defined yet.
+     */
+    load(this: State, classes?: Category[]) {
+      if (classes !== undefined) {
+        // Explicit categories provided (test / programmatic path)
+        classes = createMissingParents(classes);
+        this.classes = assignIds(classes);
+        this.classes_unsaved_changes = false;
+        return;
       }
-      classes = createMissingParents(classes);
 
-      let i = 0;
-      this.classes = classes.map(c => Object.assign(c, { id: i++ }));
+      // Load sets from settings store
+      const { sets, activeIds } = loadCategories();
+      this.category_sets = sets;
+      this.active_set_ids = activeIds;
+
+      // Compute effective classes from active sets (merged in priority order)
+      this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
       this.classes_unsaved_changes = false;
     },
-    save() {
-      const r = saveClasses(this.classes);
+
+    save(this: State) {
+      // Sync current classes back to the primary active set before persisting
+      syncToPrimarySet(this);
+      saveCategories(this.category_sets, this.active_set_ids);
+      // Also update legacy flat classes field for backwards compatibility
+      saveClasses(this.classes);
       this.classes_unsaved_changes = false;
-      return r;
     },
+
+    // ── Category set management ──────────────────────────────────────────────
+
+    /**
+     * Create a new empty category set.
+     * The new set is NOT activated automatically — call switchToSet() after if needed.
+     */
+    createSet(this: State, id: string) {
+      if (this.category_sets.find(s => s.id === id)) {
+        console.warn('Category set already exists:', id);
+        return;
+      }
+      this.category_sets.push({ id, categories: [] });
+    },
+
+    /**
+     * Delete a category set by ID.
+     * The last remaining set cannot be deleted.
+     */
+    deleteSet(this: State, id: string) {
+      if (this.category_sets.length <= 1) {
+        console.warn('Cannot delete the last category set');
+        return;
+      }
+      this.category_sets = this.category_sets.filter(s => s.id !== id);
+      this.active_set_ids = this.active_set_ids.filter(aid => aid !== id);
+      if (this.active_set_ids.length === 0) {
+        this.active_set_ids = [this.category_sets[0].id];
+      }
+      this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
+      this.classes_unsaved_changes = true;
+    },
+
+    /**
+     * Switch to a single active set by ID.
+     * Saves the current classes to the previously active set first.
+     */
+    switchToSet(this: State, id: string) {
+      if (!this.category_sets.find(s => s.id === id)) {
+        console.warn('Category set not found:', id);
+        return;
+      }
+      syncToPrimarySet(this);
+      this.active_set_ids = [id];
+      this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
+      this.classes_unsaved_changes = false;
+    },
+
+    /**
+     * Set multiple active sets (combined in priority order).
+     * The first ID in the list is the primary set (edits go here).
+     */
+    setActiveSets(this: State, ids: string[]) {
+      syncToPrimarySet(this);
+      this.active_set_ids = ids;
+      this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
+      this.classes_unsaved_changes = true;
+    },
+
+    /**
+     * Rename a category set.
+     */
+    renameSet(this: State, oldId: string, newId: string) {
+      if (newId === oldId) return;
+      if (this.category_sets.find(s => s.id === newId)) {
+        console.warn('A set with that name already exists:', newId);
+        return;
+      }
+      const set = this.category_sets.find(s => s.id === oldId);
+      if (!set) {
+        console.warn('Category set not found:', oldId);
+        return;
+      }
+      set.id = newId;
+      this.active_set_ids = this.active_set_ids.map(id => (id === oldId ? newId : id));
+      this.classes_unsaved_changes = true;
+    },
+
+    // ── Legacy mutations (operate on the effective `classes` list) ───────────
 
     // mutations
     import(this: State, classes: Category[]) {
@@ -212,10 +344,7 @@ export const useCategoryStore = defineStore('categories', {
       this.classes_unsaved_changes = true;
     },
     restoreDefaultClasses(this: State) {
-      let i = 0;
-      this.classes = createMissingParents(defaultCategories).map(c =>
-        Object.assign(c, { id: i++ })
-      );
+      this.classes = assignIds(createMissingParents(defaultCategories));
       this.classes_unsaved_changes = true;
     },
     clearAll(this: State) {

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -64,9 +64,19 @@ function computeEffectiveClasses(categorySets: CategorySet[], activeSetIds: stri
   return assignIds(createMissingParents(merged));
 }
 
-/** Copy current effective classes back into the primary active set (no-op if no sets). */
+/**
+ * Copy current effective classes back into the primary active set.
+ *
+ * Only safe when exactly one set is active: with multiple sets `state.classes`
+ * is the merged result of all active sets and cannot be split back into
+ * individual sets, so we skip the sync to avoid corrupting secondary sets.
+ */
 function syncToPrimarySet(state: State) {
   if (state.active_set_ids.length === 0 || state.category_sets.length === 0) return;
+  // Skip when multiple sets are active — state.classes is a merged result
+  // and writing it back to only the primary set would absorb all secondary
+  // sets' categories into it (data corruption).
+  if (state.active_set_ids.length > 1) return;
   const primaryId = state.active_set_ids[0];
   const primarySet = state.category_sets.find(s => s.id === primaryId);
   if (primarySet) {
@@ -251,6 +261,18 @@ export const useCategoryStore = defineStore('categories', {
       }
       syncToPrimarySet(this);
       this.active_set_ids = [id];
+      this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
+      this.classes_unsaved_changes = false;
+    },
+
+    /**
+     * Discard unsaved in-memory edits and recompute classes from the stored sets.
+     *
+     * Call this before switchToSet() when the user explicitly chooses to discard
+     * changes. Without this, switchToSet() would call syncToPrimarySet() first —
+     * writing the discarded edits back into the set's in-memory state.
+     */
+    discardChanges(this: State) {
       this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
       this.classes_unsaved_changes = false;
     },

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import {
   saveClasses,
-  loadClasses,
   saveCategories,
   loadCategories,
   cleanCategory,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import moment, { Moment } from 'moment';
 import { getClient } from '~/util/awclient';
-import { Category, defaultCategories, cleanCategory } from '~/util/classes';
+import { Category, CategorySet, defaultCategories, cleanCategory } from '~/util/classes';
 import { View, defaultViews } from '~/stores/views';
 import { isEqual } from 'lodash';
 
@@ -37,6 +37,11 @@ interface State {
   };
   always_active_pattern: string;
   classes: Category[];
+  // Named category sets — each set is an independent collection of category rules.
+  // The active_set_ids list controls which sets are combined (in priority order).
+  category_sets: CategorySet[];
+  // Ordered list of active set IDs. First entry has highest priority when merging.
+  active_set_ids: string[];
   views: View[];
 
   // Whether to show certain WIP features
@@ -75,6 +80,8 @@ export const useSettingsStore = defineStore('settings', {
 
     always_active_pattern: '',
     classes: defaultCategories,
+    category_sets: [],
+    active_set_ids: ['default'],
     views: defaultViews,
 
     // Developer settings
@@ -125,7 +132,13 @@ export const useSettingsStore = defineStore('settings', {
         //console.debug(`${locstr} ${key}:`, value);
 
         // Keys ending with 'Data' are JSON-serialized objects in localStorage
-        if ((key.endsWith('Data') || key == 'views' || key == 'classes') && !set_in_server) {
+        const isJsonKey =
+          key.endsWith('Data') ||
+          key == 'views' ||
+          key == 'classes' ||
+          key == 'category_sets' ||
+          key == 'active_set_ids';
+        if (isJsonKey && !set_in_server) {
           try {
             value = JSON.parse(value);
             // Needed due to https://github.com/ActivityWatch/activitywatch/issues/1067

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -24,6 +24,31 @@ export interface Category {
   children?: Category[];
 }
 
+export interface CategorySet {
+  id: string;
+  categories: Category[];
+}
+
+/**
+ * Merge multiple category sets in priority order (first set = highest priority).
+ * When the same category name appears in multiple sets, the first occurrence wins.
+ * Within each set, the standard specificity rule applies (deeper category wins).
+ */
+export function mergeCategorySets(sets: CategorySet[]): Category[] {
+  const seen = new Set<string>();
+  const merged: Category[] = [];
+  for (const set of sets) {
+    for (const cat of set.categories) {
+      const key = JSON.stringify(cat.name);
+      if (!seen.has(key)) {
+        seen.add(key);
+        merged.push(cat);
+      }
+    }
+  }
+  return merged;
+}
+
 const COLOR_UNCAT = '#CCC';
 
 // The default categories
@@ -196,6 +221,48 @@ export function cleanCategory(cat: Category): Category {
 export function loadClasses(): Category[] {
   const settingsStore = useSettingsStore();
   return settingsStore.classes;
+}
+
+/**
+ * Persist category sets and active set IDs to the settings store.
+ * Also updates the legacy `classes` field for backwards compatibility with external readers.
+ */
+export function saveCategories(sets: CategorySet[], activeIds: string[]) {
+  if (areWeTesting()) {
+    console.log('Not saving categories in test mode');
+    return;
+  }
+  const settingsStore = useSettingsStore();
+  const cleanSets = sets.map(s => ({ ...s, categories: s.categories.map(cleanCategory) }));
+  const effectiveClasses = mergeCategorySets(sets.filter(s => activeIds.includes(s.id))).map(
+    cleanCategory
+  );
+  settingsStore.update({
+    category_sets: cleanSets,
+    active_set_ids: activeIds,
+    classes: effectiveClasses,
+  });
+}
+
+/**
+ * Load category sets and active set IDs from the settings store.
+ * Falls back to the legacy flat `classes` setting if no sets are defined yet.
+ */
+export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
+  const settingsStore = useSettingsStore();
+  const sets: CategorySet[] = settingsStore.category_sets;
+  const activeIds: string[] = settingsStore.active_set_ids;
+
+  if (sets && sets.length > 0) {
+    return { sets, activeIds: activeIds && activeIds.length > 0 ? activeIds : [sets[0].id] };
+  }
+
+  // Migration path: no sets defined yet — wrap the existing flat classes into a "default" set
+  const legacyClasses = settingsStore.classes || defaultCategories;
+  return {
+    sets: [{ id: 'default', categories: legacyClasses }],
+    activeIds: ['default'],
+  };
 }
 
 function pickDeepest(categories: Category[]) {

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -146,10 +146,10 @@ export default {
     exportClasses: async function () {
       console.log('Exporting categories...');
 
-      // Export the active set with its ID — suitable for re-importing as a named set
+      // Export the active set with its ID — suitable for re-importing as a named set.
+      // Use classes_clean (current in-memory state) so unsaved edits are included.
       const activeSetId = this.categoryStore.active_set_ids[0] || 'default';
-      const activeSet = this.categoryStore.category_sets.find(s => s.id === activeSetId);
-      const export_data = activeSet || { id: activeSetId, categories: this.categoryStore.classes };
+      const export_data = { id: activeSetId, categories: this.categoryStore.classes_clean };
       const text = JSON.stringify(export_data, null, 2);
       await downloadFile(`aw-category-export-${export_data.id}.json`, text, 'application/json');
     },
@@ -184,10 +184,19 @@ export default {
         const existing = this.categoryStore.category_sets.find(s => s.id === setId);
         if (existing) {
           existing.categories = import_obj.categories;
+          // If importing into the active set, don't call switchToSet — it would call
+          // syncToPrimarySet first and overwrite the just-imported categories with
+          // stale in-memory classes. Use discardChanges to recompute from the updated set.
+          const isActiveSet = setId === (this.categoryStore.active_set_ids[0] || '');
+          if (isActiveSet) {
+            this.categoryStore.discardChanges();
+          } else {
+            this.categoryStore.switchToSet(setId);
+          }
         } else {
           this.categoryStore.category_sets.push({ id: setId, categories: import_obj.categories });
+          this.categoryStore.switchToSet(setId);
         }
-        this.categoryStore.switchToSet(setId);
         this.categoryStore.classes_unsaved_changes = true;
       } else {
         console.error('Unrecognized import format');

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -18,6 +18,38 @@ div
     | You can also find and share categorization rule presets on #[a(href="https://forum.activitywatch.net/c/projects/category-rules") the forum].
     | For help on how to write categorization rules, see #[a(href="https://docs.activitywatch.net/en/latest/features/categorization.html") the documentation].
 
+  // Category set switcher
+  div.my-3.p-3(style="background: var(--bs-light, #f8f9fa); border-radius: 4px;")
+    div.d-flex.align-items-center.flex-wrap(style="gap: 0.5rem;")
+      span.font-weight-bold(style="white-space: nowrap") Category set:
+      b-select(
+        v-model="activeSetId"
+        @change="onSetChange"
+        style="max-width: 220px"
+        size="sm"
+      )
+        b-select-option(
+          v-for="set in categoryStore.category_sets"
+          :key="set.id"
+          :value="set.id"
+        ) {{ set.id }}
+      b-btn(
+        @click="createSet"
+        variant="outline-primary"
+        size="sm"
+      ) New set
+      b-btn(
+        v-if="categoryStore.category_sets.length > 1"
+        @click="deleteActiveSet"
+        variant="outline-danger"
+        size="sm"
+      ) Delete set
+    div.mt-1(
+      v-if="categoryStore.category_sets.length > 1"
+      style="font-size: 0.85em; color: var(--bs-secondary, #6c757d);"
+    )
+      | {{ categoryStore.category_sets.length }} sets available — switch sets to use different rule profiles.
+
   div.my-4
     b-alert(variant="warning" :show="classes_unsaved_changes")
       | You have unsaved changes!
@@ -61,10 +93,21 @@ export default {
   data: () => ({
     categoryStore: useCategoryStore(),
     editingId: null,
+    activeSetId: 'default',
   }),
   computed: {
     ...mapState(useCategoryStore, ['classes_unsaved_changes']),
     ...mapGetters(useCategoryStore, ['classes_hierarchy']),
+  },
+  watch: {
+    'categoryStore.active_set_ids': {
+      handler(newIds: string[]) {
+        if (newIds && newIds.length > 0) {
+          this.activeSetId = newIds[0];
+        }
+      },
+      immediate: true,
+    },
   },
   mounted() {
     this.categoryStore.load();
@@ -103,11 +146,12 @@ export default {
     exportClasses: async function () {
       console.log('Exporting categories...');
 
-      const export_data = {
-        categories: this.categoryStore.classes,
-      };
+      // Export the active set with its ID — suitable for re-importing as a named set
+      const activeSetId = this.categoryStore.active_set_ids[0] || 'default';
+      const activeSet = this.categoryStore.category_sets.find(s => s.id === activeSetId);
+      const export_data = activeSet || { id: activeSetId, categories: this.categoryStore.classes };
       const text = JSON.stringify(export_data, null, 2);
-      await downloadFile('aw-category-export.json', text, 'application/json');
+      await downloadFile(`aw-category-export-${export_data.id}.json`, text, 'application/json');
     },
     importCategories: async function (elem) {
       console.log('Importing categories...');
@@ -123,8 +167,59 @@ export default {
       const text = await file.text();
       const import_obj = JSON.parse(text);
 
-      // Set import to categories as unsaved changes
-      this.categoryStore.import(import_obj.categories);
+      if (import_obj.categories && !import_obj.id) {
+        // Legacy format: flat categories array — import into the active set
+        this.categoryStore.import(import_obj.categories);
+      } else if (import_obj.id && import_obj.categories) {
+        // New CategorySet format — create or overwrite set with same ID
+        let setId = import_obj.id;
+        while (
+          this.categoryStore.category_sets.find(
+            s => s.id === setId && s.id !== (this.categoryStore.active_set_ids[0] || '')
+          )
+        ) {
+          // Avoid duplicate IDs (except if overwriting the active set)
+          setId = setId + '-imported';
+        }
+        const existing = this.categoryStore.category_sets.find(s => s.id === setId);
+        if (existing) {
+          existing.categories = import_obj.categories;
+        } else {
+          this.categoryStore.category_sets.push({ id: setId, categories: import_obj.categories });
+        }
+        this.categoryStore.switchToSet(setId);
+        this.categoryStore.classes_unsaved_changes = true;
+      } else {
+        console.error('Unrecognized import format');
+      }
+    },
+    createSet: function () {
+      const name = prompt('Name for the new category set:');
+      if (!name) return;
+      if (this.categoryStore.category_sets.find(s => s.id === name)) {
+        alert(`A set named "${name}" already exists.`);
+        return;
+      }
+      // Create the new set and switch to it (switchToSet syncs current state first)
+      this.categoryStore.createSet(name);
+      this.categoryStore.switchToSet(name);
+    },
+    deleteActiveSet: function () {
+      const id = this.categoryStore.active_set_ids[0];
+      if (!id) return;
+      if (!confirm(`Delete category set "${id}"? This cannot be undone.`)) return;
+      this.categoryStore.deleteSet(id);
+      this.categoryStore.save();
+    },
+    onSetChange: function (setId: string) {
+      if (this.classes_unsaved_changes) {
+        if (!confirm('You have unsaved changes. Switch sets anyway? (Changes will be discarded)')) {
+          // Revert the select back to current active
+          this.activeSetId = this.categoryStore.active_set_ids[0] || 'default';
+          return;
+        }
+      }
+      this.categoryStore.switchToSet(setId);
     },
     beforeUnload: function (e) {
       if (this.classes_unsaved_changes) {

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -218,6 +218,10 @@ export default {
           this.activeSetId = this.categoryStore.active_set_ids[0] || 'default';
           return;
         }
+        // User confirmed discard: reset in-memory edits before switching so that
+        // switchToSet() → syncToPrimarySet() writes back the original (clean) state,
+        // not the unsaved edits the user just chose to discard.
+        this.categoryStore.discardChanges();
       }
       this.categoryStore.switchToSet(setId);
     },


### PR DESCRIPTION
Picks up ActivityWatch/aw-webui#369 (Erik's 2022 WIP) and extends it with an updated data model and a complete implementation against the current codebase.

## What changed since #369

The codebase has evolved significantly since 2022: `classes` is now stored in the settings store (which syncs to aw-server) rather than directly in `localStorage`. This PR adapts the design accordingly.

## What's new

**`src/util/classes.ts`**
- `CategorySet` type: `{ id: string; categories: Category[] }`
- `mergeCategorySets(sets)`: merges sets in priority order (first = highest priority); more specific rules still win within a set — set order only breaks ties at equal specificity
- `saveCategories` / `loadCategories`: persist sets + active IDs to the settings store, keeping the legacy `classes` field in sync for backwards compatibility with external readers

**`src/stores/settings.ts`**
- New fields: `category_sets: CategorySet[]` + `active_set_ids: string[]`, persisted alongside the existing `classes` field

**`src/stores/categories.ts`**
- Full CRUD for sets: `createSet`, `deleteSet`, `switchToSet`, `setActiveSets`, `renameSet`
- `classes` always reflects the merged effective categories from all active sets
- Migration path: on first load with no sets defined, existing `classes` are wrapped in a `"default"` set automatically
- `save()` syncs current edits back to the primary active set before persisting all sets

**`src/views/settings/CategorizationSettings.vue`**
- Set switcher dropdown above the category editor
- "New set" and "Delete set" buttons
- Export now uses `{ id, categories }` format (with set ID in filename); import handles both legacy `{ categories }` and new `{ id, categories }` formats

## Design decisions

- **`active_set_ids: string[]`** (not a single string) — the data model already supports combining multiple sets in priority order; this PR's UI exposes single-set switching. Multi-set combining UI can follow as a small incremental change.
- **Backwards compatible**: the legacy `classes` field in the settings store is always kept in sync, so external tools reading settings are unaffected.
- **Single-set editing**: edits always go to the primary active set. When multiple sets are active (future UI), edits go to the first set in the priority list.

## Tests

All 43 tests that ran on master still pass. The 3 test suite failures (`categories.test`, `activity.test`, `views.test`) are pre-existing — they fail with `vueDemi.hasInjectionContext is not a function`, unrelated to this PR.

Closes / supersedes #369