### PR TITLE
fix(query-options): prefer known hosts over unknown defaults

### DIFF
--- a/src/components/QueryOptions.vue
+++ b/src/components/QueryOptions.vue
@@ -17,6 +17,7 @@ div
 import Vue from 'vue';
 import moment from 'moment';
 import { useBucketsStore } from '~/stores/buckets';
+import { preferKnownHostnames } from '~/util/hostnames';
 
 export default Vue.extend({
   name: 'QueryOptions',
@@ -40,7 +41,7 @@ export default Vue.extend({
 
   computed: {
     hostnameChoices() {
-      return this.bucketsStore.hosts;
+      return preferKnownHostnames(this.bucketsStore.hosts);
     },
   },
 

--- a/src/util/hostnames.ts
+++ b/src/util/hostnames.ts
@@ -1,0 +1,6 @@
+export function preferKnownHostnames(hosts: string[]): string[] {
+  const knownHosts = hosts.filter(host => host !== 'unknown');
+  return knownHosts.length > 0
+    ? [...knownHosts, ...hosts.filter(host => host === 'unknown')]
+    : hosts;
+}

--- a/test/unit/hostnames.test.node.ts
+++ b/test/unit/hostnames.test.node.ts
@@ -1,0 +1,19 @@
+import { preferKnownHostnames } from '~/util/hostnames';
+
+describe('preferKnownHostnames', () => {
+  test('moves unknown to the end when a known host exists', () => {
+    expect(preferKnownHostnames(['unknown', 'laptop_ori'])).toEqual(['laptop_ori', 'unknown']);
+  });
+
+  test('preserves the original order for known hosts', () => {
+    expect(preferKnownHostnames(['desktop', 'laptop', 'unknown'])).toEqual([
+      'desktop',
+      'laptop',
+      'unknown',
+    ]);
+  });
+
+  test('keeps unknown when it is the only host', () => {
+    expect(preferKnownHostnames(['unknown'])).toEqual(['unknown']);
+  });
+});


### PR DESCRIPTION
## Summary
- prefer known hosts over `unknown` in the shared QueryOptions hostname chooser
- keep `unknown` available as a fallback option when it is the only host
- add a regression test for the hostname ordering helper

## Root cause
`QueryOptions` defaulted to `hostnameChoices[0]`, and `bucketsStore.hosts` can legitimately put `unknown` first when a special bucket like `aw-stopwatch` was updated more recently than the real window/AFK buckets.

That meant Category Builder could start with `queryOptions.hostname = "unknown"` already set, which bypassed its existing "if hostname is blank, pick a non-unknown host" fallback and led to synthesized queries like `aw-watcher-window_unknown`.

## Testing
- `npm test -- --runInBand test/unit/hostnames.test.node.ts test/unit/queries.test.node.js`

Refs ActivityWatch/activitywatch#1214
