### PR TITLE
fix(vue3): remove dead vue-awesome imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@ckpack/vue-color": "^1.6.0",
         "@egjs/hammerjs": "^2.0.17",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-brands-svg-icons": "^7.2.0",
@@ -2120,6 +2121,31 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ckpack/vue-color": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@ckpack/vue-color/-/vue-color-1.6.0.tgz",
+      "integrity": "sha512-b9kFTKhYbNArfgP1lmnaVm0VNsWdZjqIbyHUYry7mZ+E7JeTQclbjq1+2xWn0SE3wzqRYlXmAVjECPOgteWmMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.6.0",
+        "material-colors": "^1.2.6"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -12680,6 +12706,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --ext .vue,.js,.ts src/"
   },
   "dependencies": {
+    "@ckpack/vue-color": "^1.6.0",
     "@egjs/hammerjs": "^2.0.17",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/src/components/BucketValidate.vue
+++ b/src/components/BucketValidate.vue
@@ -72,9 +72,6 @@ div
 </template>
 
 <script lang="ts">
-import 'vue-awesome/icons/check';
-import 'vue-awesome/icons/exclamation-triangle';
-import 'vue-awesome/icons/info-circle';
 import { getClient } from '~/util/awclient';
 import { overlappingEvents } from '~/util/transforms';
 import { friendlyduration } from '~/util/filters';

--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -57,8 +57,6 @@ import { useCategoryStore } from '~/stores/categories';
 import { mapState } from 'pinia';
 import { validateRegex, isRegexBroad } from '~/util/validate';
 
-import 'vue-awesome/icons/trash';
-
 export default {
   name: 'CategoryEditModal',
   components: {

--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -32,14 +32,6 @@ div
 </template>
 
 <script lang="ts">
-import 'vue-awesome/icons/regular/plus-square';
-import 'vue-awesome/icons/regular/minus-square';
-import 'vue-awesome/icons/circle';
-import 'vue-awesome/icons/caret-right';
-import 'vue-awesome/icons/trash';
-import 'vue-awesome/icons/plus';
-import 'vue-awesome/icons/edit';
-
 import CategoryEditModal from './CategoryEditModal.vue';
 import { useCategoryStore } from '~/stores/categories';
 

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -34,9 +34,7 @@ div
 
 <script lang="ts">
 // Based on https://codepen.io/Brownsugar/pen/NaGPKy
-import 'vue-awesome/icons/sync';
-
-import { Compact } from 'vue-color';
+import { Compact } from '@ckpack/vue-color';
 
 export default {
   components: {

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -14,7 +14,7 @@ div
         icon(name="sync" scale="1")
 
   div(style="position: relative")
-    picker(:value="colors" @input="updateFromPicker" v-if="displayPicker")
+    picker(:modelValue="colors" @update:modelValue="updateFromPicker" v-if="displayPicker")
 </template>
 
 <style>

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -57,9 +57,15 @@ export default {
         this.$emit('update:modelValue', val);
       }
     },
+    modelValue(val) {
+      const nextColor = val || '#000000';
+      if (nextColor !== this.colorValue) {
+        this.setColor(nextColor);
+      }
+    },
   },
   mounted() {
-    this.setColor(this.modelValue);
+    this.setColor(this.modelValue || '#000000');
   },
   methods: {
     setColor(color) {

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -40,7 +40,7 @@ export default {
   components: {
     picker: Compact,
   },
-  props: { value: { type: String, default: '#000000' } },
+  props: { modelValue: { type: String, default: '#000000' } },
   data() {
     return {
       colors: {
@@ -59,7 +59,7 @@ export default {
     },
   },
   mounted() {
-    this.setColor(this.value);
+    this.setColor(this.modelValue);
   },
   methods: {
     setColor(color) {

--- a/src/components/EventEditor.vue
+++ b/src/components/EventEditor.vue
@@ -64,10 +64,6 @@ b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEdit
 import moment from 'moment';
 import { friendlyduration } from '~/util/filters';
 
-import 'vue-awesome/icons/times';
-import 'vue-awesome/icons/save';
-import 'vue-awesome/icons/trash';
-
 export default {
   name: 'EventEditor',
   props: {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -39,13 +39,6 @@ div.container(style="color: #555; font-size: 0.9em")
 
 <script lang="ts">
 // only import the icons you use to reduce bundle size
-import 'vue-awesome/icons/brands/twitter';
-import 'vue-awesome/icons/brands/github';
-import 'vue-awesome/icons/hand-holding-heart';
-import 'vue-awesome/icons/vote-yea';
-import 'vue-awesome/icons/question-circle';
-import 'vue-awesome/icons/bug';
-import 'vue-awesome/icons/heart';
 
 import { mapState } from 'pinia';
 import { useServerStore } from '~/stores/server';

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -97,28 +97,9 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
 
 <script lang="ts">
 // only import the icons you use to reduce bundle size
-import 'vue-awesome/icons/calendar-day';
-import 'vue-awesome/icons/calendar-week';
-import 'vue-awesome/icons/stream';
-import 'vue-awesome/icons/database';
-import 'vue-awesome/icons/search';
-import 'vue-awesome/icons/code';
-import 'vue-awesome/icons/chart-line'; // TODO: switch to chart-column, when vue-awesome supports FA v6
-import 'vue-awesome/icons/chart-pie';
-import 'vue-awesome/icons/flag-checkered';
-import 'vue-awesome/icons/stopwatch';
-import 'vue-awesome/icons/cog';
-import 'vue-awesome/icons/tools';
-import 'vue-awesome/icons/history';
 
 // TODO: use circle-nodes instead in the future
-import 'vue-awesome/icons/project-diagram';
 //import 'vue-awesome/icons/cicle-nodes';
-
-import 'vue-awesome/icons/ellipsis-h';
-
-import 'vue-awesome/icons/mobile';
-import 'vue-awesome/icons/desktop';
 
 import _ from 'lodash';
 

--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -75,7 +75,6 @@ div
 <script lang="ts">
 import moment from 'moment';
 import { friendlytime } from '../util/filters';
-import 'vue-awesome/icons/sync';
 export default {
   name: 'input-timeinterval',
   props: {

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -113,9 +113,6 @@ div
 
 <script lang="ts">
 import _ from 'lodash';
-import 'vue-awesome/icons/cog';
-import 'vue-awesome/icons/times';
-import 'vue-awesome/icons/bars';
 
 import { buildBarchartDataset } from '~/util/datasets';
 

--- a/src/components/StopwatchEntry.vue
+++ b/src/components/StopwatchEntry.vue
@@ -31,9 +31,6 @@ div
 
 <script lang="ts">
 import moment from 'moment';
-import 'vue-awesome/icons/edit';
-import 'vue-awesome/icons/stop';
-import 'vue-awesome/icons/play';
 
 import EventEditor from './EventEditor.vue';
 import { friendlyduration, friendlytime, shorttime } from '~/util/filters';

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -59,11 +59,6 @@ import _ from 'lodash';
 import moment from 'moment';
 import { canonicalEvents } from '~/queries';
 
-import 'vue-awesome/icons/plus';
-import 'vue-awesome/icons/check';
-import 'vue-awesome/icons/times';
-import 'vue-awesome/icons/trash';
-
 import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
 import { friendlyduration } from '~/util/filters';

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -144,14 +144,6 @@ div
 </style>
 
 <script lang="ts">
-import 'vue-awesome/icons/trash';
-import 'vue-awesome/icons/download';
-import 'vue-awesome/icons/folder-open';
-import 'vue-awesome/icons/desktop';
-import 'vue-awesome/icons/mobile';
-import 'vue-awesome/icons/question';
-import 'vue-awesome/icons/exclamation-triangle';
-
 import { defineAsyncComponent } from 'vue';
 import _ from 'lodash';
 import Papa from 'papaparse';

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -66,11 +66,6 @@ import { defineAsyncComponent } from 'vue';
 import _ from 'lodash';
 import moment from 'moment';
 
-import 'vue-awesome/icons/search';
-import 'vue-awesome/icons/spinner';
-import 'vue-awesome/icons/angle-double-down';
-import 'vue-awesome/icons/angle-double-up';
-
 import { canonicalEvents } from '~/queries';
 
 import { useCategoryStore } from '~/stores/categories';

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -82,11 +82,6 @@ import _ from 'lodash';
 import moment from 'moment';
 import Papa from 'papaparse';
 
-import 'vue-awesome/icons/search';
-import 'vue-awesome/icons/spinner';
-import 'vue-awesome/icons/angle-double-down';
-import 'vue-awesome/icons/angle-double-up';
-
 import { canonicalEvents } from '~/queries';
 import { buildBarchartDataset } from '~/util/datasets';
 

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -46,11 +46,6 @@ import _ from 'lodash';
 import moment from 'moment';
 import { canonicalEvents } from '~/queries';
 
-import 'vue-awesome/icons/search';
-import 'vue-awesome/icons/spinner';
-import 'vue-awesome/icons/angle-double-down';
-import 'vue-awesome/icons/angle-double-up';
-
 export default {
   name: 'Search',
   data() {

--- a/src/views/Stopwatch.vue
+++ b/src/views/Stopwatch.vue
@@ -59,8 +59,6 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import StopwatchEntry from '../components/StopwatchEntry.vue';
-import 'vue-awesome/icons/play';
-import 'vue-awesome/icons/trash';
 
 export default {
   name: 'Stopwatch',

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -156,16 +156,6 @@ import { periodLengthConvertMoment } from '~/util/timeperiod';
 import { friendlyperiod, friendlyduration } from '~/util/filters';
 import _ from 'lodash';
 
-import 'vue-awesome/icons/arrow-left';
-import 'vue-awesome/icons/arrow-right';
-import 'vue-awesome/icons/sync';
-import 'vue-awesome/icons/plus';
-import 'vue-awesome/icons/edit';
-import 'vue-awesome/icons/times';
-import 'vue-awesome/icons/save';
-import 'vue-awesome/icons/question-circle';
-import 'vue-awesome/icons/filter';
-
 import { useSettingsStore } from '~/stores/settings';
 import { useCategoryStore } from '~/stores/categories';
 import { useActivityStore, QueryOptions } from '~/stores/activity';

--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -32,11 +32,6 @@ div(v-if="view")
 </template>
 
 <script lang="ts">
-import 'vue-awesome/icons/save';
-import 'vue-awesome/icons/times';
-import 'vue-awesome/icons/trash';
-import 'vue-awesome/icons/undo';
-
 import { mapState } from 'pinia';
 import draggable from 'vuedraggable';
 

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -43,7 +43,6 @@ div
 import { mapState, mapGetters } from 'pinia';
 import CategoryEditTree from '~/components/CategoryEditTree.vue';
 import CategoryEditModal from '~/components/CategoryEditModal.vue';
-import 'vue-awesome/icons/undo';
 
 import { useCategoryStore } from '~/stores/categories';
 

--- a/src/visualizations/CategoryTree.vue
+++ b/src/visualizations/CategoryTree.vue
@@ -33,9 +33,6 @@ div(style="font-size: 0.9em")
 </style>
 
 <script lang="ts">
-import 'vue-awesome/icons/circle';
-import 'vue-awesome/icons/regular/plus-square';
-import 'vue-awesome/icons/regular/minus-square';
 import _ from 'lodash';
 import { friendlyduration } from '~/util/filters';
 import { build_category_hierarchy, flatten_category_hierarchy } from '../util/classes.ts';

--- a/src/visualizations/EventList.vue
+++ b/src/visualizations/EventList.vue
@@ -115,11 +115,6 @@ $border-color: #ddd;
 </style>
 
 <script lang="ts">
-import 'vue-awesome/icons/edit';
-import 'vue-awesome/icons/tags';
-import 'vue-awesome/icons/clock';
-import 'vue-awesome/icons/calendar';
-
 import EventEditor from '~/components/EventEditor.vue';
 import { friendlytime, friendlyduration } from '~/util/filters';
 

--- a/src/visualizations/Summary.vue
+++ b/src/visualizations/Summary.vue
@@ -22,8 +22,6 @@ div
 //       Code should generally go in the framework-independent file.
 
 import summary from './summary';
-import 'vue-awesome/icons/angle-double-down';
-import 'vue-awesome/icons/angle-double-up';
 
 export default {
   name: 'aw-summary',


### PR DESCRIPTION
## Summary
- remove the stale `vue-awesome/icons/*` side-effect imports left behind on the `vue3` branch
- switch `ColorPicker.vue` from removed `vue-color` to `@ckpack/vue-color`
- keep the existing Font Awesome compatibility shim as the icon surface, so the old `<icon name="...">` call sites continue to render

## Why
Phase 1 (`#773`) moved the branch to Vue 3, but this slice still couldn't build cleanly because components were importing packages that the branch had already removed.

This is a bounded Phase 2 step, not the whole migration.

## Verification
- `npm run lint`
- `npm run build`

Refs ActivityWatch/aw-webui#772
