### PR TITLE
fix(query-explorer): solid Rename/Delete buttons for saved queries

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
         '^.+\\.ts$': 'ts-jest',
         '^.+\\.vue$': '@vue/vue2-jest',
       },
+      transformIgnorePatterns: ['/node_modules/(?!(vue-awesome)/)'],
       testMatch: ['**/test/**/*.test.js?(x)'],
       moduleNameMapper: {
         '^~/(.+)$': '<rootDir>/src/$1',
@@ -32,6 +33,7 @@ module.exports = {
         '^.+\\.ts$': 'ts-jest',
         '^.+\\.vue$': '@vue/vue2-jest',
       },
+      transformIgnorePatterns: ['/node_modules/(?!(vue-awesome)/)'],
       moduleNameMapper: {
         '^~/(.+)$': '<rootDir>/src/$1',
         '^d3$': '<rootDir>/node_modules/d3/dist/d3.min',

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -24,8 +24,10 @@ div
       div.form-group.col-lg-6
         div.saved-query-actions
           button.btn.btn-success.mr-2(type="button", @click="saveCurrentQuery()") Save Current
-          button.btn.btn-outline-secondary.mr-2(type="button", @click="renameSelectedQuery()", :disabled="!selected_saved_query_id") Rename
-          button.btn.btn-outline-danger(type="button", @click="deleteSelectedQuery()", :disabled="!selected_saved_query_id") Delete
+          button.btn.btn-secondary.mr-2(type="button", @click="renameSelectedQuery()", :disabled="!selected_saved_query_id") Rename
+          button.btn.btn-danger(type="button", @click="deleteSelectedQuery()", :disabled="!selected_saved_query_id")
+            icon(name="trash")
+            |  Delete
 
     div.form-row
       div.form-group.col-md-6
@@ -57,6 +59,7 @@ div
 </style>
 
 <script lang="ts">
+import 'vue-awesome/icons/trash';
 import moment from 'moment';
 import _ from 'lodash';
 import { useCategoryStore } from '~/stores/categories';


### PR DESCRIPTION
Follow-up to #829 based on @0xbrayo's review comment (left just after merge):

> Use a solid color for the rename button, same color used in the expand list button on the same page. Use the bin button same as in the raw data section.

**Changes:**
- **Rename**: `btn-outline-secondary` → `btn-secondary` (solid secondary, matching the "Expand list" button style used in the event list on the same page)
- **Delete**: `btn-outline-danger` → `btn-danger` with `icon(name="trash")` (matches the trash-icon+solid-danger pattern used in Buckets and activity views)

No behaviour changes — purely visual/style alignment.