### PR TITLE
feat(queries): add editor-bucket-aware categorization

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -32,6 +32,7 @@ interface BaseQueryParams {
   filter_categories: string[][];
   bid_browsers?: string[];
   bid_stopwatch?: string;
+  bid_editors?: string[];
   return_variable_suffix?: string;
 }
 
@@ -158,6 +159,19 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
       ? `stopwatch_events = query_bucket("${params.bid_stopwatch}");
          events = union_no_overlap(stopwatch_events, events);`
       : 'stopwatch_events = [];',
+    // Merge editor bucket events into the main stream so category rules can match on
+    // editor fields (project, file, language). Editor events are intersected with the
+    // current active-window period to avoid introducing new time outside window activity.
+    params.bid_editors && params.bid_editors.length > 0
+      ? [
+          'editor_events = [];',
+          ...params.bid_editors.map(
+            b => `editor_events = concat(editor_events, query_bucket("${escape_doublequote(b)}"));`
+          ),
+          'editor_events = filter_period_intersect(editor_events, events);',
+          'events = concat(events, editor_events);',
+        ].join('\n')
+      : '',
     // Categorize
     params.categories ? `events = categorize(events, ${categories_str});` : '',
     // Filter out selected categories

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -185,6 +185,17 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
     params.filter_categories
       ? `events = filter_keyvals(events, "$category", ${cat_filter_str});`
       : '',
+    // When editor buckets are active and a non-empty category filter is applied,
+    // re-intersect window_events with the filtered event stream so app/title/duration
+    // aggregations in fullDesktopQuery respect the active category filter. Without this,
+    // window_events (saved before categorize/filter) includes all window time regardless
+    // of the filter, causing incorrect duration/app/title totals.
+    params.bid_editors &&
+    params.bid_editors.length > 0 &&
+    params.filter_categories &&
+    params.filter_categories.length > 0
+      ? 'window_events = filter_period_intersect(window_events, events);'
+      : '',
     // "Return" events by setting variable named with return_variable if set
     params.return_variable_suffix
       ? `events_${params.return_variable_suffix} = events;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -171,6 +171,9 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
                 b
               )}")));`
           ),
+          // Sort before intersect: filter_period_intersect requires sorted input.
+          // With multiple editor buckets the concat is unsorted.
+          'editor_events = sort_by_timestamp(editor_events);',
           'editor_events = filter_period_intersect(editor_events, events);',
           // Save window-only events before editor merge so app/title/duration
           // aggregations in fullDesktopQuery exclude editor events (which lack

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -166,7 +166,7 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
       ? [
           'editor_events = [];',
           ...params.bid_editors.map(
-            b => `editor_events = concat(editor_events, query_bucket("${escape_doublequote(b)}"));`
+            b => `editor_events = concat(editor_events, flood(query_bucket("${escape_doublequote(b)}")));`
           ),
           'editor_events = filter_period_intersect(editor_events, events);',
           'events = concat(events, editor_events);',

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -172,7 +172,11 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
               )}")));`
           ),
           'editor_events = filter_period_intersect(editor_events, events);',
-          'events = sort_by_timestamp(concat(events, editor_events));',
+          // Save window-only events before editor merge so app/title/duration
+          // aggregations in fullDesktopQuery exclude editor events (which lack
+          // "app"/"title" fields and would otherwise create a spurious null-app bucket).
+          'window_events = events;',
+          'events = sort_by_timestamp(concat(window_events, editor_events));',
         ].join('\n')
       : '',
     // Categorize
@@ -323,6 +327,14 @@ function browserEvents(params: DesktopQueryParams): string {
 }
 
 export function fullDesktopQuery(params: DesktopQueryParams): string[] {
+  // When editor buckets are present, canonicalEvents saves window-only events in
+  // "window_events" before the editor concat. Use that for app/title breakdown so
+  // editor events (which lack "app"/"title") don't create a spurious null-app bucket.
+  // cat_events still uses the full "events" stream so category rules can fire on
+  // editor fields (project, file, language). Duration uses window_events to avoid
+  // double-counting time shared between window and editor events.
+  const hasEditors = !!(params.bid_editors && params.bid_editors.length > 0);
+  const windowSrc = hasEditors ? 'window_events' : 'events';
   return querystr_to_array(
     `
     ${canonicalEvents({
@@ -332,13 +344,13 @@ export function fullDesktopQuery(params: DesktopQueryParams): string[] {
       bid_afk: escape_doublequote(params.bid_afk),
       bid_browsers: _.map(params.bid_browsers, escape_doublequote),
     })}
-    title_events = sort_by_duration(merge_events_by_keys(events, ["app", "title"]));
+    title_events = sort_by_duration(merge_events_by_keys(${windowSrc}, ["app", "title"]));
     app_events   = sort_by_duration(merge_events_by_keys(title_events, ["app"]));
     cat_events   = sort_by_duration(merge_events_by_keys(events, ["$category"]));
 
     app_events  = limit_events(app_events, ${default_limit});
     title_events  = limit_events(title_events, ${default_limit});
-    duration = sum_durations(events);
+    duration = sum_durations(${windowSrc});
     ` + // Browser events are retrieved in canonicalQuery
       `
     browser_events = split_url_events(browser_events);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -166,10 +166,13 @@ export function canonicalEvents(params: DesktopQueryParams | AndroidQueryParams)
       ? [
           'editor_events = [];',
           ...params.bid_editors.map(
-            b => `editor_events = concat(editor_events, flood(query_bucket("${escape_doublequote(b)}")));`
+            b =>
+              `editor_events = concat(editor_events, flood(query_bucket("${escape_doublequote(
+                b
+              )}")));`
           ),
           'editor_events = filter_period_intersect(editor_events, events);',
-          'events = concat(events, editor_events);',
+          'events = sort_by_timestamp(concat(events, editor_events));',
         ].join('\n')
       : '',
     // Categorize

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -366,6 +366,7 @@ export const useActivityStore = defineStore('activity', {
           include_stopwatch && this.buckets.stopwatch.length > 0
             ? this.buckets.stopwatch[0]
             : undefined,
+        bid_editors: this.buckets.editor.length > 0 ? this.buckets.editor : undefined,
         filter_afk,
         categories,
         filter_categories,
@@ -506,6 +507,7 @@ export const useActivityStore = defineStore('activity', {
             include_stopwatch && this.buckets.stopwatch.length > 0
               ? this.buckets.stopwatch[0]
               : undefined,
+          bid_editors: this.buckets.editor.length > 0 ? this.buckets.editor : undefined,
           categories,
           filter_categories,
           filter_afk,

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -285,4 +285,55 @@ describe('canonicalEvents editor bucket support', () => {
     expect(categorizePos).toBeGreaterThan(-1);
     expect(editorPos).toBeLessThan(categorizePos);
   });
+
+  test('window_events is saved before editor concat to preserve app/title breakdown', () => {
+    // canonicalEvents must emit "window_events = events" BEFORE the concat so that
+    // fullDesktopQuery can use window_events for app/title aggregation without
+    // including editor events (which lack "app"/"title" and would create a null-app bucket).
+    const query = canonicalEvents({
+      ...baseParams,
+      bid_editors: ['aw-watcher-vim_host'],
+    });
+    const windowSavePos = query.indexOf('window_events = events');
+    const concatPos = query.indexOf('concat(window_events, editor_events)');
+    expect(windowSavePos).toBeGreaterThan(-1);
+    expect(concatPos).toBeGreaterThan(-1);
+    expect(windowSavePos).toBeLessThan(concatPos);
+  });
+
+  test('window_events is NOT emitted when bid_editors is absent', () => {
+    const query = canonicalEvents(baseParams);
+    expect(query).not.toContain('window_events');
+  });
+});
+
+import { fullDesktopQuery } from '~/queries';
+
+describe('fullDesktopQuery editor bucket regression', () => {
+  const baseDesktopParams = {
+    bid_window: 'aw-watcher-window_host',
+    bid_afk: 'aw-watcher-afk_host',
+    filter_afk: true,
+    categories: [],
+    filter_categories: [],
+  };
+
+  test('uses window_events for app/title aggregation when bid_editors is set', () => {
+    const query = fullDesktopQuery({
+      ...baseDesktopParams,
+      bid_editors: ['aw-watcher-vim_host'],
+    }).join('\n');
+    // app/title aggregation must use window_events, not events, to avoid null-app bucket
+    expect(query).toContain('merge_events_by_keys(window_events, ["app", "title"])');
+    expect(query).toContain('sum_durations(window_events)');
+    // cat_events must still use the full events (with editor events) for category breakdown
+    expect(query).toContain('merge_events_by_keys(events, ["$category"])');
+  });
+
+  test('uses events directly for app/title aggregation when no bid_editors', () => {
+    const query = fullDesktopQuery(baseDesktopParams).join('\n');
+    expect(query).toContain('merge_events_by_keys(events, ["app", "title"])');
+    expect(query).toContain('sum_durations(events)');
+    expect(query).not.toContain('window_events');
+  });
 });

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -53,7 +53,7 @@
  *             (Flatpak app ID retained: 'one.ablaze.floorp')
  */
 
-import { browser_appname_regex } from '~/queries';
+import { browser_appname_regex, canonicalEvents } from '~/queries';
 
 // Convert ActivityWatch (?i) patterns to JS RegExp with i flag for testing.
 // AW server uses Python-style (?i) inline flag; JS uses RegExp 'i' flag instead.
@@ -229,5 +229,57 @@ describe('browser_appname_regex', () => {
     for (const name of knownNames) {
       expect(re.test(name)).toBe(true);
     }
+  });
+});
+
+describe('canonicalEvents editor bucket support', () => {
+  const baseParams = {
+    bid_window: 'aw-watcher-window_host',
+    bid_afk: 'aw-watcher-afk_host',
+    filter_afk: true,
+    categories: [],
+    filter_categories: [],
+  };
+
+  test('includes editor bucket queries when bid_editors is set', () => {
+    const query = canonicalEvents({
+      ...baseParams,
+      bid_editors: ['aw-watcher-vim_host'],
+    });
+    expect(query).toContain('editor_events');
+    expect(query).toContain('aw-watcher-vim_host');
+    expect(query).toContain('filter_period_intersect');
+  });
+
+  test('includes multiple editor buckets when bid_editors has multiple entries', () => {
+    const query = canonicalEvents({
+      ...baseParams,
+      bid_editors: ['aw-watcher-vim_host', 'aw-watcher-vscode_host'],
+    });
+    expect(query).toContain('aw-watcher-vim_host');
+    expect(query).toContain('aw-watcher-vscode_host');
+  });
+
+  test('does not include editor query when bid_editors is absent', () => {
+    const query = canonicalEvents(baseParams);
+    expect(query).not.toContain('editor_events');
+  });
+
+  test('does not include editor query when bid_editors is empty', () => {
+    const query = canonicalEvents({ ...baseParams, bid_editors: [] });
+    expect(query).not.toContain('editor_events');
+  });
+
+  test('editor events are added before categorize', () => {
+    const query = canonicalEvents({
+      ...baseParams,
+      categories: [[['Development'], { type: 'regex', regex: 'myproject' }]],
+      bid_editors: ['aw-watcher-vim_host'],
+    });
+    const editorPos = query.indexOf('editor_events');
+    const categorizePos = query.indexOf('categorize');
+    expect(editorPos).toBeGreaterThan(-1);
+    expect(categorizePos).toBeGreaterThan(-1);
+    expect(editorPos).toBeLessThan(categorizePos);
   });
 });

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -336,4 +336,35 @@ describe('fullDesktopQuery editor bucket regression', () => {
     expect(query).toContain('sum_durations(events)');
     expect(query).not.toContain('window_events');
   });
+
+  test('re-intersects window_events with filtered events when editor buckets + category filter active', () => {
+    // When bid_editors + filter_categories are both set, window_events must be
+    // re-intersected with the post-filter events stream so duration/app/title
+    // aggregations respect the active category filter (Greptile 4/5 finding).
+    const query = fullDesktopQuery({
+      ...baseDesktopParams,
+      bid_editors: ['aw-watcher-vim_host'],
+      filter_categories: [['Work']],
+    }).join('\n');
+    const filterPos = query.indexOf('filter_keyvals(events, "$category"');
+    const reIntersectPos = query.indexOf('filter_period_intersect(window_events, events)');
+    expect(reIntersectPos).toBeGreaterThan(-1);
+    // re-intersect must happen AFTER filter_keyvals so it uses the filtered stream
+    expect(reIntersectPos).toBeGreaterThan(filterPos);
+  });
+
+  test('does NOT re-intersect window_events when no category filter active', () => {
+    // Without a non-empty category filter, window_events from before the editor concat
+    // is already correct — no need to re-intersect.
+    // baseDesktopParams has filter_categories: [] (empty = no active filter).
+    const query = fullDesktopQuery({
+      ...baseDesktopParams,
+      bid_editors: ['aw-watcher-vim_host'],
+      filter_categories: [],
+    }).join('\n');
+    // window_events = events save-point is present (for null-app protection)
+    expect(query).toContain('window_events = events');
+    // but no re-intersection since filter_categories is empty
+    expect(query).not.toContain('filter_period_intersect(window_events, events)');
+  });
 });

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -249,6 +249,9 @@ describe('canonicalEvents editor bucket support', () => {
     expect(query).toContain('editor_events');
     expect(query).toContain('aw-watcher-vim_host');
     expect(query).toContain('filter_period_intersect');
+    // flood() is required so category rules fire for full editing sessions,
+    // not just brief heartbeat windows
+    expect(query).toContain('flood(query_bucket("aw-watcher-vim_host"))');
   });
 
   test('includes multiple editor buckets when bid_editors has multiple entries', () => {

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -261,6 +261,12 @@ describe('canonicalEvents editor bucket support', () => {
     });
     expect(query).toContain('aw-watcher-vim_host');
     expect(query).toContain('aw-watcher-vscode_host');
+    // sort_by_timestamp must precede filter_period_intersect so multi-bucket
+    // concat output is sorted before the intersection (required by aw-query).
+    const sortPos = query.indexOf('sort_by_timestamp(editor_events)');
+    const intersectPos = query.indexOf('filter_period_intersect(editor_events');
+    expect(sortPos).toBeGreaterThan(-1);
+    expect(sortPos).toBeLessThan(intersectPos);
   });
 
   test('does not include editor query when bid_editors is absent', () => {


### PR DESCRIPTION
Implements editor-bucket-aware categorization so users can define category rules that match on editor `project`, `file`, and `language` fields.

Closes ActivityWatch/activitywatch#1305

## What changed

- Added `bid_editors?: string[]` to `BaseQueryParams` in `queries.ts`
- In `canonicalEvents()`, when editor buckets are provided, their events are fetched, intersected with the active window time (`filter_period_intersect`), and concatenated into the main event stream **before** `categorize()` runs — so category rules can match on editor fields alongside window fields
- `query_desktop_full` and `categoryQuery` in `activity.ts` now pass `this.buckets.editor` as `bid_editors` automatically
- 5 new unit tests covering: editor events appear in query, multiple buckets, empty/absent behavior, ordering before categorize

## Design

Option B (TypeScript-only, no aw-query engine changes): editor events from configured buckets are merged into the canonical event stream at query-construction time. Using `filter_period_intersect` ensures only editor events that overlap with existing active-window time are included, avoiding new uncovered time periods.

**v1 limitation**: when an editor event overlaps a window event, `sum_durations` will slightly double-count that time. This is acceptable for v1 — the primary goal (category rules firing on editor project/file/language) works correctly.