### PR TITLE
fix(ci): skip unused setup-cml Vega install

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: iterative/setup-cml@v3
+      with:
+        vega: false
 
     # Doesn't work for fetching artifacts from separate workflows
     #- name: Download screenshots


### PR DESCRIPTION
## Summary
- set `vega: false` on `iterative/setup-cml@v3` in the screenshot comment workflow
- skip setup-cml's optional Vega/canvas global npm install
- keep `cml publish` and `cml comment create` available for screenshot comments

## Why
The failing master run shows `setup-cml@v3` trying to install `canvas@2.11.2` under Node ABI v127 (Node 22). That prebuilt binary does not exist, so setup-cml falls back to a native build and dies on missing `pixman-1`.

This workflow does not use Vega tooling; it only needs CML for screenshot publishing and commit comments. Disabling Vega removes the brittle optional dependency instead of pinning around it.