### PR TITLE
Fix: Make header sticky on desktop.

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -136,8 +136,7 @@ export default {
   data() {
     return {
       activityViews: null,
-      // Make configurable?
-      fixedTopMenu: this.$isAndroid,
+      fixedTopMenu: true,
     };
   },
   computed: {


### PR DESCRIPTION
Make the header sticky on desktop.
The header was already sticky on mobile. This extends that behavior to desktop as well.

Fixes #299 