### PR TITLE
fix(timeline): localize chart date labels

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -6,6 +6,10 @@ function getStartOfDayOffset() {
   return settingsStore.startOfDay;
 }
 
+function normalize_date(dateParam: Date | string) {
+  return dateParam instanceof Date ? new Date(dateParam.getTime()) : new Date(dateParam);
+}
+
 export function seconds_to_duration(seconds: number) {
   // Returns a human-readable duration string
   const hrs = Math.floor(seconds / 60 / 60);
@@ -93,4 +97,18 @@ export function get_today_with_offset(offset?: string): string {
   // Gets "today" in an offset-aware way
   const offset_dur = get_offset_duration(offset);
   return moment().subtract(offset_dur).startOf('day').format('YYYY-MM-DD');
+}
+
+export function format_weekday_short(dateParam: Date | string, locale?: string | string[]) {
+  return new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(normalize_date(dateParam));
+}
+
+export function format_month_day(dateParam: Date | string, locale?: string | string[]) {
+  return new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(normalize_date(dateParam));
+}
+
+export function get_short_month_labels(locale?: string | string[]) {
+  return Array.from({ length: 12 }, (_, month) =>
+    new Intl.DateTimeFormat(locale, { month: 'short' }).format(new Date(2020, month, 1, 12))
+  );
 }

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -6,8 +6,8 @@ function getStartOfDayOffset() {
   return settingsStore.startOfDay;
 }
 
-function normalize_date(dateParam: Date | string) {
-  return dateParam instanceof Date ? new Date(dateParam.getTime()) : new Date(dateParam);
+function normalize_date(dateParam: Date) {
+  return new Date(dateParam.getTime());
 }
 
 export function seconds_to_duration(seconds: number) {
@@ -99,11 +99,11 @@ export function get_today_with_offset(offset?: string): string {
   return moment().subtract(offset_dur).startOf('day').format('YYYY-MM-DD');
 }
 
-export function format_weekday_short(dateParam: Date | string, locale?: string | string[]) {
+export function format_weekday_short(dateParam: Date, locale?: string | string[]) {
   return new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(normalize_date(dateParam));
 }
 
-export function format_month_day(dateParam: Date | string, locale?: string | string[]) {
+export function format_day_of_month(dateParam: Date, locale?: string | string[]) {
   return new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(normalize_date(dateParam));
 }
 

--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -13,7 +13,12 @@ import _ from 'lodash';
 import { ChartOptions } from 'chart.js';
 import 'chart.js/auto';
 import { Bar } from 'vue-chartjs/legacy';
-import { get_hour_offset } from '~/util/time';
+import {
+  format_month_day,
+  format_weekday_short,
+  get_hour_offset,
+  get_short_month_labels,
+} from '~/util/time';
 
 function hourToTick(hours: number): string {
   if (hours > 1) {
@@ -65,29 +70,20 @@ export default {
         // Look up days of the week from `start`
         return _.range(7).map(d => {
           const date = new Date(start);
+          date.setHours(12, 0, 0, 0);
           date.setDate(date.getDate() + d);
-          return date.toLocaleDateString('en-US', { weekday: 'short' });
+          return format_weekday_short(date);
         });
       } else if (resolution.startsWith('month')) {
         // FIXME: Needs access to the timeperiod start to know which month
         // How many days are in the given month?
         const date = new Date(start);
         const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
-        const ordinalsEnUS = {
-          one: 'st',
-          two: 'nd',
-          few: 'rd',
-          many: 'th',
-          zero: 'th',
-          other: 'th',
-        };
-        const toOrdinalSuffix = (num: number, locale = 'en-US', ordinals = ordinalsEnUS) => {
-          const pluralRules = new Intl.PluralRules(locale, { type: 'ordinal' });
-          return `${num}${ordinals[pluralRules.select(num)]}`;
-        };
-        return _.range(1, daysInMonth + 1).map(d => toOrdinalSuffix(d));
+        return _.range(1, daysInMonth + 1).map(d =>
+          format_month_day(new Date(date.getFullYear(), date.getMonth(), d, 12))
+        );
       } else if (resolution == 'year') {
-        return ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return get_short_month_labels();
       } else {
         console.error(`Invalid resolution: ${resolution}`);
         return [];

--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -14,7 +14,7 @@ import { ChartOptions } from 'chart.js';
 import 'chart.js/auto';
 import { Bar } from 'vue-chartjs/legacy';
 import {
-  format_month_day,
+  format_day_of_month,
   format_weekday_short,
   get_hour_offset,
   get_short_month_labels,
@@ -80,7 +80,7 @@ export default {
         const date = new Date(start);
         const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
         return _.range(1, daysInMonth + 1).map(d =>
-          format_month_day(new Date(date.getFullYear(), date.getMonth(), d, 12))
+          format_day_of_month(new Date(date.getFullYear(), date.getMonth(), d, 12))
         );
       } else if (resolution == 'year') {
         return get_short_month_labels();

--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -1,4 +1,9 @@
-import { seconds_to_duration } from '~/util/time';
+import {
+  format_month_day,
+  format_weekday_short,
+  get_short_month_labels,
+  seconds_to_duration,
+} from '~/util/time';
 
 describe('seconds_to_duration', () => {
   test('should format 8145 seconds as "2h 15m 45s"', () => {
@@ -23,5 +28,40 @@ describe('seconds_to_duration', () => {
 
   test('should format 30 seconds as "30s"', () => {
     expect(seconds_to_duration(30)).toBe('30s');
+  });
+});
+
+describe('locale-aware time labels', () => {
+  test('should format weekday labels using the supplied locale', () => {
+    const monday = new Date(2026, 4, 18, 12);
+
+    expect(format_weekday_short(monday, 'en-US')).toBe(
+      new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(monday)
+    );
+    expect(format_weekday_short(monday, 'sv-SE')).toBe(
+      new Intl.DateTimeFormat('sv-SE', { weekday: 'short' }).format(monday)
+    );
+    expect(format_weekday_short(monday, 'sv-SE')).not.toBe(format_weekday_short(monday, 'en-US'));
+  });
+
+  test('should format month-day labels without hardcoded english ordinals', () => {
+    expect(format_month_day(new Date(2026, 4, 1, 12), 'en-US')).toBe('1');
+  });
+
+  test('should format short month labels using the supplied locale', () => {
+    const enUSMonths = get_short_month_labels('en-US');
+    const svSEMonths = get_short_month_labels('sv-SE');
+
+    expect(enUSMonths).toEqual(
+      Array.from({ length: 12 }, (_, month) =>
+        new Intl.DateTimeFormat('en-US', { month: 'short' }).format(new Date(2020, month, 1, 12))
+      )
+    );
+    expect(svSEMonths).toEqual(
+      Array.from({ length: 12 }, (_, month) =>
+        new Intl.DateTimeFormat('sv-SE', { month: 'short' }).format(new Date(2020, month, 1, 12))
+      )
+    );
+    expect(svSEMonths).not.toEqual(enUSMonths);
   });
 });

--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -1,5 +1,5 @@
 import {
-  format_month_day,
+  format_day_of_month,
   format_weekday_short,
   get_short_month_labels,
   seconds_to_duration,
@@ -45,7 +45,7 @@ describe('locale-aware time labels', () => {
   });
 
   test('should format month-day labels without hardcoded english ordinals', () => {
-    expect(format_month_day(new Date(2026, 4, 1, 12), 'en-US')).toBe('1');
+    expect(format_day_of_month(new Date(2026, 4, 1, 12), 'en-US')).toBe('1');
   });
 
   test('should format short month labels using the supplied locale', () => {


### PR DESCRIPTION
## Summary
- remove hardcoded English weekday and month labels from `TimelineBarChart`
- use locale-aware helpers for weekly, monthly, and yearly chart labels
- cover the new helpers with a focused unit test

## Testing
- `npm test -- --runInBand test/unit/time.test.js`

## Context
This fixes the locale inconsistency reported in `ActivityWatch/aw-server-rust#602`. The UI lives in `aw-webui`, so I am landing the frontend change here first and linking the parent issue back to this PR.