### PR TITLE
fix(ui): replace <wbr> with zero-width space in timeline labels, move bulk-delete to dropdown

### DIFF
--- a/src/util/timelineLabels.ts
+++ b/src/util/timelineLabels.ts
@@ -8,9 +8,10 @@ function escapeHtml(str: string): string {
 }
 
 function addWrapOpportunities(str: string): string {
-  // `str` must already be HTML-escaped because those entities contain no `_`, `/`,
-  // or `-`, so the inserted <wbr> tags can't split them.
-  return str.replace(/([/_-])/g, '$1<wbr>');
+  // Insert zero-width space after word-breaking characters so the label
+  // breaks at natural boundaries without HTML <wbr> tags (vis-timeline
+  // does not support <wbr> in group label content).
+  return str.replace(/([/_-])/g, '$1\u200B');
 }
 
 export function formatTimelineBucketLabelHtml(bucketId: string): string {

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -34,12 +34,18 @@ div
                      :title="device.first_seen")
                   | {{ device.first_seen | friendlytime }}
         div
-          b-button(size="sm",
-                   variant="outline-danger",
-                   :title="`Delete all ${device.buckets.length} buckets for ${device.hostname}`",
-                   @click="openDeleteHostModal(device)")
-            icon(name="trash")
-            |  Delete all buckets for this host
+          b-dropdown(size="sm",
+                     variant="outline-secondary",
+                     no-caret,
+                     right,
+                     :title="`More actions for ${device.hostname}`")
+            template(v-slot:button-content)
+              icon(name="ellipsis-v")
+            b-dropdown-item-button(@click="openDeleteHostModal(device)",
+                     variant="danger",
+                     :title="`Delete all ${device.buckets.length} buckets for ${device.hostname}`")
+              icon(name="trash")
+              |  Delete all buckets for this host
 
     b-row
       b-col
@@ -188,6 +194,7 @@ import 'vue-awesome/icons/desktop';
 import 'vue-awesome/icons/mobile';
 import 'vue-awesome/icons/question';
 import 'vue-awesome/icons/exclamation-triangle';
+import 'vue-awesome/icons/ellipsis-v';
 
 import _ from 'lodash';
 import Papa from 'papaparse';

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -38,7 +38,8 @@ div
                      variant="outline-secondary",
                      no-caret,
                      right,
-                     :title="`More actions for ${device.hostname}`")
+                     :title="`More actions for ${device.hostname}`",
+                     :aria-label="`More actions for ${device.hostname}`")
             template(v-slot:button-content)
               icon(name="ellipsis-v")
             b-dropdown-item-button(@click="openDeleteHostModal(device)",

--- a/test/unit/timelineLabels.test.node.ts
+++ b/test/unit/timelineLabels.test.node.ts
@@ -1,25 +1,25 @@
 import { formatTimelineBucketLabelHtml } from '~/util/timelineLabels';
 
 describe('formatTimelineBucketLabelHtml', () => {
-  test('adds wrap opportunities for long bucket names', () => {
+  it('should add word-break opportunities after separators', () => {
     expect(formatTimelineBucketLabelHtml('aw-watcher-window_host')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window_host">aw-<wbr>watcher-<wbr>window_<wbr>host</span>'
+      '<span class="timeline-label" title="aw-watcher-window_host">aw-\u200Bwatcher-\u200Bwindow_\u200Bhost</span>'
     );
   });
 
-  test('abbreviates synced bucket names and preserves wrap opportunities', () => {
+  it('should abbreviate synced bucket names', () => {
     expect(formatTimelineBucketLabelHtml('aw-watcher-window_host-synced-from-remote-host')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window_host-synced-from-remote-host">aw-<wbr>watcher-<wbr>window (synced from remote-<wbr>host)</span>'
+      '<span class="timeline-label" title="aw-watcher-window_host-synced-from-remote-host">aw-\u200Bwatcher-\u200Bwindow (synced from remote-\u200Bhost)</span>'
     );
   });
 
-  test('adds wrap opportunities for slash-separated bucket names', () => {
+  it('should handle slashes', () => {
     expect(formatTimelineBucketLabelHtml('aw-watcher-window/host/session')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window/host/session">aw-<wbr>watcher-<wbr>window/<wbr>host/<wbr>session</span>'
+      '<span class="timeline-label" title="aw-watcher-window/host/session">aw-\u200Bwatcher-\u200Bwindow/\u200Bhost/\u200Bsession</span>'
     );
   });
 
-  test('escapes HTML before inserting wrap opportunities', () => {
+  it('should escape HTML in bucket IDs', () => {
     expect(formatTimelineBucketLabelHtml('bucket<script>')).toBe(
       '<span class="timeline-label" title="bucket&lt;script&gt;">bucket&lt;script&gt;</span>'
     );


### PR DESCRIPTION
Two fixes prompted by @ErikBjare in https://github.com/ActivityWatch/aw-webui/pull/829#issuecomment-4510979771:

**1. Timeline label <wbr> → zero-width space**
vis-timeline does not support HTML `<wbr>` tags in group label content (the inline label shown on the timeline Y-axis). The `\u200B` zero-width space achieves the same word-break effect without HTML tags that vis-timeline strips or renders incorrectly.

**2. Move 'Delete all buckets for this host' to a dropdown menu**
The bulk-delete button was a large red button visible on every device card. Since this is a rare/dangerous action, it now lives in a three-dots vertical dropdown alongside other device actions. The dropdown uses `vue-awesome/icons/ellipsis-v`. 

Closes the feedback from Erik's review.