### PR TITLE
fix(ci): restore PAT for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,10 +14,6 @@ on:
       # List all required workflow names here.
       - Build
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto_merge:
     name: Auto-merge

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,10 @@
 name: Dependabot Auto-merge
 
-# Use the repository-scoped GitHub Actions token instead of an external PAT.
-# The workflow-level permissions below grant the merge action the access it needs.
+# NOTE: `merge-me-action` still needs the bot PAT here.
+# Using `secrets.GITHUB_TOKEN` fails on `workflow_run` with
+# "Resource not accessible by integration" when the action queries
+# branch protection rules over GraphQL.
+# See: https://github.com/ridedott/merge-me-action/issues/1581
 
 on:
   workflow_run:
@@ -27,4 +30,4 @@ jobs:
     steps:
       - uses: ridedott/merge-me-action@2568f177a681785a874d6e7af950eb1a0dd31123
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- restore `AWBOT_GH_TOKEN` for the Dependabot auto-merge workflow
- keep the SHA-pinned action and `workflow_run.event == 'pull_request'` guard from #828
- document that `secrets.GITHUB_TOKEN` fails here because `merge-me-action` still queries branch protection over GraphQL

## Verification
- reproduced the failing master run: `gh run view 26254040558 --repo ActivityWatch/aw-webui --log-failed`
- validated the updated workflow YAML locally with `python3` + `yaml.safe_load`
