### PR TITLE
fix(views): use queryOptions.start for +1 week button (closes #817)

### DIFF
--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -56,7 +56,7 @@ div
     div
       | Didn't find what you were looking for?
       br
-      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="start = start.subtract(1, 'week'); search()") +1 week]
+      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="extendByWeek()") +1 week]
 </template>
 
 <style scoped lang="scss"></style>
@@ -208,6 +208,10 @@ export default {
 
       console.log('generated nodes & links');
       return { nodes, links };
+    },
+    extendByWeek() {
+      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.generate();
     },
   },
 };

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -71,7 +71,7 @@ div
     div
       | Didn't find what you were looking for?
       br
-      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="start = start.subtract(1, 'week'); search()") +1 week]
+      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="extendByWeek()") +1 week]
 
 </template>
 
@@ -175,6 +175,11 @@ export default {
         columns: ['timestamp', 'duration', 'category', 'app', 'title'],
       });
       await downloadFile('events.csv', csv, 'text/csv');
+    },
+
+    extendByWeek() {
+      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.generate();
     },
   },
 };

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -96,7 +96,7 @@ export default {
         this.status = null;
       }
     },
-    extendByWeek: function () {
+    extendByWeek() {
       this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
       this.search();
     },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -38,7 +38,7 @@ div
     div
       | Didn't find what you were looking for?
       br
-      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="start = start.subtract(1, 'week'); search()") +1 week]
+      | Add a week to the search: #[b-button(size="sm" variant="outline-dark" @click="extendByWeek()") +1 week]
 </template>
 
 <script lang="ts">
@@ -95,6 +95,10 @@ export default {
       } finally {
         this.status = null;
       }
+    },
+    extendByWeek: function () {
+      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.search();
     },
   },
 };


### PR DESCRIPTION
## Summary

Fixes the \`TypeError: Cannot read properties of undefined (reading 'subtract')\` reported in #817 when clicking the **+1 week** button on the Search page (and also affects the Report and Graph views).

## Root cause

The button's inline expression was:

\`\`\`pug
@click=\"start = start.subtract(1, 'week'); search()\"
\`\`\`

But \`start\` is not a top-level data field — it lives at \`queryOptions.start\`. Clicking the button accessed an undefined identifier and threw immediately. @realsudarshan diagnosed this exactly in the issue.

## Fix

Replace the inline expression with an \`extendByWeek()\` method per affected view:

\`\`\`js
extendByWeek() {
  this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
  this.generate(); // or this.search() in Search.vue
}
\`\`\`

The extra \`moment(...)\` wrapper handles the case where \`queryOptions.start\` was emitted by the QueryOptions datepicker as a \`YYYY-MM-DD\` string (it would otherwise still throw on subsequent clicks even after fixing the identifier).

## Affected views

- \`src/views/Search.vue\` (the one in the bug report) — calls \`search()\`
- \`src/views/Report.vue\` (same pattern, calls \`generate()\`)
- \`src/views/Graph.vue\` (same pattern, calls \`generate()\`)

## Verification

- \`npm run lint\` — passes (only pre-existing warnings in vite.config.js / vue.config.js)
- \`npm test\` — 14 suites / 61 tests passing
- Build/manual click-test still recommended; the moment-wrapped subtract handles both the moment-object initial state and the date-string state from the datepicker.

Closes #817.