### PR TITLE
fix(search): fix TypeError when extending search range by a week

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -38,7 +38,7 @@ div
     div
       | Didn't find what you were looking for?
       br
-      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="start = start.subtract(1, 'week'); search()") +1 week]
+      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="addWeek()") +1 week]
 </template>
 
 <script lang="ts">
@@ -70,6 +70,10 @@ export default {
     };
   },
   methods: {
+    addWeek: function () {
+      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week').format('YYYY-MM-DD');
+      this.search();
+    },
     search: async function () {
       let query = canonicalEvents({
         bid_window: 'aw-watcher-window_' + this.queryOptions.hostname,

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -71,7 +71,7 @@ export default {
   },
   methods: {
     addWeek: function () {
-      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week').format('YYYY-MM-DD');
+      this.queryOptions.start = moment(this.queryOptions.start, 'YYYY-MM-DD').subtract(1, 'week').format('YYYY-MM-DD');
       this.search();
     },
     search: async function () {


### PR DESCRIPTION
## Description
Fixes a crash on the Search page that occurred when clicking the "+1 week" button to expand the search scope. 

### The Problem
* The "+1 week" button's click handler was trying to call `.subtract()` on `start`, which was undefined (it should have been `queryOptions.start`).
* Even when pointing to `queryOptions.start`, it threw a `TypeError` because the date returned by the `b-form-datepicker` is a formatted string, not a `moment` object.

### The Solution
* Created a dedicated `addWeek()` method.
* The method correctly parses the `queryOptions.start` string into a `moment` object, subtracts 1 week, formats it back to `'YYYY-MM-DD'`, and then triggers the `search()` function.
Fixes #817 

https://github.com/user-attachments/assets/e73cc96e-a1d4-4c79-9ec7-e141d37644f5

