### PR TITLE
fix(vue3): replace datetime component with native datetime-local input in EventEditor

### DIFF
--- a/src/components/EventEditor.vue
+++ b/src/components/EventEditor.vue
@@ -13,10 +13,12 @@ b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEdit
         td {{ event.id }}
       tr
         th Start
-        datetime(type="datetime" v-model="start")
+        td
+          input(type="datetime-local" v-model="start")
       tr
         th End
-        datetime(type="datetime" v-model="end")
+        td
+          input(type="datetime-local" v-model="end")
       tr
         th Duration
         td {{ friendlyduration(editedEvent.duration) }}
@@ -78,7 +80,7 @@ export default {
   computed: {
     start: {
       get: function () {
-        return moment(this.editedEvent.timestamp).format();
+        return moment(this.editedEvent.timestamp).format('YYYY-MM-DDTHH:mm');
       },
       set: function (dt) {
         // Duration needs to be set first since otherwise the computed for end will use the new timestamp
@@ -89,7 +91,7 @@ export default {
     end: {
       get: function () {
         const end = moment(this.editedEvent.timestamp).add(this.editedEvent.duration, 'seconds');
-        return end.format();
+        return end.format('YYYY-MM-DDTHH:mm');
       },
       set: function (dt) {
         this.editedEvent.duration = moment(dt).diff(this.editedEvent.timestamp, 'seconds');

--- a/src/components/EventEditor.vue
+++ b/src/components/EventEditor.vue
@@ -14,11 +14,11 @@ b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEdit
       tr
         th Start
         td
-          input(type="datetime-local" v-model="start")
+          input(type="datetime-local" step="1" v-model="start")
       tr
         th End
         td
-          input(type="datetime-local" v-model="end")
+          input(type="datetime-local" step="1" v-model="end")
       tr
         th Duration
         td {{ friendlyduration(editedEvent.duration) }}
@@ -80,7 +80,7 @@ export default {
   computed: {
     start: {
       get: function () {
-        return moment(this.editedEvent.timestamp).format('YYYY-MM-DDTHH:mm');
+        return moment(this.editedEvent.timestamp).format('YYYY-MM-DDTHH:mm:ss');
       },
       set: function (dt) {
         // Duration needs to be set first since otherwise the computed for end will use the new timestamp
@@ -91,7 +91,7 @@ export default {
     end: {
       get: function () {
         const end = moment(this.editedEvent.timestamp).add(this.editedEvent.duration, 'seconds');
-        return end.format('YYYY-MM-DDTHH:mm');
+        return end.format('YYYY-MM-DDTHH:mm:ss');
       },
       set: function (dt) {
         this.editedEvent.duration = moment(dt).diff(this.editedEvent.timestamp, 'seconds');


### PR DESCRIPTION
Replaces the Vue 2-only `datetime` component in EventEditor with native `<input type="datetime-local">`, preserving the existing save/delete flow and computed start/end/duration logic.\n\n- Uses `YYYY-MM-DDTHH:mm` format for datetime-local compatibility\n- Keeps the existing computed start/end properties that maintain duration invariant\n- Unblocks event editing on the vue3 branch where vue-datetime was removed\n\nRefs: ActivityWatch/aw-webui#788 (umbrella)