### PR TITLE
fix: match Zen browser in Firefox web watcher buckets

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -264,7 +264,9 @@ function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
 // See: test/unit/queries.test.node.ts, https://github.com/ActivityWatch/aw-webui/issues/749
 export const browser_appname_regex: Record<string, string> = {
   chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium)',
-  firefox: '(?i)(firefox|librewolf|waterfox|nightly)',
+  // Zen Browser installs the Firefox WebExtension build and can report into
+  // aw-watcher-web-firefox buckets, so match it as Firefox-compatible too.
+  firefox: '(?i)(firefox|librewolf|waterfox|nightly|zen)',
   opera: '(?i)(opera)',
   brave: '(?i)(brave)',
   edge: '(?i)^(microsoft[-_ ]?edge|msedge)',

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -129,6 +129,12 @@ describe('browser_appname_regex', () => {
     }
   });
 
+  test('firefox pattern matches Zen when it reports to a Firefox web watcher bucket', () => {
+    const re = toRegex(browser_appname_regex.firefox);
+    expect(re.test('Zen')).toBe(true);
+    expect(re.test('Zen Browser')).toBe(true);
+  });
+
   test('opera pattern matches all known Opera app names', () => {
     const re = toRegex(browser_appname_regex.opera);
     const knownNames = ['opera.exe', 'Opera.exe', 'Opera'];


### PR DESCRIPTION
## Summary
- include Zen in the Firefox-compatible browser app regex
- keep the existing dedicated Zen bucket support unchanged
- add a unit test for Zen app names reported with Firefox web watcher buckets

## Why
Zen Browser can use the Firefox WebExtension build of aw-watcher-web, which reports URL events into aw-watcher-web-firefox buckets. In that setup the window watcher reports the browser app as `Zen`, but the Firefox bucket query only accepted Firefox/LibreWolf/Waterfox/Nightly app names, so Browser view dropped those URL events.

## Test
- `npx jest --selectProjects node test/unit/queries.test.node.ts --runInBand`