### PR TITLE
fix(ci): repair dependabot automation

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -25,6 +25,6 @@ jobs:
       github.actor == 'dependabot[bot]'
 
     steps:
-      - uses: ridedott/merge-me-action@v2
+      - uses: ridedott/merge-me-action@2568f177a681785a874d6e7af950eb1a0dd31123
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-merge
 
-# NOTE: This workflow relies on a Personal Access Token from the @ActivityWatchBot user
-#       See this issue for details: https://github.com/ridedott/merge-me-action/issues/1581
+# Use the repository-scoped GitHub Actions token instead of an external PAT.
+# The workflow-level permissions below grant the merge action the access it needs.
 
 on:
   workflow_run:
@@ -13,15 +13,18 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   auto_merge:
     name: Auto-merge
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.actor == 'dependabot[bot]'
 
     steps:
       - uses: ridedott/merge-me-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26584,9 +26584,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,6 @@
     },
     "postcss": "^8.5.10",
     "serialize-javascript": "^7.0.5",
-    "webpack-dev-server": "^5.2.1"
+    "webpack-dev-server": "^5.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- bump the existing `webpack-dev-server` override from `^5.2.1` to `^5.2.4` and refresh the lockfile
- switch Dependabot auto-merge off the stale `AWBOT_GH_TOKEN` secret to the repo `GITHUB_TOKEN`
- restrict auto-merge to successful `pull_request` workflow runs and grant `pull-requests: write`

## Verification
- `npm ci`
- `npm run build`
- `timeout 20s npm run serve` (startup reached the dev-server compile phase before timeout)
- `npm audit --json --omit=optional | jq .vulnerabilities["webpack-dev-server"], .vulnerabilities["webpack-dev-middleware"]`
- `npm test -- --runInBand`