### PR TITLE
feat: add saved query presets to Query Explorer

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -12,6 +12,8 @@ function jsonEq(a: any, b: any) {
   return isEqual(jsonA, jsonB);
 }
 
+let settingsLoadPromise: Promise<void> | null = null;
+
 // Backoffs for NewReleaseNotification
 export const SHORT_BACKOFF_PERIOD = 24 * 60 * 60;
 export const LONG_BACKOFF_PERIOD = 5 * 24 * 60 * 60;
@@ -105,9 +107,17 @@ export const useSettingsStore = defineStore('settings', {
 
   actions: {
     async ensureLoaded() {
-      if (!this.loaded) {
-        await this.load();
+      if (this.loaded) {
+        return;
       }
+
+      if (!settingsLoadPromise) {
+        settingsLoadPromise = this.load().finally(() => {
+          settingsLoadPromise = null;
+        });
+      }
+
+      await settingsLoadPromise;
     },
     async load({ save }: { save?: boolean } = {}) {
       if (typeof localStorage === 'undefined') {
@@ -230,6 +240,7 @@ export const useSettingsStore = defineStore('settings', {
     },
     async update(new_state: Record<string, any>) {
       console.log('Updating state', new_state);
+      await this.ensureLoaded();
       this.$patch(new_state);
       await this.save();
     },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import moment, { Moment } from 'moment';
 import { getClient } from '~/util/awclient';
 import { Category, CategorySet, defaultCategories, cleanCategory } from '~/util/classes';
+import { SavedQuery } from '~/util/savedQueries';
 import { View, defaultViews } from '~/stores/views';
 import { isEqual } from 'lodash';
 
@@ -43,6 +44,7 @@ interface State {
   // Ordered list of active set IDs. First entry has highest priority when merging.
   active_set_ids: string[];
   views: View[];
+  saved_queries: SavedQuery[];
 
   // Whether to show certain WIP features
   devmode: boolean;
@@ -83,6 +85,7 @@ export const useSettingsStore = defineStore('settings', {
     category_sets: [],
     active_set_ids: ['default'],
     views: defaultViews,
+    saved_queries: [],
 
     // Developer settings
     // NOTE: PRODUCTION might be undefined (in tests, for example)
@@ -141,7 +144,8 @@ export const useSettingsStore = defineStore('settings', {
           key == 'views' ||
           key == 'classes' ||
           key == 'category_sets' ||
-          key == 'active_set_ids';
+          key == 'active_set_ids' ||
+          key == 'saved_queries';
         try {
           if (isJsonKey) {
             let parsed = JSON.parse(raw);

--- a/src/util/savedQueries.ts
+++ b/src/util/savedQueries.ts
@@ -36,8 +36,8 @@ export function buildSavedQuery({
     id,
     name: name.trim(),
     query_code,
-    start_offset: reference.diff(moment(startdate).startOf('day'), 'hours'),
-    end_offset: reference.diff(moment(enddate).startOf('day'), 'hours'),
+    start_offset: reference.diff(moment(startdate).startOf('day'), 'days'),
+    end_offset: reference.diff(moment(enddate).startOf('day'), 'days'),
     event_type,
   };
 }
@@ -45,11 +45,11 @@ export function buildSavedQuery({
 export function resolveSavedQueryDates(savedQuery: SavedQuery, now: Moment | string = moment()) {
   const reference = referenceDay(now);
   const startOffset = savedQuery.start_offset ?? 0;
-  const endOffset = savedQuery.end_offset ?? -24;
+  const endOffset = savedQuery.end_offset ?? -1;
 
   return {
-    startdate: moment(reference).subtract(startOffset, 'hours').format('YYYY-MM-DD'),
-    enddate: moment(reference).subtract(endOffset, 'hours').format('YYYY-MM-DD'),
+    startdate: moment(reference).subtract(startOffset, 'days').format('YYYY-MM-DD'),
+    enddate: moment(reference).subtract(endOffset, 'days').format('YYYY-MM-DD'),
   };
 }
 

--- a/src/util/savedQueries.ts
+++ b/src/util/savedQueries.ts
@@ -1,0 +1,89 @@
+import moment, { Moment } from 'moment';
+
+export interface SavedQuery {
+  id: string;
+  name: string;
+  query_code: string;
+  start_offset?: number;
+  end_offset?: number;
+  event_type?: string;
+}
+
+function referenceDay(now: Moment | string = moment()) {
+  return moment(now).startOf('day');
+}
+
+export function buildSavedQuery({
+  id,
+  name,
+  query_code,
+  startdate,
+  enddate,
+  event_type,
+  now = moment(),
+}: {
+  id: string;
+  name: string;
+  query_code: string;
+  startdate: string;
+  enddate: string;
+  event_type?: string;
+  now?: Moment | string;
+}): SavedQuery {
+  const reference = referenceDay(now);
+
+  return {
+    id,
+    name: name.trim(),
+    query_code,
+    start_offset: reference.diff(moment(startdate).startOf('day'), 'hours'),
+    end_offset: reference.diff(moment(enddate).startOf('day'), 'hours'),
+    event_type,
+  };
+}
+
+export function resolveSavedQueryDates(savedQuery: SavedQuery, now: Moment | string = moment()) {
+  const reference = referenceDay(now);
+  const startOffset = savedQuery.start_offset ?? 0;
+  const endOffset = savedQuery.end_offset ?? -24;
+
+  return {
+    startdate: moment(reference).subtract(startOffset, 'hours').format('YYYY-MM-DD'),
+    enddate: moment(reference).subtract(endOffset, 'hours').format('YYYY-MM-DD'),
+  };
+}
+
+export function getDefaultSavedQueryName(queryCode: string, now: Moment | string = moment()) {
+  const firstLine = queryCode
+    .split('\n')
+    .map(line => line.trim())
+    .find(Boolean);
+
+  if (firstLine) {
+    return firstLine.slice(0, 60);
+  }
+
+  return `Query ${moment(now).format('YYYY-MM-DD')}`;
+}
+
+export function buildSavedQueryId(name: string, existingIds: string[] = []) {
+  const base =
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'saved-query';
+
+  let candidate = base;
+  let suffix = 2;
+  while (existingIds.includes(candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
+}
+
+export function sortSavedQueries(savedQueries: SavedQuery[]) {
+  return [...savedQueries].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+}

--- a/src/util/savedQueries.ts
+++ b/src/util/savedQueries.ts
@@ -4,6 +4,9 @@ export interface SavedQuery {
   id: string;
   name: string;
   query_code: string;
+  start_day_offset?: number;
+  end_day_offset?: number;
+  // Legacy hour-based offsets are kept as read-only fallbacks for already-saved presets.
   start_offset?: number;
   end_offset?: number;
   event_type?: string;
@@ -11,6 +14,20 @@ export interface SavedQuery {
 
 function referenceDay(now: Moment | string = moment()) {
   return moment(now).startOf('day');
+}
+
+function resolveDayOffset(
+  dayOffset: number | undefined,
+  legacyHourOffset: number | undefined,
+  defaultValue: number
+) {
+  if (dayOffset !== undefined) {
+    return dayOffset;
+  }
+  if (legacyHourOffset !== undefined) {
+    return Math.round(legacyHourOffset / 24);
+  }
+  return defaultValue;
 }
 
 export function buildSavedQuery({
@@ -36,16 +53,16 @@ export function buildSavedQuery({
     id,
     name: name.trim(),
     query_code,
-    start_offset: reference.diff(moment(startdate).startOf('day'), 'days'),
-    end_offset: reference.diff(moment(enddate).startOf('day'), 'days'),
+    start_day_offset: reference.diff(moment(startdate).startOf('day'), 'days'),
+    end_day_offset: reference.diff(moment(enddate).startOf('day'), 'days'),
     event_type,
   };
 }
 
 export function resolveSavedQueryDates(savedQuery: SavedQuery, now: Moment | string = moment()) {
   const reference = referenceDay(now);
-  const startOffset = savedQuery.start_offset ?? 0;
-  const endOffset = savedQuery.end_offset ?? -1;
+  const startOffset = resolveDayOffset(savedQuery.start_day_offset, savedQuery.start_offset, 0);
+  const endOffset = resolveDayOffset(savedQuery.end_day_offset, savedQuery.end_offset, -1);
 
   return {
     startdate: moment(reference).subtract(startOffset, 'days').format('YYYY-MM-DD'),

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -10,7 +10,22 @@ div
   div.alert.alert-danger(v-if="error")
     | {{error}}
 
+  div.alert.alert-danger(v-if="saved_query_error")
+    | {{saved_query_error}}
+
   form
+    div.form-row
+      div.form-group.col-lg-6
+        | Saved Queries
+        select.form-control(v-model="selected_saved_query_id", @change="loadSelectedQuery()")
+          option(value="") Select saved query...
+          option(v-for="savedQuery in savedQueries", :key="savedQuery.id", :value="savedQuery.id")
+            | {{savedQuery.name}}
+      div.form-group.col-lg-6.d-flex.align-items-end.flex-wrap
+        button.btn.btn-outline-primary.mr-2.mb-2(type="button", @click="saveCurrentQuery()") Save Current
+        button.btn.btn-outline-secondary.mr-2.mb-2(type="button", @click="renameSelectedQuery()", :disabled="!selected_saved_query_id") Rename
+        button.btn.btn-outline-danger.mb-2(type="button", @click="deleteSelectedQuery()", :disabled="!selected_saved_query_id") Delete
+
     div.form-row
       div.form-group.col-md-6
         | Start
@@ -38,6 +53,15 @@ div
 import moment from 'moment';
 import _ from 'lodash';
 import { useCategoryStore } from '~/stores/categories';
+import { useSettingsStore } from '~/stores/settings';
+import {
+  buildSavedQuery,
+  buildSavedQueryId,
+  getDefaultSavedQueryName,
+  resolveSavedQueryDates,
+  SavedQuery,
+  sortSavedQueries,
+} from '~/util/savedQueries';
 
 const today = moment().startOf('day');
 const tomorrow = moment(today).add(24, 'hours');
@@ -45,6 +69,8 @@ const tomorrow = moment(today).add(24, 'hours');
 export default {
   name: 'QueryExplorer',
   data() {
+    const settingsStore = useSettingsStore();
+
     // allow queries to be saved in a URL parameter
     let queryCode = this.$route.query.q;
 
@@ -60,26 +86,155 @@ RETURN = sort_by_duration(merged_events);
     }
 
     return {
+      settingsStore,
       query_code: queryCode,
       event_type: 'currentwindow',
       events: [],
       today: today.format(),
       tomorrow: tomorrow.format(),
       error: '',
+      saved_query_error: '',
+      selected_saved_query_id: '',
       startdate: today.format('YYYY-MM-DD'),
       enddate: tomorrow.format('YYYY-MM-DD'),
     };
   },
   computed: {
+    savedQueries: function (): SavedQuery[] {
+      return sortSavedQueries(this.settingsStore.saved_queries || []);
+    },
+    selectedSavedQuery: function (): SavedQuery | null {
+      return this.savedQueries.find(query => query.id === this.selected_saved_query_id) || null;
+    },
     eventcount_str: function () {
       if (Array.isArray(this.events)) return 'Number of events: ' + this.events.length;
       else return '';
     },
   },
-  mounted: function () {
+  mounted: async function () {
+    await this.settingsStore.ensureLoaded();
     useCategoryStore().load();
   },
   methods: {
+    persistSavedQueries: async function (savedQueries: SavedQuery[]) {
+      try {
+        this.saved_query_error = '';
+        await this.settingsStore.update({ saved_queries: sortSavedQueries(savedQueries) });
+        return true;
+      } catch (e) {
+        console.error('Failed to save query presets', e);
+        this.saved_query_error = 'Failed to save query presets.';
+        return false;
+      }
+    },
+    loadSelectedQuery: function () {
+      if (!this.selectedSavedQuery) {
+        return;
+      }
+
+      const { startdate, enddate } = resolveSavedQueryDates(this.selectedSavedQuery);
+      this.query_code = this.selectedSavedQuery.query_code;
+      this.event_type = this.selectedSavedQuery.event_type || 'currentwindow';
+      this.startdate = startdate;
+      this.enddate = enddate;
+      this.saved_query_error = '';
+    },
+    saveCurrentQuery: async function () {
+      const current = this.selectedSavedQuery;
+
+      if (current && confirm(`Update saved query "${current.name}"?`)) {
+        const updatedQuery = buildSavedQuery({
+          id: current.id,
+          name: current.name,
+          query_code: this.query_code,
+          startdate: this.startdate,
+          enddate: this.enddate,
+          event_type: this.event_type,
+        });
+
+        const didPersist = await this.persistSavedQueries(
+          this.savedQueries.map(savedQuery =>
+            savedQuery.id === current.id ? updatedQuery : savedQuery
+          )
+        );
+        if (didPersist) {
+          this.selected_saved_query_id = current.id;
+        }
+        return;
+      }
+
+      const defaultName = current?.name || getDefaultSavedQueryName(this.query_code);
+      const name = prompt('Name for the saved query:', defaultName);
+      if (name === null) {
+        return;
+      }
+
+      const trimmedName = name.trim();
+      if (_.isEmpty(trimmedName)) {
+        alert('Saved query name cannot be empty.');
+        return;
+      }
+
+      const newId = buildSavedQueryId(
+        trimmedName,
+        this.savedQueries.map(savedQuery => savedQuery.id)
+      );
+      const newQuery = buildSavedQuery({
+        id: newId,
+        name: trimmedName,
+        query_code: this.query_code,
+        startdate: this.startdate,
+        enddate: this.enddate,
+        event_type: this.event_type,
+      });
+
+      const didPersist = await this.persistSavedQueries([...this.savedQueries, newQuery]);
+      if (didPersist) {
+        this.selected_saved_query_id = newId;
+      }
+    },
+    renameSelectedQuery: async function () {
+      if (!this.selectedSavedQuery) {
+        return;
+      }
+
+      const name = prompt('Rename saved query:', this.selectedSavedQuery.name);
+      if (name === null) {
+        return;
+      }
+
+      const trimmedName = name.trim();
+      if (_.isEmpty(trimmedName)) {
+        alert('Saved query name cannot be empty.');
+        return;
+      }
+
+      await this.persistSavedQueries(
+        this.savedQueries.map(savedQuery =>
+          savedQuery.id === this.selectedSavedQuery.id
+            ? { ...savedQuery, name: trimmedName }
+            : savedQuery
+        )
+      );
+    },
+    deleteSelectedQuery: async function () {
+      if (!this.selectedSavedQuery) {
+        return;
+      }
+
+      if (
+        !confirm(`Delete saved query "${this.selectedSavedQuery.name}"? This cannot be undone.`)
+      ) {
+        return;
+      }
+
+      const didPersist = await this.persistSavedQueries(
+        this.savedQueries.filter(savedQuery => savedQuery.id !== this.selected_saved_query_id)
+      );
+      if (didPersist) {
+        this.selected_saved_query_id = '';
+      }
+    },
     query: async function () {
       let query = this.query_code;
 

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -142,7 +142,11 @@ RETURN = sort_by_duration(merged_events);
     saveCurrentQuery: async function () {
       const current = this.selectedSavedQuery;
 
-      if (current && confirm(`Update saved query "${current.name}"?`)) {
+      if (current) {
+        if (!confirm(`Update saved query "${current.name}"?`)) {
+          return;
+        }
+
         const updatedQuery = buildSavedQuery({
           id: current.id,
           name: current.name,

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -167,7 +167,7 @@ RETURN = sort_by_duration(merged_events);
         return;
       }
 
-      const defaultName = current?.name || getDefaultSavedQueryName(this.query_code);
+      const defaultName = getDefaultSavedQueryName(this.query_code);
       const name = prompt('Name for the saved query:', defaultName);
       if (name === null) {
         return;
@@ -213,11 +213,10 @@ RETURN = sort_by_duration(merged_events);
         return;
       }
 
+      const selectedQueryId = this.selectedSavedQuery.id;
       await this.persistSavedQueries(
         this.savedQueries.map(savedQuery =>
-          savedQuery.id === this.selectedSavedQuery.id
-            ? { ...savedQuery, name: trimmedName }
-            : savedQuery
+          savedQuery.id === selectedQueryId ? { ...savedQuery, name: trimmedName } : savedQuery
         )
       );
     },

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -14,17 +14,18 @@ div
     | {{saved_query_error}}
 
   form
-    div.form-row
+    div.form-row.align-items-end
       div.form-group.col-lg-6
-        | Saved Queries
-        select.form-control(v-model="selected_saved_query_id", @change="loadSelectedQuery()")
+        label.mb-1(for="saved-query-select") Saved Queries
+        select#saved-query-select.form-control(v-model="selected_saved_query_id", @change="loadSelectedQuery()")
           option(value="") Select saved query...
           option(v-for="savedQuery in savedQueries", :key="savedQuery.id", :value="savedQuery.id")
             | {{savedQuery.name}}
-      div.form-group.col-lg-6.d-flex.align-items-end.flex-wrap
-        button.btn.btn-outline-primary.mr-2.mb-2(type="button", @click="saveCurrentQuery()") Save Current
-        button.btn.btn-outline-secondary.mr-2.mb-2(type="button", @click="renameSelectedQuery()", :disabled="!selected_saved_query_id") Rename
-        button.btn.btn-outline-danger.mb-2(type="button", @click="deleteSelectedQuery()", :disabled="!selected_saved_query_id") Delete
+      div.form-group.col-lg-6
+        div.saved-query-actions
+          button.btn.btn-success.mr-2(type="button", @click="saveCurrentQuery()") Save Current
+          button.btn.btn-outline-secondary.mr-2(type="button", @click="renameSelectedQuery()", :disabled="!selected_saved_query_id") Rename
+          button.btn.btn-outline-danger(type="button", @click="deleteSelectedQuery()", :disabled="!selected_saved_query_id") Delete
 
     div.form-row
       div.form-group.col-md-6
@@ -47,7 +48,13 @@ div
   aw-selectable-eventview(:events="events", :event_type="event_type")
 </template>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.saved-query-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>
 
 <script lang="ts">
 import moment from 'moment';

--- a/test/unit/QueryExplorer.test.js
+++ b/test/unit/QueryExplorer.test.js
@@ -1,0 +1,36 @@
+import QueryExplorer from '~/views/QueryExplorer.vue';
+
+describe('QueryExplorer saved query actions', () => {
+  test('cancelling an update does not fall through to save-as-new', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue(null);
+    const persistSavedQueries = jest.fn();
+
+    const savedQuery = {
+      id: 'daily-coding-time',
+      name: 'Daily Coding Time',
+      query_code: 'RETURN = [];',
+      start_offset: 0,
+      end_offset: -1,
+      event_type: 'currentwindow',
+    };
+
+    const vm = {
+      selectedSavedQuery: savedQuery,
+      savedQueries: [savedQuery],
+      query_code: 'RETURN = [];',
+      startdate: '2026-05-20',
+      enddate: '2026-05-21',
+      event_type: 'currentwindow',
+      persistSavedQueries,
+      selected_saved_query_id: savedQuery.id,
+    };
+
+    await QueryExplorer.methods.saveCurrentQuery.call(vm);
+
+    expect(confirmSpy).toHaveBeenCalledWith('Update saved query "Daily Coding Time"?');
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(persistSavedQueries).not.toHaveBeenCalled();
+    expect(vm.selected_saved_query_id).toBe(savedQuery.id);
+  });
+});

--- a/test/unit/QueryExplorer.test.js
+++ b/test/unit/QueryExplorer.test.js
@@ -1,29 +1,36 @@
 import QueryExplorer from '~/views/QueryExplorer.vue';
 
-describe('QueryExplorer saved query actions', () => {
-  test('cancelling an update does not fall through to save-as-new', async () => {
+describe('QueryExplorer saveCurrentQuery', () => {
+  test('canceling an overwrite confirm aborts without opening the save-as-new prompt', async () => {
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
-    const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue(null);
+    const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue('Should not be used');
+
     const persistSavedQueries = jest.fn();
-
-    const savedQuery = {
-      id: 'daily-coding-time',
-      name: 'Daily Coding Time',
-      query_code: 'RETURN = [];',
-      start_offset: 0,
-      end_offset: -1,
-      event_type: 'currentwindow',
-    };
-
     const vm = {
-      selectedSavedQuery: savedQuery,
-      savedQueries: [savedQuery],
-      query_code: 'RETURN = [];',
-      startdate: '2026-05-20',
       enddate: '2026-05-21',
       event_type: 'currentwindow',
       persistSavedQueries,
-      selected_saved_query_id: savedQuery.id,
+      query_code: 'RETURN = [];',
+      savedQueries: [
+        {
+          id: 'daily-coding-time',
+          name: 'Daily Coding Time',
+          query_code: 'RETURN = [];',
+          start_day_offset: 0,
+          end_day_offset: -1,
+          event_type: 'currentwindow',
+        },
+      ],
+      selectedSavedQuery: {
+        id: 'daily-coding-time',
+        name: 'Daily Coding Time',
+        query_code: 'RETURN = [];',
+        start_day_offset: 0,
+        end_day_offset: -1,
+        event_type: 'currentwindow',
+      },
+      selected_saved_query_id: 'daily-coding-time',
+      startdate: '2026-05-20',
     };
 
     await QueryExplorer.methods.saveCurrentQuery.call(vm);
@@ -31,6 +38,8 @@ describe('QueryExplorer saved query actions', () => {
     expect(confirmSpy).toHaveBeenCalledWith('Update saved query "Daily Coding Time"?');
     expect(promptSpy).not.toHaveBeenCalled();
     expect(persistSavedQueries).not.toHaveBeenCalled();
-    expect(vm.selected_saved_query_id).toBe(savedQuery.id);
+
+    confirmSpy.mockRestore();
+    promptSpy.mockRestore();
   });
 });

--- a/test/unit/savedQueries.test.node.ts
+++ b/test/unit/savedQueries.test.node.ts
@@ -21,12 +21,26 @@ describe('saved query helpers', () => {
     });
 
     expect(savedQuery.start_offset).toBe(0);
-    expect(savedQuery.end_offset).toBe(-24);
+    expect(savedQuery.end_offset).toBe(-1);
 
     expect(resolveSavedQueryDates(savedQuery, moment('2026-05-27T08:00:00Z'))).toEqual({
       startdate: '2026-05-27',
       enddate: '2026-05-28',
     });
+  });
+
+  test('stores relative date offsets in days', () => {
+    const savedQuery = buildSavedQuery({
+      id: 'weekly-review',
+      name: 'Weekly Review',
+      query_code: 'RETURN = [];',
+      startdate: '2026-05-18',
+      enddate: '2026-05-21',
+      now: moment('2026-05-20T15:45:00Z'),
+    });
+
+    expect(savedQuery.start_offset).toBe(2);
+    expect(savedQuery.end_offset).toBe(-1);
   });
 
   test('slugifies and de-duplicates saved query ids', () => {
@@ -40,7 +54,7 @@ describe('saved query helpers', () => {
     expect(
       getDefaultSavedQueryName('\n  merged_events = merge_events();\nRETURN = merged_events;')
     ).toBe('merged_events = merge_events();');
-    expect(getDefaultSavedQueryName('   \n  ', moment('2026-05-20T00:00:00Z'))).toBe(
+    expect(getDefaultSavedQueryName('   \n  ', moment('2026-05-20T12:00:00'))).toBe(
       'Query 2026-05-20'
     );
   });

--- a/test/unit/savedQueries.test.node.ts
+++ b/test/unit/savedQueries.test.node.ts
@@ -1,0 +1,57 @@
+import moment from 'moment';
+
+import {
+  buildSavedQuery,
+  buildSavedQueryId,
+  getDefaultSavedQueryName,
+  resolveSavedQueryDates,
+  sortSavedQueries,
+} from '~/util/savedQueries';
+
+describe('saved query helpers', () => {
+  test('rebuilds relative dates from saved offsets', () => {
+    const savedQuery = buildSavedQuery({
+      id: 'daily-coding-time',
+      name: 'Daily Coding Time',
+      query_code: 'RETURN = [];',
+      startdate: '2026-05-20',
+      enddate: '2026-05-21',
+      event_type: 'currentwindow',
+      now: moment('2026-05-20T15:45:00Z'),
+    });
+
+    expect(savedQuery.start_offset).toBe(0);
+    expect(savedQuery.end_offset).toBe(-24);
+
+    expect(resolveSavedQueryDates(savedQuery, moment('2026-05-27T08:00:00Z'))).toEqual({
+      startdate: '2026-05-27',
+      enddate: '2026-05-28',
+    });
+  });
+
+  test('slugifies and de-duplicates saved query ids', () => {
+    expect(buildSavedQueryId('Daily Coding Time', ['daily-coding-time'])).toBe(
+      'daily-coding-time-2'
+    );
+    expect(buildSavedQueryId('!!!', [])).toBe('saved-query');
+  });
+
+  test('derives a default name from the first non-empty query line', () => {
+    expect(
+      getDefaultSavedQueryName('\n  merged_events = merge_events();\nRETURN = merged_events;')
+    ).toBe('merged_events = merge_events();');
+    expect(getDefaultSavedQueryName('   \n  ', moment('2026-05-20T00:00:00Z'))).toBe(
+      'Query 2026-05-20'
+    );
+  });
+
+  test('sorts saved queries by name and then id', () => {
+    expect(
+      sortSavedQueries([
+        { id: 'b', name: 'Work', query_code: '' },
+        { id: 'a', name: 'Work', query_code: '' },
+        { id: 'c', name: 'Browser', query_code: '' },
+      ]).map(query => query.id)
+    ).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/test/unit/savedQueries.test.node.ts
+++ b/test/unit/savedQueries.test.node.ts
@@ -17,13 +17,13 @@ describe('saved query helpers', () => {
       startdate: '2026-05-20',
       enddate: '2026-05-21',
       event_type: 'currentwindow',
-      now: moment('2026-05-20T15:45:00Z'),
+      now: moment('2026-05-20T12:00:00'),
     });
 
     expect(savedQuery.start_day_offset).toBe(0);
     expect(savedQuery.end_day_offset).toBe(-1);
 
-    expect(resolveSavedQueryDates(savedQuery, moment('2026-05-27T08:00:00Z'))).toEqual({
+    expect(resolveSavedQueryDates(savedQuery, moment('2026-05-27T12:00:00'))).toEqual({
       startdate: '2026-05-27',
       enddate: '2026-05-28',
     });
@@ -39,7 +39,7 @@ describe('saved query helpers', () => {
           start_offset: 0,
           end_offset: -23,
         },
-        moment('2026-05-27T08:00:00Z')
+        moment('2026-05-27T12:00:00')
       )
     ).toEqual({
       startdate: '2026-05-27',
@@ -54,7 +54,7 @@ describe('saved query helpers', () => {
       query_code: 'RETURN = [];',
       startdate: '2026-05-18',
       enddate: '2026-05-21',
-      now: moment('2026-05-20T15:45:00Z'),
+      now: moment('2026-05-20T12:00:00'),
     });
 
     expect(savedQuery.start_day_offset).toBe(2);

--- a/test/unit/savedQueries.test.node.ts
+++ b/test/unit/savedQueries.test.node.ts
@@ -20,10 +20,28 @@ describe('saved query helpers', () => {
       now: moment('2026-05-20T15:45:00Z'),
     });
 
-    expect(savedQuery.start_offset).toBe(0);
-    expect(savedQuery.end_offset).toBe(-1);
+    expect(savedQuery.start_day_offset).toBe(0);
+    expect(savedQuery.end_day_offset).toBe(-1);
 
     expect(resolveSavedQueryDates(savedQuery, moment('2026-05-27T08:00:00Z'))).toEqual({
+      startdate: '2026-05-27',
+      enddate: '2026-05-28',
+    });
+  });
+
+  test('rounds legacy hour offsets back to day offsets when loading older presets', () => {
+    expect(
+      resolveSavedQueryDates(
+        {
+          id: 'legacy-dst-query',
+          name: 'Legacy DST Query',
+          query_code: 'RETURN = [];',
+          start_offset: 0,
+          end_offset: -23,
+        },
+        moment('2026-05-27T08:00:00Z')
+      )
+    ).toEqual({
       startdate: '2026-05-27',
       enddate: '2026-05-28',
     });
@@ -39,8 +57,8 @@ describe('saved query helpers', () => {
       now: moment('2026-05-20T15:45:00Z'),
     });
 
-    expect(savedQuery.start_offset).toBe(2);
-    expect(savedQuery.end_offset).toBe(-1);
+    expect(savedQuery.start_day_offset).toBe(2);
+    expect(savedQuery.end_day_offset).toBe(-1);
   });
 
   test('slugifies and de-duplicates saved query ids', () => {

--- a/test/unit/store/settings.test.node.ts
+++ b/test/unit/store/settings.test.node.ts
@@ -1,0 +1,66 @@
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useSettingsStore } from '~/stores/settings';
+
+describe('settings store', () => {
+  setActivePinia(createPinia());
+  const settingsStore = useSettingsStore();
+
+  beforeEach(() => {
+    settingsStore.$reset();
+    jest.restoreAllMocks();
+  });
+
+  test('ensureLoaded coalesces concurrent loads', async () => {
+    let resolveLoad!: () => void;
+    const loadMock = jest.spyOn(settingsStore, 'load').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveLoad = () => {
+            settingsStore.$patch({ _loaded: true });
+            resolve();
+          };
+        })
+    );
+
+    const firstLoad = settingsStore.ensureLoaded();
+    const secondLoad = settingsStore.ensureLoaded();
+
+    expect(loadMock).toHaveBeenCalledTimes(1);
+
+    resolveLoad();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(settingsStore.loaded).toBe(true);
+  });
+
+  test('update waits for settings to load before patching state', async () => {
+    const savedQueries = [
+      {
+        id: 'daily-coding-time',
+        name: 'Daily Coding Time',
+        query_code: 'RETURN = [];',
+        start_day_offset: 0,
+        end_day_offset: -1,
+        event_type: 'currentwindow',
+      },
+    ];
+    const steps: string[] = [];
+
+    jest.spyOn(settingsStore, 'ensureLoaded').mockImplementation(async () => {
+      steps.push('ensureLoaded');
+      expect(settingsStore.saved_queries).toEqual([]);
+      settingsStore.$patch({ _loaded: true });
+    });
+
+    jest.spyOn(settingsStore, 'save').mockImplementation(async () => {
+      steps.push('save');
+      expect(settingsStore.saved_queries).toEqual(savedQueries);
+    });
+
+    await settingsStore.update({ saved_queries: savedQueries });
+
+    expect(steps).toEqual(['ensureLoaded', 'save']);
+    expect(settingsStore.saved_queries).toEqual(savedQueries);
+  });
+});


### PR DESCRIPTION
## Summary
- add server-backed saved query presets to the Query Explorer via the existing settings store
- support save, load, rename, and delete flows with relative date-range persistence
- add saved-query helper tests covering offset rebuilds, slug generation, and sorting

Closes #824.
