### PR TITLE
fix(timeline): wrap long bucket labels on narrow screens

### DIFF
--- a/src/util/timelineLabels.ts
+++ b/src/util/timelineLabels.ts
@@ -8,6 +8,8 @@ function escapeHtml(str: string): string {
 }
 
 function addWrapOpportunities(str: string): string {
+  // `str` must already be HTML-escaped because those entities contain no `_`, `/`,
+  // or `-`, so the inserted <wbr> tags can't split them.
   return str.replace(/([/_-])/g, '$1<wbr>');
 }
 

--- a/src/util/timelineLabels.ts
+++ b/src/util/timelineLabels.ts
@@ -1,0 +1,25 @@
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function addWrapOpportunities(str: string): string {
+  return str.replace(/([/_-])/g, '$1<wbr>');
+}
+
+export function formatTimelineBucketLabelHtml(bucketId: string): string {
+  const escaped = escapeHtml(bucketId);
+  const syncMatch = bucketId.match(/^([^_]+)_.*-synced-from-(.+)$/);
+
+  if (syncMatch) {
+    const baseLabel = addWrapOpportunities(escapeHtml(syncMatch[1]));
+    const remoteLabel = addWrapOpportunities(escapeHtml(syncMatch[2]));
+    return `<span class="timeline-label" title="${escaped}">${baseLabel} (synced from ${remoteLabel})</span>`;
+  }
+
+  return `<span class="timeline-label" title="${escaped}">${addWrapOpportunities(escaped)}</span>`;
+}

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -30,9 +30,11 @@ div#visualization {
 
   .vis-labelset .vis-label .vis-inner {
     max-width: 250px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow: visible;
+    text-overflow: initial;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    line-height: 1.2;
   }
 
   .timeline-timeline {
@@ -57,6 +59,7 @@ import { buildTooltip } from '../util/tooltip.js';
 import { getCategoryColorFromEvent, getTitleAttr } from '../util/color';
 import { getSwimlane } from '../util/swimlane.js';
 import { IEvent } from '../util/interfaces';
+import { formatTimelineBucketLabelHtml } from '../util/timelineLabels';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
@@ -237,25 +240,10 @@ export default {
         alert('selected multiple items: ' + JSON.stringify(properties.items));
       }
     },
-    escapeHtml(str: string): string {
-      return str
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-    },
     abbreviateBucketName(bucketId: string): string {
       // Abbreviate synced bucket names which can be extremely long (#682)
       // e.g. "aw-watcher-window_host-synced-from-remotehost" -> "aw-watcher-window (synced from remotehost)"
-      const escaped = this.escapeHtml(bucketId);
-      const syncMatch = bucketId.match(/^([^_]+)_.*-synced-from-(.+)$/);
-      if (syncMatch) {
-        return `<span title="${escaped}">${this.escapeHtml(
-          syncMatch[1]
-        )} (synced from ${this.escapeHtml(syncMatch[2])})</span>`;
-      }
-      return `<span title="${escaped}">${escaped}</span>`;
+      return formatTimelineBucketLabelHtml(bucketId);
     },
     ensureUpdate() {
       // Will only run update() if data available and never ran before

--- a/test/unit/timelineLabels.test.node.ts
+++ b/test/unit/timelineLabels.test.node.ts
@@ -1,0 +1,21 @@
+import { formatTimelineBucketLabelHtml } from '~/util/timelineLabels';
+
+describe('formatTimelineBucketLabelHtml', () => {
+  test('adds wrap opportunities for long bucket names', () => {
+    expect(formatTimelineBucketLabelHtml('aw-watcher-window_host')).toBe(
+      '<span class="timeline-label" title="aw-watcher-window_host">aw-<wbr>watcher-<wbr>window_<wbr>host</span>'
+    );
+  });
+
+  test('abbreviates synced bucket names and preserves wrap opportunities', () => {
+    expect(formatTimelineBucketLabelHtml('aw-watcher-window_host-synced-from-remote-host')).toBe(
+      '<span class="timeline-label" title="aw-watcher-window_host-synced-from-remote-host">aw-<wbr>watcher-<wbr>window (synced from remote-<wbr>host)</span>'
+    );
+  });
+
+  test('escapes HTML before inserting wrap opportunities', () => {
+    expect(formatTimelineBucketLabelHtml('bucket<script>')).toBe(
+      '<span class="timeline-label" title="bucket&lt;script&gt;">bucket&lt;script&gt;</span>'
+    );
+  });
+});

--- a/test/unit/timelineLabels.test.node.ts
+++ b/test/unit/timelineLabels.test.node.ts
@@ -13,6 +13,12 @@ describe('formatTimelineBucketLabelHtml', () => {
     );
   });
 
+  test('adds wrap opportunities for slash-separated bucket names', () => {
+    expect(formatTimelineBucketLabelHtml('aw-watcher-window/host/session')).toBe(
+      '<span class="timeline-label" title="aw-watcher-window/host/session">aw-<wbr>watcher-<wbr>window/<wbr>host/<wbr>session</span>'
+    );
+  });
+
   test('escapes HTML before inserting wrap opportunities', () => {
     expect(formatTimelineBucketLabelHtml('bucket<script>')).toBe(
       '<span class="timeline-label" title="bucket&lt;script&gt;">bucket&lt;script&gt;</span>'


### PR DESCRIPTION
## Summary
- allow vis timeline row labels to wrap instead of forcing ellipsis
- insert `<wbr>` break opportunities into long bucket labels while preserving HTML escaping
- cover the formatter with a small unit test

## Why
Timeline row labels currently force `white-space: nowrap`, which makes long bucket names unreadable on narrow layouts. This is the concrete label-wrapping bug from ActivityWatch/activitywatch#1243, and it should also help the Android-too-small complaint in ActivityWatch/activitywatch#1303.

## Testing
- `npx eslint --ext .vue,.ts src/visualizations/VisTimeline.vue src/util/timelineLabels.ts test/unit/timelineLabels.test.node.ts`
- `npx jest --config jest.config.cjs --selectProjects=node --runTestsByPath test/unit/timelineLabels.test.node.ts --runInBand`

## Notes
- I started a full `npm run build`, but stopped waiting on the repo's existing slow webpack/Sass pipeline once lint and the targeted regression test were green. The build output showed existing Sass deprecation spam, not a failure from this patch.
