### PR TITLE
feat(auth): bootstrap API token from URL/session

### DIFF
--- a/src/util/awclient.ts
+++ b/src/util/awclient.ts
@@ -1,4 +1,5 @@
 import { AWClient } from 'aw-client';
+import type { AxiosInstance } from 'axios';
 
 import { useSettingsStore } from '~/stores/settings';
 
@@ -55,6 +56,10 @@ export function stripApiTokenFromCurrentUrl(): void {
   window.history.replaceState(window.history.state, '', nextUrl || '/');
 }
 
+// NOTE: The token is visible in window.location.href from page load until this
+// function executes.  In the intended WebView/launcher environment no third-party
+// scripts run, so the exposure window is acceptable.  For general browser use,
+// consider passing the credential via the URL fragment instead of a query param.
 export function loadApiTokenFromBrowser(): string | null {
   if (typeof window === 'undefined') {
     return null;
@@ -70,8 +75,9 @@ export function loadApiTokenFromBrowser(): string | null {
   return getStoredApiToken();
 }
 
-export function applyApiToken(client: { req: { defaults: any } }, token: string | null): void {
-  const headers = client.req.defaults.headers || {};
+export function applyApiToken(client: { req: AxiosInstance }, token: string | null): void {
+  const defaults = client.req.defaults;
+  const headers = (defaults.headers as Record<string, Record<string, unknown>>) || {};
   const commonHeaders = headers.common || {};
 
   if (token) {
@@ -81,7 +87,7 @@ export function applyApiToken(client: { req: { defaults: any } }, token: string 
   }
 
   headers.common = commonHeaders;
-  client.req.defaults.headers = headers;
+  defaults.headers = headers as typeof defaults.headers;
 }
 
 export function createClient(force?: boolean): AWClient {

--- a/src/util/awclient.ts
+++ b/src/util/awclient.ts
@@ -2,7 +2,87 @@ import { AWClient } from 'aw-client';
 
 import { useSettingsStore } from '~/stores/settings';
 
+const API_TOKEN_QUERY_PARAM = 'token';
+const API_TOKEN_STORAGE_KEY = 'aw-api-token';
+
 let _client: AWClient | null;
+
+function normalizeToken(token: string | null): string | null {
+  if (!token) {
+    return null;
+  }
+
+  const trimmed = token.trim();
+  return trimmed ? trimmed : null;
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+
+  return sessionStorage;
+}
+
+export function getStoredApiToken(): string | null {
+  return normalizeToken(getSessionStorage()?.getItem(API_TOKEN_STORAGE_KEY) ?? null);
+}
+
+export function getApiTokenFromLocation(currentLocation: Pick<Location, 'search'>): string | null {
+  if (typeof URLSearchParams === 'undefined') {
+    return null;
+  }
+
+  return normalizeToken(new URLSearchParams(currentLocation.search).get(API_TOKEN_QUERY_PARAM));
+}
+
+function persistApiToken(token: string): void {
+  getSessionStorage()?.setItem(API_TOKEN_STORAGE_KEY, token);
+}
+
+export function stripApiTokenFromCurrentUrl(): void {
+  if (typeof window === 'undefined' || typeof history === 'undefined') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(API_TOKEN_QUERY_PARAM)) {
+    return;
+  }
+
+  url.searchParams.delete(API_TOKEN_QUERY_PARAM);
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState(window.history.state, '', nextUrl || '/');
+}
+
+export function loadApiTokenFromBrowser(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const urlToken = getApiTokenFromLocation(window.location);
+  if (urlToken) {
+    persistApiToken(urlToken);
+    stripApiTokenFromCurrentUrl();
+    return urlToken;
+  }
+
+  return getStoredApiToken();
+}
+
+export function applyApiToken(client: { req: { defaults: any } }, token: string | null): void {
+  const headers = client.req.defaults.headers || {};
+  const commonHeaders = headers.common || {};
+
+  if (token) {
+    commonHeaders.Authorization = `Bearer ${token}`;
+  } else {
+    delete commonHeaders.Authorization;
+  }
+
+  headers.common = commonHeaders;
+  client.req.defaults.headers = headers;
+}
 
 export function createClient(force?: boolean): AWClient {
   let baseURL = '';
@@ -21,6 +101,7 @@ export function createClient(force?: boolean): AWClient {
       testing: !production,
       baseURL,
     });
+    applyApiToken(_client, loadApiTokenFromBrowser());
   } else {
     throw 'Tried to instantiate global AWClient twice!';
   }

--- a/test/unit/awclient.test.js
+++ b/test/unit/awclient.test.js
@@ -10,18 +10,15 @@ jest.mock('aw-client', () => ({
   })),
 }));
 
-import { AWClient } from 'aw-client';
-
-import {
-  createClient,
-  getApiTokenFromLocation,
-  getStoredApiToken,
-  loadApiTokenFromBrowser,
-} from '~/util/awclient';
-
 describe('awclient auth bootstrap', () => {
-  beforeEach(() => {
-    AWClient.mockClear();
+  let AWClient;
+  let createClient, getApiTokenFromLocation, getStoredApiToken, loadApiTokenFromBrowser;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    ({ AWClient } = await import('aw-client'));
+    ({ createClient, getApiTokenFromLocation, getStoredApiToken, loadApiTokenFromBrowser } =
+      await import('~/util/awclient'));
     sessionStorage.clear();
     window.history.replaceState({}, '', '/');
   });

--- a/test/unit/awclient.test.js
+++ b/test/unit/awclient.test.js
@@ -1,0 +1,66 @@
+jest.mock('aw-client', () => ({
+  AWClient: jest.fn().mockImplementation(() => ({
+    req: {
+      defaults: {
+        headers: {
+          common: {},
+        },
+      },
+    },
+  })),
+}));
+
+import { AWClient } from 'aw-client';
+
+import {
+  createClient,
+  getApiTokenFromLocation,
+  getStoredApiToken,
+  loadApiTokenFromBrowser,
+} from '~/util/awclient';
+
+describe('awclient auth bootstrap', () => {
+  beforeEach(() => {
+    AWClient.mockClear();
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  test('reads token from the URL query string', () => {
+    expect(getApiTokenFromLocation({ search: '?token=secret&foo=bar' })).toBe('secret');
+    expect(getApiTokenFromLocation({ search: '?token=   ' })).toBeNull();
+    expect(getApiTokenFromLocation({ search: '?foo=bar' })).toBeNull();
+  });
+
+  test('loads token from URL, stores it for the tab, and strips it from the address bar', () => {
+    window.history.replaceState({}, '', '/settings?token=secret&foo=bar#hash');
+
+    expect(loadApiTokenFromBrowser()).toBe('secret');
+    expect(getStoredApiToken()).toBe('secret');
+    expect(window.location.pathname).toBe('/settings');
+    expect(window.location.search).toBe('?foo=bar');
+    expect(window.location.hash).toBe('#hash');
+  });
+
+  test('falls back to the stored token when the URL has none', () => {
+    sessionStorage.setItem('aw-api-token', 'stored-secret');
+
+    expect(loadApiTokenFromBrowser()).toBe('stored-secret');
+  });
+
+  test('createClient applies the Bearer token to default request headers', () => {
+    window.history.replaceState({}, '', '/?token=secret');
+
+    const client = createClient(true);
+
+    expect(AWClient).toHaveBeenCalledWith(
+      'aw-webui',
+      expect.objectContaining({
+        baseURL: 'http://127.0.0.1:5666',
+        testing: true,
+      })
+    );
+    expect(client.req.defaults.headers.common.Authorization).toBe('Bearer secret');
+    expect(window.location.search).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- load `?token=...` from the browser URL into tab-scoped `sessionStorage`
- strip the token from the address bar after bootstrap while preserving other query params and hash
- apply `Authorization: Bearer ...` to the shared aw-webui client defaults
- add regression tests for URL parsing, persistence, cleanup, and header injection

## Context
This is the remaining aw-webui piece of the ActivityWatch API auth rollout discussed in ActivityWatch/activitywatch#1199. It makes browser access work when a launcher/WebView opens aw-webui with a tokenized URL.

## Testing
- `npx eslint --ext=js,ts src/util/awclient.ts test/unit/awclient.test.js`
- `npx jest --runInBand --runTestsByPath test/unit/awclient.test.js test/unit/NewReleaseNotification.test.js test/unit/store/activity.test.node.ts`
- `npx tsc --noEmit --pretty false`