### PR TITLE
fix: remove deprecated keyboard option from vis-timeline

### DIFF
--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -105,12 +105,8 @@ export default {
           overflowMethod: 'flip',
           delay: 0,
         },
-        // Keyboard & scroll navigation (see #629)
+        // Horizontal scroll navigation (see #629)
         horizontalScroll: true, // horizontal scroll/swipe pans the timeline
-        keyboard: {
-          enabled: true,
-          speed: { x: 10, y: 0, zoom: 0.02 },
-        },
       },
       editingEvent: null,
       editingEventBucket: null,


### PR DESCRIPTION
vis-timeline v7 dropped the `keyboard` configuration option (it was part of the original vis.js library). Passing it triggers a console warning:

```
Unknown option detected: "keyboard". Did you mean "end"?
```

This shows up as an error in the Raw Data view — reported in ActivityWatch/aw-server-rust#603.

The fix just removes the `keyboard` block from `VisTimeline.vue` options. `horizontalScroll` is kept since it's still a valid vis-timeline v7 option.