### PR TITLE
feat(ui): pre-release polish pass — bug fixes, tests, and view-level revamps

### DIFF
--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -22,9 +22,8 @@ b-modal(id="edit" ref="edit" title="Edit category" @show="resetModal" @hidden="h
             | Case insensitive
         div.flex-grow-1
           small.text-right
-            //div(v-if="valid" style="color: green") Valid
-            div(v-if="!validPattern" style="color: red") Invalid pattern
-            div(v-if="validPattern && broad_pattern" style="color: orange") Pattern too broad
+            div.text-danger(v-if="!validPattern") Invalid pattern
+            div.text-warning(v-if="validPattern && broad_pattern") Pattern too broad
 
   hr
   div.my-1

--- a/src/components/CategoryEditTree.vue
+++ b/src/components/CategoryEditTree.vue
@@ -17,7 +17,7 @@ div
     div.col-4.col-md-8
       span.d-none.d-md-inline
         span(v-if="_class.rule.type === 'regex'") Rule ({{_class.rule.type}}): #[code {{_class.rule.regex}}]
-        span(v-else, style="color: #888") No rule
+        span.text-muted(v-else) No rule
       span.float-right
         b-btn.ml-1.border-0(size="sm", variant="outline-secondary", @click="showEditModal(_class.id)" pill)
           icon(name="edit")

--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -7,20 +7,24 @@ div
       | The selected date range is too long. The maximum is {{ maxDuration/(24*60*60) }} days.
 
   div.input-time-interval.d-flex.flex-wrap.align-items-start.justify-content-between
-    div
-      div.d-flex.align-items-center.flex-wrap.mb-2
-        label.col-form-label.col-form-label-sm.mr-2.mb-0(for="time-mode") Mode
-        b-form-radio-group#time-mode(
-          v-model="mode",
-          @change="valueChanged",
-          buttons,
-          button-variant="outline-secondary",
-          size="sm",
-          :options="modeOptions"
-        )
+    // Two-row grid: labels share a fixed-width column so the Mode toggle
+    // and the Range controls line up vertically and the secondary label
+    // stays in the same spot (just "Range") regardless of which mode is
+    // active. Previously the label flipped between "Quick range" / "Range"
+    // and the inputs shifted horizontally on every toggle.
+    div.time-interval-grid
+      label.col-form-label.col-form-label-sm.mb-0(for="time-mode") Mode
+      b-form-radio-group#time-mode(
+        v-model="mode",
+        @change="valueChanged",
+        buttons,
+        button-variant="outline-secondary",
+        size="sm",
+        :options="modeOptions"
+      )
 
-      div.d-flex.align-items-center.flex-wrap(v-if="mode == 'last_duration'")
-        label.col-form-label.col-form-label-sm.mr-2.mb-0 Quick range
+      label.col-form-label.col-form-label-sm.mb-0 Range
+      div.d-flex.flex-wrap.align-items-center(v-if="mode == 'last_duration'")
         div.btn-group(role="group" aria-label="Quick durations")
           template(v-for="(dur, idx) in durations")
             input(
@@ -31,14 +35,14 @@ div
               @change="applyLastDuration"
             ).d-none
             label(:for="'dur' + idx" v-html="dur.label").btn.btn-light.btn-sm
-
-      div.d-flex.align-items-center.flex-wrap.mt-2(v-if="mode == 'range'")
-        label.col-form-label.col-form-label-sm.mr-2.mb-0 Range
+      div.d-flex.flex-wrap.align-items-center(v-else)
         input.form-control.form-control-sm.mr-1(
           type="date", v-model="start", :max="end || undefined", style="width: auto"
+          aria-label="Start date"
         )
         input.form-control.form-control-sm.mr-1(
           type="date", v-model="end", :min="start || undefined", placeholder="(optional)", style="width: auto"
+          aria-label="End date (optional)"
         )
         b-button(
           size="sm" variant="outline-dark"
@@ -58,6 +62,16 @@ div
 <style scoped lang="scss">
 .input-time-interval {
   row-gap: 0.5rem;
+}
+
+.time-interval-grid {
+  display: grid;
+  // Fixed label column keeps Mode/Range labels aligned and the controls
+  // start at the same X regardless of which mode is active.
+  grid-template-columns: 4rem 1fr;
+  column-gap: 0.75rem;
+  row-gap: 0.5rem;
+  align-items: center;
 }
 
 .btn-group {

--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -6,68 +6,65 @@ div
     b-alert(v-if="daterangeTooLong", variant="warning", show)
       | The selected date range is too long. The maximum is {{ maxDuration/(24*60*60) }} days.
 
-  div.d-flex.justify-content-between
-    table
-      tr
-        td.pr-2
-          label.col-form-label.col-form-label-sm Show last
-        td(colspan=2)
-          .btn-group(role="group")
-            template(v-for="(dur, idx) in durations")
-              input(
-                type="radio"
-                :id="'dur' + idx"
-                :value="dur.seconds"
-                v-model="duration"
-                @change="applyLastDuration"
-              ).d-none
-              label(:for="'dur' + idx" v-html="dur.label").btn.btn-light.btn-sm
+  div.input-time-interval.d-flex.flex-wrap.align-items-start.justify-content-between
+    div
+      div.d-flex.align-items-center.flex-wrap.mb-2
+        label.col-form-label.col-form-label-sm.mr-2.mb-0(for="time-mode") Mode
+        b-form-radio-group#time-mode(
+          v-model="mode",
+          @change="valueChanged",
+          buttons,
+          button-variant="outline-secondary",
+          size="sm",
+          :options="modeOptions"
+        )
 
-      tr
-        td.pr-2
-          label.col-form-label.col-form-label-sm Show from
-        td
-          select(id="mode", v-model="mode", @change="valueChanged")
-            option(value='last_duration') Last duration
-            option(value='range') Date range
-      tr(v-if="mode == 'last_duration'")
-        th.pr-2
-          label(for="duration") Show last:
-        td
-          select(id="duration", v-model="duration", @change="valueChanged")
-            option(:value="15*60") 15min
-            option(:value="30*60") 30min
-            option(:value="60*60") 1h
-            option(:value="2*60*60") 2h
-            option(:value="4*60*60") 4h
-            option(:value="6*60*60") 6h
-            option(:value="12*60*60") 12h
-            option(:value="24*60*60") 24h
-      tr(v-if="mode == 'range'")
-        th.pr-2 Range:
-        td
-          input(type="date", v-model="start", :max="end || undefined")
-          input(type="date", v-model="end", :min="start || undefined", placeholder="(optional)")
-          button(
-            class="btn btn-outline-dark btn-sm",
-            type="button",
-            :disabled="invalidDaterange || emptyDaterange || daterangeTooLong",
-            @click="applyRange"
-          ) Apply
+      div.d-flex.align-items-center.flex-wrap(v-if="mode == 'last_duration'")
+        label.col-form-label.col-form-label-sm.mr-2.mb-0 Quick range
+        div.btn-group(role="group" aria-label="Quick durations")
+          template(v-for="(dur, idx) in durations")
+            input(
+              type="radio"
+              :id="'dur' + idx"
+              :value="dur.seconds"
+              v-model="duration"
+              @change="applyLastDuration"
+            ).d-none
+            label(:for="'dur' + idx" v-html="dur.label").btn.btn-light.btn-sm
 
-    div.text-muted.d-none.d-md-block(style="text-align:right" v-if="showUpdate")
-      b-button.mt-2.px-2(@click="refresh()", variant="outline-dark", size="sm", style="opacity: 0.7")
-        icon(name="sync")
+      div.d-flex.align-items-center.flex-wrap.mt-2(v-if="mode == 'range'")
+        label.col-form-label.col-form-label-sm.mr-2.mb-0 Range
+        input.form-control.form-control-sm.mr-1(
+          type="date", v-model="start", :max="end || undefined", style="width: auto"
+        )
+        input.form-control.form-control-sm.mr-1(
+          type="date", v-model="end", :min="start || undefined", placeholder="(optional)", style="width: auto"
+        )
+        b-button(
+          size="sm" variant="outline-dark"
+          :disabled="invalidDaterange || emptyDaterange || daterangeTooLong"
+          @click="applyRange"
+        ) Apply
+
+    div.text-right.d-none.d-md-block(v-if="showUpdate")
+      b-button.px-2(@click="refresh()", variant="outline-dark", size="sm")
+        icon.mr-1(name="sync")
         span.d-none.d-md-inline
           | Refresh
-      div.mt-2.small(v-if="lastUpdate")
+      div.mt-2.small.text-muted(v-if="lastUpdate")
         | Last update: #[time(:datetime="lastUpdate.format()") {{lastUpdate | friendlytime}}]
 </template>
 
 <style scoped lang="scss">
+.input-time-interval {
+  row-gap: 0.5rem;
+}
+
 .btn-group {
   input[type='radio']:checked + label {
-    background-color: #aaa;
+    background-color: #495057;
+    color: #fff;
+    border-color: #495057;
   }
 }
 </style>
@@ -109,6 +106,10 @@ export default {
         { seconds: 12 * 60 * 60, label: '12h' },
         { seconds: 24 * 60 * 60, label: '24h' },
         { seconds: 48 * 60 * 60, label: '48h' },
+      ],
+      modeOptions: [
+        { text: 'Last duration', value: 'last_duration' },
+        { text: 'Date range', value: 'range' },
       ],
     };
   },

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -8,7 +8,7 @@ div
       template(v-slot:button-content)
         icon(name="cog")
       b-dropdown-item(v-for="t in types" :key="t" variant="outline-secondary" @click="$emit('onTypeChange', id, t)")
-        | {{ visualizations[t].title }} #[span.small(v-if="!visualizations[t].available" style="color: #A50") (no data)]
+        | {{ visualizations[t].title }} #[span.small.text-warning(v-if="!visualizations[t].available") (no data)]
     b-button.p-0(size="sm", variant="outline-danger" @click="$emit('onRemove', id)")
       icon(name="times")
 
@@ -21,7 +21,7 @@ div
     div(v-if="!has_prerequisites")
       b-alert.small.px-2.py-1(show variant="warning")
         | This feature is missing data from a required watcher.
-        | You can find a list of all watchers in #[a(href="https://activitywatch.readthedocs.io/en/latest/watchers.html") the documentation].
+        | You can find a list of all watchers in #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") the documentation].
 
     div(v-if="type == 'top_apps'")
       aw-summary(:fields="activityStore.window.top_apps",

--- a/src/components/StopwatchEntry.vue
+++ b/src/components/StopwatchEntry.vue
@@ -1,16 +1,16 @@
 <template lang="pug">
 div
-  div.row.px-3.py-2.stopwatch-entry#root
-    div.flex-fill
+  div.d-flex.flex-wrap.align-items-center.px-3.py-2.stopwatch-entry
+    div.flex-fill.mr-2
       span #[b {{event.data.label || 'No label'}}]
-      span(style="color: #888") &nbsp;|&nbsp;
+      span.text-muted &nbsp;|&nbsp;
       span(v-if="event.data.running")
         | Running for #[span(:title="event.timestamp") {{event.data.running ? (now - event.timestamp) / 1000 : event.duration | friendlyduration}}]
         | &nbsp;(Started {{ event.timestamp | shorttime }})
       span(v-else)
         | Started #[span(:title="event.timestamp") {{event.timestamp | friendlytime}}]
         | &nbsp;({{event.data.running ? (now - event.timestamp) / 1000 : event.duration | friendlyduration}})
-    div
+    div.stopwatch-entry__actions
       b-button.mx-1(v-if="event.data.running", @click="stop", variant="outline-primary", size="sm")
         icon.ml-0.mr-1(name="stop")
         | Stop
@@ -24,8 +24,17 @@ div
 </template>
 
 <style scoped lang="scss">
-#root:hover {
-  background-color: #eee;
+.stopwatch-entry {
+  border-bottom: 1px solid #eee;
+}
+
+.stopwatch-entry:hover {
+  background-color: #f8f9fa;
+}
+
+.stopwatch-entry__actions {
+  display: flex;
+  flex-wrap: nowrap;
 }
 </style>
 

--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -1,18 +1,19 @@
 <template lang="pug">
 div
-  // TODO: Add some way to disable this notification, probably by making the ratio threshold configurable
-  b-alert.my-2(v-if="isVisible", variant="info", show)
+  b-alert.my-2(v-if="isVisible", variant="info", show dismissible @dismissed="onDismiss")
     p.mb-0
       | #[b High uncategorized time]
       br
       | You have a total of {{ uncategorizedDuration[0] | friendlyduration }} uncategorized time,
       | that's {{ Math.round(100 * uncategorizedDuration[0] / uncategorizedDuration[1]) }}% of all time {{ periodText }}.
       | You can address this by using the #[router-link(:to="{ path: '/settings/categorization', query: { builder: 'open' } }") Category Builder].
+      | #[small.text-muted.d-block.mt-1 You can hide or adjust this hint in #[router-link(:to="{ path: '/settings/general' }") Settings].]
 </template>
 
 <script lang="ts">
 import { mapState } from 'pinia';
 import { useActivityStore } from '~/stores/activity';
+import { useSettingsStore } from '~/stores/settings';
 
 export default {
   name: 'aw-uncategorized-notification',
@@ -24,8 +25,8 @@ export default {
   },
   computed: {
     ...mapState(useActivityStore, ['uncategorizedDuration']),
+    ...mapState(useSettingsStore, ['uncategorizedNotificationData']),
     ratio() {
-      console.log(this.uncategorizedDuration);
       return this.uncategorizedDuration
         ? this.uncategorizedDuration[0] / this.uncategorizedDuration[1]
         : 0;
@@ -45,14 +46,29 @@ export default {
       return periodMap[this.periodLength] || 'today';
     },
     isVisible() {
-      // TODO: make configurable?
-      // if total duration is less than 1 hour, don't show it
-      const overTotal = this.total > 60 * 60;
-      // if ratio is > 0.3, show it
-      const overRatio = this.ratio > 0.3;
+      const cfg = this.uncategorizedNotificationData || {};
+      if (cfg.isEnabled === false) return false;
+      const minTotalSeconds =
+        typeof cfg.minTotalSeconds === 'number' ? cfg.minTotalSeconds : 60 * 60;
+      const minRatio = typeof cfg.minRatio === 'number' ? cfg.minRatio : 0.3;
+      const overTotal = this.total > minTotalSeconds;
+      const overRatio = this.ratio > minRatio;
       // if there's a category filter (url has category query param), don't show it
       const hasCategoryFilter = this.$route.query.category;
       return overTotal && overRatio && !hasCategoryFilter;
+    },
+  },
+  methods: {
+    onDismiss() {
+      // Dismiss persists by disabling the hint outright; user can
+      // re-enable from Settings → General.
+      const settingsStore = useSettingsStore();
+      settingsStore.update({
+        uncategorizedNotificationData: {
+          ...this.uncategorizedNotificationData,
+          isEnabled: false,
+        },
+      });
     },
   },
 };

--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -7,7 +7,7 @@ div
       | You have a total of {{ uncategorizedDuration[0] | friendlyduration }} uncategorized time,
       | that's {{ Math.round(100 * uncategorizedDuration[0] / uncategorizedDuration[1]) }}% of all time {{ periodText }}.
       | You can address this by using the #[router-link(:to="{ path: '/settings/categorization', query: { builder: 'open' } }") Category Builder].
-      | #[small.text-muted.d-block.mt-1 You can hide or adjust this hint in #[router-link(:to="{ path: '/settings/general' }") Settings].]
+      | #[small.d-block.mt-1(style="opacity: 0.85") You can hide or adjust this hint in #[router-link(:to="{ path: '/settings/general' }") Settings].]
 </template>
 
 <script lang="ts">

--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -83,10 +83,10 @@ export default {
 <style scoped>
 .uncategorized-hint__cog {
   color: inherit;
-  opacity: 0.7;
+  opacity: 0.45;
 }
 .uncategorized-hint__cog:hover,
 .uncategorized-hint__cog:focus {
-  opacity: 1;
+  opacity: 0.85;
 }
 </style>

--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -3,14 +3,20 @@ div
   b-alert.my-2(v-if="isVisible", variant="info", show dismissible @dismissed="onDismiss")
     p.mb-0
       | #[b High uncategorized time]
+      router-link.ml-1.uncategorized-hint__cog(
+        :to="{ path: '/settings/general' }"
+        title="Hide or adjust this hint in Settings"
+        aria-label="Hide or adjust this hint in Settings"
+      )
+        icon(name="cog" scale="0.85")
       br
       | You have a total of {{ uncategorizedDuration[0] | friendlyduration }} uncategorized time,
       | that's {{ Math.round(100 * uncategorizedDuration[0] / uncategorizedDuration[1]) }}% of all time {{ periodText }}.
       | You can address this by using the #[router-link(:to="{ path: '/settings/categorization', query: { builder: 'open' } }") Category Builder].
-      | #[small.d-block.mt-1(style="opacity: 0.85") You can hide or adjust this hint in #[router-link(:to="{ path: '/settings/general' }") Settings].]
 </template>
 
 <script lang="ts">
+import 'vue-awesome/icons/cog';
 import { mapState } from 'pinia';
 import { useActivityStore } from '~/stores/activity';
 import { useSettingsStore } from '~/stores/settings';
@@ -73,3 +79,14 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.uncategorized-hint__cog {
+  color: inherit;
+  opacity: 0.7;
+}
+.uncategorized-hint__cog:hover,
+.uncategorized-hint__cog:focus {
+  opacity: 1;
+}
+</style>

--- a/src/components/UncategorizedNotification.vue
+++ b/src/components/UncategorizedNotification.vue
@@ -7,7 +7,7 @@ div
       br
       | You have a total of {{ uncategorizedDuration[0] | friendlyduration }} uncategorized time,
       | that's {{ Math.round(100 * uncategorizedDuration[0] / uncategorizedDuration[1]) }}% of all time {{ periodText }}.
-      | You can address this by using the #[router-link(:to="{ path: '/settings/category-builder' }") Category Builder].
+      | You can address this by using the #[router-link(:to="{ path: '/settings/categorization', query: { builder: 'open' } }") Category Builder].
 </template>
 
 <script lang="ts">

--- a/src/route.js
+++ b/src/route.js
@@ -65,7 +65,10 @@ const router = new VueRouter({
     { path: '/alerts', component: Alerts },
     { path: '/timespiral', component: TimespiralView },
     { path: '/settings', component: Settings },
-    { path: '/settings/category-builder', component: CategoryBuilder },
+    // Category Builder now lives embedded inside the Categorization
+    // settings panel; keep the old standalone route as a redirect so
+    // external links / bookmarks still land somewhere useful.
+    { path: '/settings/category-builder', redirect: '/settings/categorization' },
     // :group lets the active settings panel survive reloads / be linkable.
     // The matcher excludes 'category-builder' so the more specific route above
     // wins; new groups added in Settings.vue should also be added here.

--- a/src/route.js
+++ b/src/route.js
@@ -73,7 +73,7 @@ const router = new VueRouter({
     // The matcher excludes 'category-builder' so the more specific route above
     // wins; new groups added in Settings.vue should also be added here.
     {
-      path: '/settings/:group(general|appearance|updates|categorization|privacy|developer)',
+      path: '/settings/:group(general|appearance|categorization|privacy|developer)',
       component: Settings,
       props: true,
     },

--- a/src/route.js
+++ b/src/route.js
@@ -13,7 +13,10 @@ const QueryExplorer = () => import('./views/QueryExplorer.vue');
 const Timeline = () => import('./views/Timeline.vue');
 const Trends = () => import('./views/Trends.vue');
 const Settings = () => import('./views/settings/Settings.vue');
-const CategoryBuilder = () => import('./views/settings/CategoryBuilder.vue');
+// CategoryBuilder is no longer a top-level route — it's embedded inside
+// CategorizationSettings. The /settings/category-builder path is now a
+// redirect, so no direct reference here. Keeping the import out avoids
+// pulling a second copy into a separate chunk.
 const Stopwatch = () => import('./views/Stopwatch.vue');
 const WorkReport = () => import('./views/WorkReport.vue');
 const Alerts = () => import('./views/Alerts.vue');

--- a/src/route.js
+++ b/src/route.js
@@ -66,6 +66,14 @@ const router = new VueRouter({
     { path: '/timespiral', component: TimespiralView },
     { path: '/settings', component: Settings },
     { path: '/settings/category-builder', component: CategoryBuilder },
+    // :group lets the active settings panel survive reloads / be linkable.
+    // The matcher excludes 'category-builder' so the more specific route above
+    // wins; new groups added in Settings.vue should also be added here.
+    {
+      path: '/settings/:group(general|appearance|updates|categorization|privacy|developer)',
+      component: Settings,
+      props: true,
+    },
     { path: '/stopwatch', component: Stopwatch },
     { path: '/work-report', component: WorkReport },
     { path: '/search', component: Search },

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -31,11 +31,29 @@ export const useBucketsStore = defineStore('buckets', {
     hosts(state: State): string[] {
       // TODO: Include consideration of device_id UUID
       let hosts = _.uniq(_.map(state.buckets, bucket => bucket.hostname || bucket.data.hostname));
-      // sort by last_updated, such that the most recently updated host is first (likely the current host)
+
+      // Sort priority:
+      //   1. Host that matches the server's own hostname (the device the
+      //      webui is running on) — almost always what the user wants by
+      //      default in views like Alerts/Trends.
+      //   2. Hosts that actually have the buckets we typically query against
+      //      (window + AFK), so views don't pick a stale legacy hostname
+      //      with only one orphan bucket and then immediately error out.
+      //   3. Then by last_updated, newest first (legacy behavior).
+      const serverStore = useServerStore();
+      const selfHost = serverStore.info && serverStore.info.hostname;
       hosts = _.orderBy(
         hosts,
-        host => _.max(_.map(this.bucketsByHostname[host], b => b.last_updated)),
-        ['desc']
+        [
+          host => (host && host === selfHost ? 1 : 0),
+          host => {
+            const hasWindow = this.bucketsWindow(host).length > 0;
+            const hasAfk = this.bucketsAFK(host).length > 0;
+            return hasWindow && hasAfk ? 2 : hasWindow || hasAfk ? 1 : 0;
+          },
+          host => _.max(_.map(this.bucketsByHostname[host], b => b.last_updated)) || '',
+        ],
+        ['desc', 'desc', 'desc']
       );
       return hosts;
     },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -39,6 +39,14 @@ interface State {
     nextPollTime: Moment;
     timesPollIsShown: number;
   };
+  uncategorizedNotificationData: {
+    isEnabled: boolean;
+    // Below this total tracked duration (seconds) the hint is hidden —
+    // avoids nagging on quiet days.
+    minTotalSeconds: number;
+    // Hint shows when the uncategorized fraction crosses this ratio.
+    minRatio: number;
+  };
   always_active_pattern: string;
   privacy_filters: PrivacyFilterRule[];
   classes: Category[];
@@ -82,6 +90,11 @@ export const useSettingsStore = defineStore('settings', {
       isEnabled: true,
       nextPollTime: moment().add(INITIAL_WAIT_PERIOD, 'seconds'),
       timesPollIsShown: 0,
+    },
+    uncategorizedNotificationData: {
+      isEnabled: true,
+      minTotalSeconds: 60 * 60, // 1 hour
+      minRatio: 0.3, // 30%
     },
 
     always_active_pattern: '',

--- a/src/util/timelineLabels.ts
+++ b/src/util/timelineLabels.ts
@@ -11,10 +11,43 @@ function addWrapOpportunities(str: string): string {
   // Insert zero-width space after word-breaking characters so the label
   // breaks at natural boundaries without HTML <wbr> tags (vis-timeline
   // does not support <wbr> in group label content).
-  return str.replace(/([/_-])/g, '$1\u200B');
+  return str.replace(/([/_-])/g, '$1​');
 }
 
-export function formatTimelineBucketLabelHtml(bucketId: string): string {
+// Strips the noisy aw-watcher- / aw- prefix and the trailing
+// _<hostname> segment so a bucket id like
+//   aw-watcher-window_erb-m2.localdomain
+// reads as just "window" in the timeline's row label. The full id is
+// still surfaced via the <title> tooltip on hover for unambiguity.
+// Returns null when the input doesn't match the conventional shape, so
+// callers can fall back to the original id.
+export function shortenBucketLabel(bucketId: string): string | null {
+  // Drop the host suffix first (everything from the first underscore on).
+  // Some bucket ids have no host (e.g. "aw-stopwatch"), in which case we
+  // keep the full id.
+  const sepIdx = bucketId.indexOf('_');
+  const head = sepIdx === -1 ? bucketId : bucketId.slice(0, sepIdx);
+
+  // Drop the conventional prefix.
+  let body = head;
+  if (body.startsWith('aw-watcher-')) body = body.slice('aw-watcher-'.length);
+  else if (body.startsWith('aw-')) body = body.slice('aw-'.length);
+
+  if (!body || body === head) return null;
+  return body;
+}
+
+export interface BucketLabelOptions {
+  // When the timeline mixes buckets from multiple hosts (no host filter
+  // applied), the short label "window" collides between hosts. Pass the
+  // bucket's hostname to disambiguate as e.g. "window @ host".
+  hostname?: string;
+}
+
+export function formatTimelineBucketLabelHtml(
+  bucketId: string,
+  options: BucketLabelOptions = {}
+): string {
   const escaped = escapeHtml(bucketId);
   const syncMatch = bucketId.match(/^([^_]+)_.*-synced-from-(.+)$/);
 
@@ -24,5 +57,16 @@ export function formatTimelineBucketLabelHtml(bucketId: string): string {
     return `<span class="timeline-label" title="${escaped}">${baseLabel} (synced from ${remoteLabel})</span>`;
   }
 
+  const short = shortenBucketLabel(bucketId);
+  if (short) {
+    let display = short;
+    if (options.hostname) {
+      display = `${short} @ ${options.hostname}`;
+    }
+    const shortLabel = addWrapOpportunities(escapeHtml(display));
+    return `<span class="timeline-label" title="${escaped}">${shortLabel}</span>`;
+  }
+
+  // Fallback: keep the full id with wrap opportunities.
   return `<span class="timeline-label" title="${escaped}">${addWrapOpportunities(escaped)}</span>`;
 }

--- a/src/util/workReport.ts
+++ b/src/util/workReport.ts
@@ -77,5 +77,11 @@ export function buildWorkReportQuery(
           duration = sum_durations(events);
           RETURN = {"events": events, "duration": duration};
         `;
-  return query;
+  // Strip per-line trailing whitespace so the snapshot test stays stable
+  // under the trailing-whitespace pre-commit hook. aw-query is whitespace-
+  // tolerant so this has no runtime effect.
+  return query
+    .split('\n')
+    .map(line => line.replace(/\s+$/, ''))
+    .join('\n');
 }

--- a/src/util/workReport.ts
+++ b/src/util/workReport.ts
@@ -45,3 +45,37 @@ export function getSupportedWorkReportHosts(selectedHosts: string[], buckets: IB
   const unsupportedHosts = new Set(getUnsupportedWorkReportHosts(selectedHosts, buckets));
   return selectedHosts.filter(host => !unsupportedHosts.has(host));
 }
+
+// Builds the aw-query string for the Work Time Report. Extracted from the
+// component so the generated query can be snapshot-tested — that's how we
+// catch arg-count regressions like flood(events, breakTime) which aw-query
+// rejects with "Tried to call function flood with invalid amount of arguments".
+export function buildWorkReportQuery(
+  hosts: string[],
+  categoriesStr: string,
+  categoriesFilter: any[]
+): string {
+  let query = '';
+  for (let hi = 0; hi < hosts.length; hi++) {
+    const hostname = hosts[hi];
+    query += `
+            events_${hi} = flood(query_bucket("aw-watcher-window_${hostname}"));
+            not_afk_${hi} = flood(query_bucket("aw-watcher-afk_${hostname}"));
+            not_afk_${hi} = filter_keyvals(not_afk_${hi}, "status", ["not-afk"]);
+            events_${hi} = filter_period_intersect(events_${hi}, not_afk_${hi});
+            events_${hi} = categorize(events_${hi}, ${categoriesStr});
+            events_${hi} = filter_keyvals(events_${hi}, "$category", ${JSON.stringify(
+      categoriesFilter
+    )});
+          `;
+  }
+  query += '\nevents = [];';
+  for (let hi = 0; hi < hosts.length; hi++) {
+    query += `\nevents = union_no_overlap(events, events_${hi});`;
+  }
+  query += `
+          duration = sum_durations(events);
+          RETURN = {"events": events, "duration": duration};
+        `;
+  return query;
+}

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -7,11 +7,15 @@ div
   // TODO: Send notifications when goals met
   // TODO: Query from day start, not 24h ago
 
-  b-alert(style="warning" show)
+  b-alert(variant="warning" show)
     | This feature is still in early development.
 
   b-alert(v-if="error" show variant="danger")
     | {{error}}
+
+  b-alert(v-if="hostnames.length === 0" show variant="info")
+    | No host with both window and AFK buckets is available, so alerts can't run yet.
+    | Install #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") aw-watcher-window and aw-watcher-afk] to enable this view.
 
   b-card(v-for="alert in alerts", :key="alert.name")
     b-button.float-right(@click="deleteAlert(alert.name)" size="sm" variant="outline-danger")
@@ -21,17 +25,16 @@ div
     div Category: {{ alert.category.join(" > ") }}
     div Current: {{ alertTime(alert.category) | friendlyduration }} / {{alert.goal}} minutes
       span(v-if="alertTime(alert.category) >= alert.goal")
-        icon(name="check" style="color: #0C0")
+        icon.text-success(name="check")
       span(v-else)
-        icon(name="times" color="#555")
+        icon.text-muted(name="times")
 
-  b-input-group.mt-3
-    b-btn(@click="check" variant="success") Check
-    b-input-group-append
-      b-form-checkbox.my-2.ml-3(v-model="autorefresh", @change="toggleAutoRefresh", switch) Toggle autorefresh every 10s
+  div.d-flex.align-items-center.mt-3
+    b-btn(@click="check" variant="success" :disabled="!hostname") Check
+    b-form-checkbox.ml-3.mb-0(v-model="autorefresh", @change="toggleAutoRefresh", switch) Auto-refresh every 10s
 
-  small(v-if="last_updated")
-    | Last updated: {{ last_updated }}
+  small.text-muted(v-if="last_updated")
+    | Last updated #[time(:datetime="last_updated && last_updated.toISOString && last_updated.toISOString()") {{ last_updated | friendlytime }}]
 
   hr
 
@@ -118,7 +121,13 @@ export default {
   mounted: async function () {
     await this.bucketsStore.ensureLoaded();
     await this.categoryStore.load();
-    this.hostnames = this.bucketsStore.hosts;
+    // Filter to hosts that actually have the buckets we query against.
+    // Prevents "There's no bucket named 'aw-watcher-afk_<host>'" when the
+    // hosts list contains a stale hostname with only one orphan bucket.
+    this.hostnames = this.bucketsStore.hosts.filter(
+      h =>
+        this.bucketsStore.bucketsWindow(h).length > 0 && this.bucketsStore.bucketsAFK(h).length > 0
+    );
     this.hostname = this.hostnames[0];
   },
   methods: {

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -42,7 +42,7 @@ div
           icon(name="ellipsis-v")
         b-dropdown-item-button(
           @click="openDeleteHostModal(device)",
-          variant="danger",
+          button-class="text-danger",
           :title="`Delete all ${device.buckets.length} buckets for ${device.hostname}`"
         )
           icon.mr-1(name="trash")
@@ -81,7 +81,7 @@ div
               icon.mr-1(name="download")
               | Export events as CSV
             b-dropdown-divider
-            b-dropdown-item-button(@click="openDeleteBucketModal(data.item.id)", title="Delete this bucket permanently", variant="danger")
+            b-dropdown-item-button(@click="openDeleteBucketModal(data.item.id)", title="Delete this bucket permanently", button-class="text-danger")
               icon.mr-1(name="trash")
               | Delete bucket
 
@@ -198,17 +198,17 @@ div
 }
 
 ::v-deep .bucket-table td {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   vertical-align: middle;
 }
 
+// Truncate only the bucket id span itself, not the cell — applying
+// overflow:hidden to the td clips the row's kebab popover menu.
 ::v-deep .bucket-id {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   vertical-align: middle;
 }
 

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -1,93 +1,97 @@
 <template lang="pug">
 div
-  h2 Buckets
+  h3 Buckets
 
   b-alert(show)
-    | Are you looking to collect more data? Check out #[a(href="https://activitywatch.readthedocs.io/en/latest/watchers.html") the docs] for more watchers.
+    | Are you looking to collect more data? Check out #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") the docs] for more watchers.
 
   // By device
-  b-card.mb-3(v-for="device in bucketsStore.bucketsByDevice", :key="device.hostname || device.device_id")
-    div.mb-3
-      div.d-flex.justify-content-between
-        div.d-flex
-          div
-            icon(v-if="device.hostname === 'unknown'" name="question")
-            // TODO: detect device type somewhere else (should unify with store logic)
-            icon(v-else, name="desktop")
-            | &nbsp;
-          div
-            b {{ device.hostname }}
-            span.small.ml-2(v-if="serverStore.info.hostname == device.hostname")
-              | (the current device)
-            div.small
-              div(v-if="device.hostname !== device.device_id", style="color: #666")
-                | ID: {{ device.id }}
-              div
-                | Last updated:&nbsp;
-                time(:style="{'color': isRecent(device.last_updated) ? 'green' : 'inherit'}",
-                     :datetime="device.last_updated",
-                     :title="device.last_updated")
-                  | {{ device.last_updated | friendlytime }}
-              div
-                | First seen:&nbsp;
-                time(:datetime="device.first_seen",
-                     :title="device.first_seen")
-                  | {{ device.first_seen | friendlytime }}
+  b-card.bucket-card.mb-3(
+    v-for="device in bucketsStore.bucketsByDevice",
+    :key="device.hostname || device.device_id",
+    :class="{'bucket-card--unknown': device.hostname === 'unknown'}"
+  )
+    div.d-flex.justify-content-between.align-items-start.mb-2
+      div.d-flex.align-items-center
+        icon.mr-2.text-muted(v-if="device.hostname === 'unknown'" name="question" scale="1.2")
+        icon.mr-2.text-secondary(v-else, name="desktop" scale="1.2")
         div
-          b-dropdown(size="sm",
-                     variant="outline-secondary",
-                     no-caret,
-                     right,
-                     :title="`More actions for ${device.hostname}`",
-                     :aria-label="`More actions for ${device.hostname}`")
+          span.font-weight-bold {{ device.hostname }}
+          b-badge.ml-2(v-if="serverStore.info.hostname == device.hostname" variant="info") this device
+          div.small.text-muted(v-if="device.hostname !== device.device_id")
+            | ID: {{ device.id }}
+          div.small(v-if="deviceHasEvents(device)")
+            span.text-muted Last updated&nbsp;
+            time(:class="{'text-success': isRecent(device.last_updated)}",
+                 :datetime="device.last_updated",
+                 :title="device.last_updated")
+              | {{ device.last_updated | friendlytime }}
+          div.small.text-muted(v-else)
+            | No events recorded yet
+      b-dropdown.kebab-dropdown(
+        size="sm",
+        variant="outline-secondary",
+        toggle-class="border-0",
+        no-caret,
+        right,
+        boundary="window",
+        :title="`More actions for ${device.hostname}`",
+        :aria-label="`More actions for ${device.hostname}`"
+      )
+        template(v-slot:button-content)
+          icon(name="ellipsis-v")
+        b-dropdown-item-button(
+          @click="openDeleteHostModal(device)",
+          variant="danger",
+          :title="`Delete all ${device.buckets.length} buckets for ${device.hostname}`"
+        )
+          icon.mr-1(name="trash")
+          | Delete all buckets for this host
+
+    // No `responsive` wrapper: with fixed column widths the table fits its
+    // container, and dropping the wrapper means the row dropdowns can render
+    // outside the table without being clipped by overflow-x: auto.
+    b-table.mb-0.bucket-table(
+      small, hover,
+      :items="device.buckets",
+      :fields="fields"
+    )
+      template(v-slot:cell(id)="data")
+        small.text-monospace.bucket-id(:title="data.item.id") {{ data.item.id }}
+      template(v-slot:cell(last_updated)="data")
+        small(v-if="bucketHasEvents(data.item)", :class="{'text-success': isRecent(data.item.last_updated)}")
+          | {{ data.item.last_updated | friendlytime }}
+        small.text-muted(v-else) no events
+      template(v-slot:cell(actions)="data")
+        b-button-group(size="sm")
+          b-button(variant="primary", :to="'/buckets/' + data.item.id", title="Open bucket")
+            icon.d-none.d-md-inline-block.mr-1(name="folder-open")
+            | Open
+          // boundary="window" so the menu renders on top of the
+          // b-table's responsive overflow wrapper instead of being clipped
+          // (which previously made the whole row turn into a scrollbox).
+          b-dropdown.kebab-dropdown(variant="outline-secondary", toggle-class="border-0", size="sm", right, no-caret, boundary="window", title="More actions")
             template(v-slot:button-content)
               icon(name="ellipsis-v")
-            b-dropdown-item-button(@click="openDeleteHostModal(device)",
-                     variant="danger",
-                     :title="`Delete all ${device.buckets.length} buckets for ${device.hostname}`")
-              icon(name="trash")
-              |  Delete all buckets for this host
+            // FIXME: These also exist as almost-copies in the Bucket view, can maybe be shared/reused instead.
+            b-dropdown-item(@click="export_bucket_json(data.item.id)", title="Export bucket to JSON")
+              icon.mr-1(name="download")
+              | Export as JSON
+            b-dropdown-item(@click="export_csv(data.item.id)", title="Export events to CSV")
+              icon.mr-1(name="download")
+              | Export events as CSV
+            b-dropdown-divider
+            b-dropdown-item-button(@click="openDeleteBucketModal(data.item.id)", title="Delete this bucket permanently", variant="danger")
+              icon.mr-1(name="trash")
+              | Delete bucket
 
-    b-row
-      b-col
-        b-table.mb-0(small, hover, :items="device.buckets", :fields="fields", responsive="md")
-          template(v-slot:cell(last_updated)="data")
-            small(v-if="data.item.last_updated", :style="{'color': isRecent(data.item.last_updated) ? 'green' : 'inherit'}")
-              | {{ data.item.last_updated | friendlytime }}
-          template(v-slot:cell(actions)="data")
-            b-button-toolbar.float-right
-              b-button-group(size="sm", class="mx-1")
-                b-button(variant="primary", :to="'/buckets/' + data.item.id")
-                  icon(name="folder-open").d-none.d-md-inline-block
-                  | Open
-                b-dropdown(variant="outline-secondary", size="sm", text="More")
-                  // FIXME: These also exist as almost-copies in the Bucket view, can maybe be shared/reused instead.
-                  b-dropdown-item(
-                             @click="export_bucket_json(data.item.id)",
-                             title="Export bucket to JSON",
-                             variant="secondary")
-                      icon(name="download")
-                      | Export bucket as JSON
-                  b-dropdown-item(
-                              @click="export_csv(data.item.id)",
-                             title="Export events to CSV",
-                             variant="secondary")
-                      icon(name="download")
-                      | Export events as CSV
-                  b-dropdown-divider
-                  b-dropdown-item-button(@click="openDeleteBucketModal(data.item.id)",
-                           title="Delete this bucket permanently",
-                           variant="danger")
-                    | #[icon(name="trash")] Delete bucket
+    div(v-for="msg in runChecks(device)" :key="msg")
+      b-alert.mt-2.mb-0.py-1.px-2.small(show variant="warning")
+        icon(name="exclamation-triangle")
+        | &nbsp;
+        | {{ msg }}
 
-    // Checks
-    hr.mt-1(v-if="runChecks(device).length > 0")
-    div.small.text-muted(v-for="msg in runChecks(device)", style="color: #333")
-      icon(name="exclamation-triangle")
-      | &nbsp;
-      | {{ msg }}
-
-  b-modal(id="delete-modal", title="Danger!", centered, hide-footer)
+  b-modal(id="delete-modal", title="Delete bucket?", centered, hide-footer)
     | Are you sure you want to delete bucket "{{delete_bucket_selected}}"?
     br
     br
@@ -99,7 +103,7 @@ div
       b-button(@click="deleteBucket(delete_bucket_selected)", variant="danger")
         | Confirm
 
-  b-modal(id="delete-host-modal", title="Danger!", centered, hide-footer, @hidden="delete_host_selected = null; delete_host_error = null")
+  b-modal(id="delete-host-modal", :title="delete_host_selected ? `Delete all buckets for ${delete_host_selected.hostname}?` : 'Delete buckets?'", centered, hide-footer, @hidden="delete_host_selected = null; delete_host_error = null")
     template(v-if="delete_host_selected")
       | Are you sure you want to delete
       |
@@ -128,31 +132,33 @@ div
           template(v-else)
             | Confirm
 
-  h3 Import and export buckets
+  h4.mt-4 Import and export buckets
 
   b-card-group.deck
     b-card(header="Import buckets")
-      b-alert(v-if="import_error" show variant="danger" dismissable)
+      b-alert(v-if="import_error" show variant="danger" dismissible)
         | {{ import_error }}
       b-form-file(v-model="import_file"
                   placeholder="Choose or drop a file here..."
                   drop-placeholder="Drop file here...")
-      // TODO: This spinner could be placed in a more suitable place
-      div(v-if="import_file" class="spinner-border" role="status")
-      span
-        | A valid file to import is a JSON file from either an export of a single bucket or an export from multiple buckets.
-        | If there are buckets with the same name the import will fail.
+      div.mt-2(v-if="import_file")
+        b-spinner.mr-2(small)
+        small.text-muted Importing...
+      small.d-block.mt-2.text-muted
+        | Provide a JSON file exported from a single bucket or from multiple buckets.
+        | Import fails if a bucket with the same ID already exists.
     b-card(header="Export buckets")
+      p.small.text-muted Download every bucket on this server as a single JSON file. Use this for backups.
       b-button(@click="export_all_buckets_json()",
                title="Export all buckets to JSON",
                variant="outline-secondary")
-        icon(name="download")
+        icon.mr-1(name="download")
         | Export all buckets as JSON
 
   hr
 
   aw-devonly(reason="This section is still under development")
-    h2.p-2 Tools
+    h4.p-2 Tools
 
     hr
 
@@ -180,6 +186,44 @@ div
 <style scoped lang="scss">
 .bucket-card {
   margin-bottom: 1em;
+}
+
+.bucket-card--unknown {
+  opacity: 0.85;
+  background: #fbfbfb;
+}
+
+.bucket-table {
+  table-layout: fixed;
+}
+
+::v-deep .bucket-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+::v-deep .bucket-id {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+// Ghost-styled kebab dropdowns: invisible until hover/focus, like
+// the "borderless" overflow menus in most modern UIs.
+::v-deep .kebab-dropdown > .btn {
+  color: #6c757d;
+  background: transparent;
+}
+
+::v-deep .kebab-dropdown > .btn:hover,
+::v-deep .kebab-dropdown > .btn:focus,
+::v-deep .kebab-dropdown.show > .btn {
+  background: #f0f1f3;
+  color: #212529;
 }
 
 .bucket-last-updated {
@@ -223,11 +267,33 @@ export default {
       delete_host_selected: null,
       deleting_host: false,
       delete_host_error: null,
+      // Explicit thStyle widths so each device's table aligns with the
+      // others (b-table otherwise auto-fits per-card based on its own
+      // content, which produced jagged columns across hosts).
       fields: [
-        { key: 'id', label: 'Bucket ID', sortable: true },
-        { key: 'hostname', sortable: true },
-        { key: 'last_updated', label: 'Updated', sortable: true },
-        { key: 'actions', label: '' },
+        {
+          key: 'id',
+          label: 'Bucket ID',
+          sortable: true,
+          thStyle: { width: '45%' },
+        },
+        {
+          key: 'hostname',
+          sortable: true,
+          thStyle: { width: '25%' },
+        },
+        {
+          key: 'last_updated',
+          label: 'Updated',
+          sortable: true,
+          thStyle: { width: '15%' },
+        },
+        {
+          key: 'actions',
+          label: '',
+          thStyle: { width: '15%' },
+          tdClass: 'text-right',
+        },
       ],
     };
   },
@@ -258,6 +324,18 @@ export default {
   methods: {
     isRecent: function (date) {
       return moment().diff(date) / 1000 < 120;
+    },
+    // last_updated is only set once a bucket has actually been written to:
+    //   - aw-server-python omits it when the bucket has no events
+    //   - aw-server-rust's store harmonization (see update_buckets) sets
+    //     last_updated from metadata.end, which is also only present once
+    //     events exist
+    // The previous device-level "Last updated 0s ago" was just moment(undefined).fromNow().
+    bucketHasEvents: function (bucket) {
+      return Boolean(bucket && bucket.last_updated);
+    },
+    deviceHasEvents: function (device) {
+      return _.some(device.buckets, b => this.bucketHasEvents(b));
     },
     runChecks: function (device) {
       const checks = [

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -5,10 +5,7 @@ div
   b-alert(show variant="warning")
     | This feature is still in early development. See PR #[a(href="https://github.com/ActivityWatch/aw-webui/pull/365") aw-webui#365] for more information.
 
-  | Displays a graph of categories and their transitions.
-
-  b-alert.mt-2(style="warning" show)
-    | This feature is still in early development.
+  p Displays a graph of categories and their transitions.
 
   b-alert(v-if="error" show variant="danger")
     | {{error}}
@@ -28,7 +25,7 @@ div
       | Generate
 
   div.d-flex.mt-1
-    span.mr-auto.small(style="color: #666") Hostname: {{queryOptions.hostname}}
+    span.mr-auto.small.text-muted Hostname: {{queryOptions.hostname}}
     b-button.border-0(size="sm", variant="outline-dark" @click="show_options = !show_options")
       span(v-if="!show_options")
         | #[icon(name="angle-double-down")] Show options

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,16 +3,18 @@ div
   b-alert(v-if="$isAndroid" show)
     | #[b Note:] ActivityWatch on Android is in a very early stage of development. There will be bugs, but we hope you bear with us as we refine things and get it on par with the desktop version of ActivityWatch (which you should try!).
 
-  h3 Hello early user,
+  h3 Welcome to ActivityWatch
   p
-    | It's still early days for ActivityWatch#[span(v-if="$isAndroid") (especially on Android!)]. We've come a long way but we need users (like you!)
-    | to provide feedback and help us turn ActivityWatch into a successful project.
-    | Early users like you mean a lot to us, and we hope you'll reach out to us with any ideas you have for improvements!
+    | We've come a long way#[span(v-if="$isAndroid") (especially on Android!)] but we still need users (like you!) to provide feedback and help us turn ActivityWatch into a successful project.
+    | We'd love to hear any ideas you have for improvements.
   p
     | If you are a developer, we hope you can contribute by writing a watcher, visualization, or something else, and share it with us on the forum!
+  p.mb-0 Thank you for using ActivityWatch!
   p
-    div Thank you for using ActivityWatch!
-    small If you have a minute to spare, please take the time to fill out our #[a(href="https://forms.gle/q2N9K5RoERBV8kqPA") user survey] or #[a(href="https://forum.activitywatch.net/c/features") vote on features on the forum].
+    a(href="https://forms.gle/q2N9K5RoERBV8kqPA") Fill out our user survey
+    | &nbsp;or&nbsp;
+    a(href="https://forum.activitywatch.net/c/features") vote on features on the forum
+    | &nbsp;to help shape what comes next.
 
   hr
 
@@ -46,20 +48,20 @@ div
   div.row
     div.col-md-6
       h4 Resources
-      p
-        ul
-          li #[a(href="https://activitywatch.net/") Website]
-          li #[a(href="https://activitywatch.readthedocs.org/") Documentation]
-          li #[a(href="https://forum.activitywatch.net/") Forum]
-          li #[a(href="https://discord.gg/vDskV9q") Discord]
-          li #[a(href="https://www.reddit.com/r/activitywatch/") Reddit]
-          li #[a(href="https://github.com/ActivityWatch/activitywatch") GitHub]
-          li(v-if="!info.version.includes('rust')" ) #[a(href="/api/") API Browser]
+      ul
+        li #[a(href="https://activitywatch.net/") Website]
+        li #[a(href="https://docs.activitywatch.net/") Documentation]
+        li #[a(href="https://forum.activitywatch.net/") Forum]
+        li #[a(href="https://discord.gg/vDskV9q") Discord]
+        li #[a(href="https://www.reddit.com/r/activitywatch/") Reddit]
+        li #[a(href="https://github.com/ActivityWatch/activitywatch") GitHub]
+        li(v-if="!info.version.includes('rust')") #[a(:href="apiBrowserUrl") API Browser]
 
     div.col-md-6
-      h4 Want to know what we're working on?
+      h4 What we're working on
       p
-        | Check out the #[a(href="https://forum.activitywatch.net/c/news") development updates]!
+        | Stay up to date with the #[a(href="https://forum.activitywatch.net/c/news") development updates]
+        | and follow the project on #[a(href="https://github.com/ActivityWatch/activitywatch") GitHub] for release notes.
 
   hr
 
@@ -78,6 +80,12 @@ export default {
   name: 'Home',
   computed: {
     ...mapState(useServerStore, ['info']),
+    // Resolve the API browser link relative to the current document so it
+    // works when the webui is served behind a reverse proxy at a sub-path.
+    apiBrowserUrl(): string {
+      const base = window.location.pathname.replace(/[^/]*$/, '');
+      return base + 'api/';
+    },
   },
 };
 </script>

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -4,7 +4,7 @@ div
 
   | Generate a report of time spent on a certain category of device activity.
 
-  b-alert.mt-2(style="warning" show)
+  b-alert.mt-2(variant="warning" show)
     | This feature is still in early development.
 
   b-alert(v-if="error" show variant="danger")
@@ -17,7 +17,7 @@ div
         | Generate
 
   div.d-flex.mt-1
-    span.mr-auto.small(style="color: #666") Hostname: {{queryOptions.hostname}}
+    span.mr-auto.small.text-muted Hostname: {{queryOptions.hostname}}
     b-button.border-0(size="sm", variant="outline-dark" @click="show_options = !show_options")
       span(v-if="!show_options")
         | #[icon(name="angle-double-down")] Show options
@@ -37,7 +37,7 @@ div
 
     div.d-flex
       div.flex-fill
-        | Found {{ events.length }} events in {{ queryTime / 1000 }} seconds
+        | Found {{ events.length }} events in {{ (queryTime / 1000).toFixed(2) }} seconds
       div
         b-input-group(size="sm")
           b-input-group-prepend
@@ -53,8 +53,8 @@ div
     hr
 
     vis-timeline(:events="events.slice(0, 500)" filterShortEvents=true)
-    div.small(v-if="events.length > 500")
-      | Too many events, will only show last 500 events.
+    div.small.text-muted(v-if="events.length > 500")
+      | Showing the {{ 500 }} most recent events of {{ events.length }} total.
 
     hr
 
@@ -63,8 +63,6 @@ div
     hr
 
     aw-selectable-eventview(:events="events")
-
-    hr
 
     hr
 

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -2,7 +2,7 @@
 div
   h3 Search
 
-  b-alert(style="warning" show)
+  b-alert(variant="warning" show)
     | This feature is still in early development.
 
   b-alert(v-if="error" show variant="danger")

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -12,11 +12,11 @@ div
     b-input(v-model="pattern" v-on:keyup.enter="search()" placeholder="Regex pattern to search for")
     b-input-group-append
       b-button(type="button", @click="search()" variant="success")
-        icon(name="search")
+        icon.mr-1(name="search")
         | Search
 
   div.d-flex.mt-1
-    span.mr-auto.small(style="color: #666") Hostname: {{queryOptions.hostname}}
+    span.mr-auto.small.text-muted Hostname: {{queryOptions.hostname}}
     b-button.border-0(size="sm", variant="outline-dark" @click="show_options = !show_options")
       span(v-if="!show_options")
         | #[icon(name="angle-double-down")] Show options

--- a/src/views/Stopwatch.vue
+++ b/src/views/Stopwatch.vue
@@ -1,10 +1,23 @@
 <template lang="pug">
 div
-  h3.mb-3 Stopwatch
-
-  b-alert(show variant="info")
-    | Track manually-logged sessions alongside automatic tracking. To see your stopwatch totals on a dashboard,
-    | open an Activity view, click #[b Edit view], then #[b Add visualization] and pick #[b Top Stopwatch Events].
+  div.d-flex.align-items-center.mb-3
+    h3.mb-0 Stopwatch
+    button.btn.btn-link.p-0.ml-2.text-muted(
+      id="stopwatch-help"
+      type="button"
+      aria-label="About the stopwatch"
+    )
+      icon(name="question-circle")
+    b-popover(
+      target="stopwatch-help"
+      triggers="hover focus click blur"
+      placement="bottom"
+      title="About the stopwatch"
+    )
+      | Track manually-logged sessions alongside automatic tracking.
+      | To see your stopwatch totals on a dashboard, open an Activity view,
+      | click #[b Edit view], then #[b Add visualization] and pick
+      | #[b Top Stopwatch Events].
 
   b-input-group(size="lg")
     b-input(
@@ -58,6 +71,7 @@ import moment from 'moment';
 import StopwatchEntry from '../components/StopwatchEntry.vue';
 import 'vue-awesome/icons/play';
 import 'vue-awesome/icons/trash';
+import 'vue-awesome/icons/question-circle';
 
 export default {
   name: 'Stopwatch',

--- a/src/views/Stopwatch.vue
+++ b/src/views/Stopwatch.vue
@@ -1,14 +1,17 @@
 <template lang="pug">
 div
-  h2 Stopwatch
-  p
-    | Using bucket: {{bucket_id}}
+  h3.mb-3 Stopwatch
 
-  b-alert(show)
+  b-alert(show variant="info")
     | This is an early experiment. Data entered here is not shown in the Activity view, yet.
 
   b-input-group(size="lg")
-    b-input(v-model="label" placeholder="What are you working on?")
+    b-input(
+      v-model="label"
+      placeholder="What are you working on?"
+      aria-label="What are you working on?"
+      @keyup.enter="startTimer(label)"
+    )
     b-input-group-append
       b-button(@click="startTimer(label)", variant="success")
         icon(name="play")
@@ -17,30 +20,23 @@ div
   hr
 
   div(v-if="loading")
-    span.text-muted.center.aw-loading Loading...
-  div.row(v-else)
-    div.col-md-12
-      h3 Running
-      div(v-if="runningTimers.length > 0")
-        div(v-for="e in runningTimers" :key="e.id")
-          stopwatch-entry(:event="e", :bucket_id="bucket_id", :now="now",
-            @delete="removeTimer", @update="updateTimer")
-          hr(style="margin: 0")
-      div(v-else)
-        span(style="color: #555") No stopwatch running
-        hr
+    b-spinner.mr-2(small)
+    span.text-muted Loading...
+  div(v-else)
+    h3.mt-3 Running
+    div(v-if="runningTimers.length > 0")
+      div(v-for="e in runningTimers" :key="e.id")
+        stopwatch-entry(:event="e", :bucket_id="bucket_id", :now="now",
+          @delete="removeTimer", @update="updateTimer")
+    p.text-muted.mb-0(v-else) No stopwatch running. Start one above to track focused work.
 
-      div(v-if="stoppedTimers.length > 0")
-        h3.mt-4.mb-4 History
-        div(v-for="k in Object.keys(timersByDate).sort().reverse()")
-          h5.mt-2.mb-1 {{ k }}
-          div(v-for="e in timersByDate[k]" :key="e.id")
-            stopwatch-entry(:event="e", :bucket_id="bucket_id", :now="now",
-              @delete="removeTimer", @update="updateTimer", @new="startTimer(e.data.label)")
-            hr(style="margin: 0")
-      div(v-else)
-        span(style="color: #555") No history to show
-        hr
+    div(v-if="stoppedTimers.length > 0")
+      h3.mt-4.mb-2 History
+      div(v-for="k in Object.keys(timersByDate).sort().reverse()" :key="k")
+        h5.mt-3.mb-1 {{ k }}
+        div(v-for="e in timersByDate[k]" :key="e.id")
+          stopwatch-entry(:event="e", :bucket_id="bucket_id", :now="now",
+            @delete="removeTimer", @update="updateTimer", @new="startTimer(e.data.label)")
 </template>
 
 <style scoped lang="scss">

--- a/src/views/Stopwatch.vue
+++ b/src/views/Stopwatch.vue
@@ -3,8 +3,8 @@ div
   h3.mb-3 Stopwatch
 
   b-alert(show variant="info")
-    | Track manually-logged sessions alongside automatic tracking. Add the
-    | #[b Top Stopwatch Events] visualization to an Activity view (via #[b + New view] or by editing an existing one) to see your stopwatch totals.
+    | Track manually-logged sessions alongside automatic tracking. To see your stopwatch totals on a dashboard,
+    | open an Activity view, click #[b Edit view], then #[b Add visualization] and pick #[b Top Stopwatch Events].
 
   b-input-group(size="lg")
     b-input(

--- a/src/views/Stopwatch.vue
+++ b/src/views/Stopwatch.vue
@@ -3,7 +3,8 @@ div
   h3.mb-3 Stopwatch
 
   b-alert(show variant="info")
-    | This is an early experiment. Data entered here is not shown in the Activity view, yet.
+    | Track manually-logged sessions alongside automatic tracking. Add the
+    | #[b Top Stopwatch Events] visualization to an Activity view (via #[b + New view] or by editing an existing one) to see your stopwatch totals.
 
   b-input-group(size="lg")
     b-input(

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -6,8 +6,8 @@ div
 
   // Toolbar: filters (primary), display kebab (swimlanes etc.), event count,
   // and keyboard hint. Flex-wrap so it doesn't overlap at narrow widths.
-  div.timeline-toolbar.d-flex.flex-wrap.align-items-center.mb-2
-    details.timeline-filters.mr-2.mb-2(ref="filtersDetails")
+  div.timeline-toolbar.d-flex.flex-wrap.align-items-center
+    details.timeline-filters.mr-2(ref="filtersDetails")
       summary.timeline-chip.timeline-chip--clickable
         icon.mr-1(name="filter")
         b Filters: {{ filter_summary }}
@@ -70,7 +70,7 @@ div
 
     // Display options (swimlanes, future visual toggles) tucked behind a
     // ghost kebab so they don't compete visually with Filters.
-    b-dropdown.kebab-dropdown.mr-2.mb-2(
+    b-dropdown.kebab-dropdown.mr-2(
       size="sm"
       variant="outline-secondary"
       toggle-class="border-0"
@@ -89,10 +89,10 @@ div
         @click="swimlane = opt.value"
       ) {{ opt.text }}
 
-    div.timeline-chip.mr-2.mb-2.text-muted
+    div.timeline-chip.mr-2.text-muted
       | {{ num_events }} events shown
 
-    small.text-muted.ml-auto.mb-2
+    small.text-muted.ml-auto
       | Scroll to zoom, swipe to pan, arrow keys to navigate
 
   b-alert.mb-2(v-if="buckets !== null && num_events === 0", variant="warning", show)
@@ -409,7 +409,8 @@ export default {
 
 <style scoped>
 .timeline-toolbar {
-  row-gap: 0;
+  row-gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .timeline-chip {

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -4,18 +4,9 @@ div
 
   input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", :maxDuration="maxDuration").mb-3
 
-  // Toolbar: event count, swimlane selector, filters dropdown, and keyboard
-  // hint, laid out as a flex row so they wrap cleanly at narrow widths
-  // (replacing the prior float/inline-block hack that overlapped at 800px).
+  // Toolbar: filters (primary), display kebab (swimlanes etc.), event count,
+  // and keyboard hint. Flex-wrap so it doesn't overlap at narrow widths.
   div.timeline-toolbar.d-flex.flex-wrap.align-items-center.mb-2
-    div.timeline-chip.mr-2.mb-2
-      | Events shown: {{ num_events }}
-    div.timeline-chip.mr-2.mb-2
-      label.mb-0.mr-1(for="timeline-swimlane") Swimlanes:
-      select#timeline-swimlane.form-control.form-control-sm.d-inline-block(v-model="swimlane", style="width: auto")
-        option(:value='null') None
-        option(value='category') Categories
-        option(value='bucketType') Bucket Specific
     details.timeline-filters.mr-2.mb-2(ref="filtersDetails")
       summary.timeline-chip.timeline-chip--clickable
         icon.mr-1(name="filter")
@@ -76,6 +67,31 @@ div
                 span.badge.badge-info.mr-1(v-for="(cat, idx) in filter_categories", :key="idx")
                   | {{ cat.join(' > ') }}
                   button.ml-1.close.small(@click="removeCategory(idx)", type="button", aria-label="Remove category", style="font-size: 0.85rem; line-height: 1") &times;
+
+    // Display options (swimlanes, future visual toggles) tucked behind a
+    // ghost kebab so they don't compete visually with Filters.
+    b-dropdown.kebab-dropdown.mr-2.mb-2(
+      size="sm"
+      variant="outline-secondary"
+      toggle-class="border-0"
+      no-caret
+      right
+      title="Display options"
+      aria-label="Display options"
+    )
+      template(v-slot:button-content)
+        icon(name="ellipsis-v")
+      b-dropdown-header Swimlanes
+      b-dropdown-item-button(
+        v-for="opt in swimlaneOptions"
+        :key="String(opt.value)"
+        :active="swimlane === opt.value"
+        @click="swimlane = opt.value"
+      ) {{ opt.text }}
+
+    div.timeline-chip.mr-2.mb-2.text-muted
+      | {{ num_events }} events shown
+
     small.text-muted.ml-auto.mb-2
       | Scroll to zoom, swipe to pan, arrow keys to navigate
 
@@ -93,6 +109,7 @@ div
 
 <script lang="ts">
 import 'vue-awesome/icons/filter';
+import 'vue-awesome/icons/ellipsis-v';
 import _ from 'lodash';
 import { mapState } from 'pinia';
 import { useSettingsStore } from '~/stores/settings';
@@ -121,6 +138,11 @@ export default {
       filter_merge_similar: false,
       filter_categories: [],
       swimlane: null,
+      swimlaneOptions: [
+        { value: null, text: 'None' },
+        { value: 'category', text: 'Group by category' },
+        { value: 'bucketType', text: 'Group by bucket type' },
+      ],
       updateTimelineWindow: true,
     };
   },

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -18,6 +18,7 @@ div
         option(value='bucketType') Bucket Specific
     details.timeline-filters.mr-2.mb-2(ref="filtersDetails")
       summary.timeline-chip.timeline-chip--clickable
+        icon.mr-1(name="filter")
         b Filters: {{ filter_summary }}
       div.timeline-filters-panel.shadow-sm
         table
@@ -91,6 +92,7 @@ div
 </template>
 
 <script lang="ts">
+import 'vue-awesome/icons/filter';
 import _ from 'lodash';
 import { mapState } from 'pinia';
 import { useSettingsStore } from '~/stores/settings';

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -1,87 +1,87 @@
 <template lang="pug">
 div
-  h2 Timeline
+  h3 Timeline
 
   input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", :maxDuration="maxDuration").mb-3
 
-  // blocks
-  div.d-inline-block.border.rounded.p-2.mr-2
-    | Events shown:  {{ num_events }}
-  div.d-inline-block.border.rounded.p-2.mr-2
-    | Swimlanes:
-    select(v-model="swimlane")
-      option(:value='null') None
-      option(value='category') Categories
-      option(value='bucketType') Bucket Specific
-  details.d-inline-block.bg-light.small.border.rounded.mr-2.px-2
-    summary.p-2
-      b Filters: {{ filter_summary }}
-    div.p-2.bg-light
-      table
-        tr
-          th.pt-2.pr-3
-            label Host:
-          td
-              select(v-model="filter_hostname")
+  // Toolbar: event count, swimlane selector, filters dropdown, and keyboard
+  // hint, laid out as a flex row so they wrap cleanly at narrow widths
+  // (replacing the prior float/inline-block hack that overlapped at 800px).
+  div.timeline-toolbar.d-flex.flex-wrap.align-items-center.mb-2
+    div.timeline-chip.mr-2.mb-2
+      | Events shown: {{ num_events }}
+    div.timeline-chip.mr-2.mb-2
+      label.mb-0.mr-1(for="timeline-swimlane") Swimlanes:
+      select#timeline-swimlane.form-control.form-control-sm.d-inline-block(v-model="swimlane", style="width: auto")
+        option(:value='null') None
+        option(value='category') Categories
+        option(value='bucketType') Bucket Specific
+    details.timeline-filters.mr-2.mb-2(ref="filtersDetails")
+      summary.timeline-chip.timeline-chip--clickable
+        b Filters: {{ filter_summary }}
+      div.timeline-filters-panel.shadow-sm
+        table
+          tr
+            th.pt-2.pr-3
+              label(for="timeline-filter-host") Host:
+            td
+              select#timeline-filter-host.form-control.form-control-sm(v-model="filter_hostname")
                 option(:value='null') All
                 option(v-for="host in hosts", :value="host") {{ host }}
-        tr
-          th.pt-2.pr-3
-            label Client:
-          td
-            select(v-model="filter_client")
-              option(:value='null') All
-              option(v-for="client in clients", :value="client") {{ client }}
-        tr
-          th.pt-2.pr-3
-            label AFK:
-          td
-            b-form-checkbox(v-model="filter_afk" size="sm" switch)
-              | Filter AFK
-        tr
-          th.pt-2.pr-3
-            label Merge:
-          td
-            b-form-checkbox(v-model="filter_merge_similar" size="sm" switch)
-              | Merge by app
-        tr
-          th.pt-2.pr-3
-            label Categories:
-          td
-            select(@change="onCategorySelect($event)", :value="''")
-              option(value="" disabled) {{ filter_categories.length > 0 ? 'Add category...' : 'All' }}
-              option(v-for="cat in category_options", :key="cat.text", :value="cat.text") {{ cat.text }}
-            div.mt-1(v-if="filter_categories.length > 0")
-              span.badge.badge-info.mr-1(v-for="(cat, idx) in filter_categories", :key="idx")
-                | {{ cat.join(' > ') }}
-                button.ml-1.close.small(@click="removeCategory(idx)", type="button", style="font-size: 0.8rem") &times;
-  div.d-inline-block.border.rounded.p-2.mr-2(v-if="num_events !== 0")
-    | Events shown: {{ num_events }}
-  b-alert.d-inline-block.p-2.mb-0.mt-2(v-if="num_events === 0", variant="warning", show)
+          tr
+            th.pt-2.pr-3
+              label(for="timeline-filter-client") Client:
+            td
+              select#timeline-filter-client.form-control.form-control-sm(v-model="filter_client")
+                option(:value='null') All
+                option(v-for="client in clients", :value="client") {{ client }}
+          tr
+            th.pt-2.pr-3
+              label(for="timeline-filter-duration") Duration:
+            td
+              select#timeline-filter-duration.form-control.form-control-sm(v-model="filter_duration")
+                option(:value='null') All
+                option(:value='2') 2+ secs
+                option(:value='5') 5+ secs
+                option(:value='10') 10+ secs
+                option(:value='30') 30+ sec
+                option(:value='1 * 60') 1+ mins
+                option(:value='2 * 60') 2+ mins
+                option(:value='3 * 60') 3+ mins
+                option(:value='10 * 60') 10+ mins
+                option(:value='30 * 60') 30+ mins
+                option(:value='1 * 60 * 60') 1+ hrs
+                option(:value='2 * 60 * 60') 2+ hrs
+          tr
+            th.pt-2.pr-3
+              label AFK:
+            td
+              b-form-checkbox(v-model="filter_afk" size="sm" switch)
+                | Filter AFK
+          tr
+            th.pt-2.pr-3
+              label Merge:
+            td
+              b-form-checkbox(v-model="filter_merge_similar" size="sm" switch)
+                | Merge by app
+          tr
+            th.pt-2.pr-3
+              label(for="timeline-filter-categories") Categories:
+            td
+              select#timeline-filter-categories.form-control.form-control-sm(@change="onCategorySelect($event)", :value="''")
+                option(value="" disabled) {{ filter_categories.length > 0 ? 'Add category...' : 'All' }}
+                option(v-for="cat in category_options", :key="cat.text", :value="cat.text") {{ cat.text }}
+              div.mt-1(v-if="filter_categories.length > 0")
+                span.badge.badge-info.mr-1(v-for="(cat, idx) in filter_categories", :key="idx")
+                  | {{ cat.join(' > ') }}
+                  button.ml-1.close.small(@click="removeCategory(idx)", type="button", aria-label="Remove category", style="font-size: 0.85rem; line-height: 1") &times;
+    small.text-muted.ml-auto.mb-2
+      | Scroll to zoom, swipe to pan, arrow keys to navigate
+
+  b-alert.mb-2(v-if="buckets !== null && num_events === 0", variant="warning", show)
     | No events match selected criteria. Timeline is not updated.
-  div.float-right.small.text-muted.pt-3
-        tr
-          th.pt-2.pr-3
-            label Duration:
-          td
-            select(v-model="filter_duration")
-              option(:value='null') All
-              option(:value='2') 2+ secs
-              option(:value='5') 5+ secs
-              option(:value='10') 10+ secs
-              option(:value='30') 30+ sec
-              option(:value='1 * 60') 1+ mins
-              option(:value='2 * 60') 2+ mins
-              option(:value='3 * 60') 3+ mins
-              option(:value='10 * 60') 10+ mins
-              option(:value='30 * 60') 30+ mins
-              option(:value='1 * 60 * 60') 1+ hrs
-              option(:value='2 * 60 * 60') 2+ hrs
-  div(style="float: right; color: #999").d-inline-block.pt-3
-    | Scroll to zoom, swipe/horizontal-scroll to pan, arrow keys to navigate
 
   div(v-if="buckets !== null")
-    div(style="clear: both")
     vis-timeline(:buckets="buckets", :showRowLabels='true', :queriedInterval="daterange", :swimlane="swimlane", :updateTimelineWindow='updateTimelineWindow')
 
     aw-devonly(reason="Not ready for production, still experimenting")
@@ -384,18 +384,56 @@ export default {
 </script>
 
 <style scoped>
-details {
+.timeline-toolbar {
+  row-gap: 0;
+}
+
+.timeline-chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  background: #fff;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.875rem;
+  line-height: 1.25;
+}
+
+.timeline-chip--clickable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.timeline-chip--clickable:hover {
+  background: #f8f9fa;
+}
+
+.timeline-filters {
   position: relative;
 }
 
-details[open] summary ~ * {
-  visibility: visible;
+.timeline-filters > summary {
+  list-style: none;
+}
+
+.timeline-filters > summary::-webkit-details-marker {
+  display: none;
+}
+
+.timeline-filters-panel {
+  display: none;
   position: absolute;
-  border: 1px solid #ddd;
-  border-radius: 5px;
   left: 0;
-  top: 2.7em;
-  background: white;
+  top: calc(100% + 4px);
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem;
   z-index: 100;
+  min-width: 320px;
+}
+
+.timeline-filters[open] .timeline-filters-panel {
+  display: block;
 }
 </style>

--- a/src/views/TimespiralView.vue
+++ b/src/views/TimespiralView.vue
@@ -1,11 +1,17 @@
 <template lang="pug">
 div
-  h1 Timespiral
-  b-alert(show, variant="info")
+  h3 Timespiral
+  b-alert(show, variant="warning")
     | This is a work-in-progress experiment.
-  div Bucket: {{ bucketId }}
-  div Events: {{ events.length }}
-  Timespiral(:events="events")
+
+  div(v-if="!bucketId")
+    p.text-muted
+      | No AFK bucket found on this host. Install
+      | #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") aw-watcher-afk]
+      | to use the Timespiral.
+  div(v-else)
+    p.small.text-muted Bucket: #[code {{ bucketId }}] &middot; Events: {{ events.length }}
+    Timespiral(:events="events")
 </template>
 
 <script lang="ts">
@@ -33,9 +39,13 @@ export default {
     }
     this.bucketId = buckets[0];
 
+    // Show the last week by default. Previously hard-coded to 2022-08-08
+    // which left most users staring at an empty chart.
+    const start = new Date();
+    start.setDate(start.getDate() - 7);
     const bucket = await bucketStore.getBucketWithEvents({
       id: this.bucketId,
-      start: new Date('2022-08-08'),
+      start,
     });
     this.events = bucket.events;
     console.log('Retrieved events:', this.events);

--- a/src/views/Trends.vue
+++ b/src/views/Trends.vue
@@ -1,112 +1,383 @@
-<!--
-
-  NOTE: This file was copied from Activity.vue, could probably be refactored into something a lot better with less code duplication.
-
--->
-
 <template lang="pug">
 div
-  h3.mb-0 Trends for {{ timeperiod | friendlyperiod }}
+  div.d-flex.flex-wrap.align-items-center.mb-3
+    h3.mb-0.mr-3 Trends
 
-  // Select a hostname from the ones available in the store
-  b-input-group(size="sm")
-    b-form-select(
-      v-model="host"
-      label="Host"
-      :options="bucketsStore.hosts"
-      placeholder="Select a hostname")
+    b-button-group.mr-2.mb-1(size="sm")
+      b-button.px-3(
+        v-for="opt in periodOptions"
+        :key="opt.value"
+        :pressed="periodDays === opt.value"
+        @click="setPeriod(opt.value)"
+        variant="outline-dark"
+      ) {{ opt.text }}
 
-  div.mb-2
-    ul.list-group.list-group-horizontal-md.mb-3(style="font-size: 0.9em; opacity: 0.7")
-      li.list-group-item.pl-0.pr-3.py-0.border-0
-        | #[b Host:] {{ host }}
+    b-form-select.mr-2.mb-1(
+      v-if="bucketsStore.hosts.length > 1"
+      size="sm"
+      :value="host"
+      :options="hostOptions"
+      @change="onHostChange"
+      style="width: auto"
+    )
 
-  b-alert(variant="warning" show)
-    | This feature is still in early development.
+    small.text-muted.ml-auto.mb-1
+      | Comparing #[b {{ currentRangeLabel }}] vs #[b {{ previousRangeLabel }}].
 
-  div
+  div(v-if="!host")
+    b-alert(show variant="info")
+      | No host with window/AFK buckets available. Install
+      | #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") aw-watcher-window and aw-watcher-afk]
+      | to use this view.
+
+  div(v-else-if="loading")
+    b-spinner.mr-2(small)
+    span.text-muted Computing trends over {{ periodDays }} + {{ periodDays }} days…
+
+  div(v-else)
+    b-row.mb-3
+      b-col(md="4")
+        b-card.h-100
+          small.text-muted Active time
+          h4.mb-0 {{ totalCurrent | friendlyduration }}
+          div.small.mt-1(:class="deltaClass(totalDelta)")
+            | {{ formatDelta(totalCurrent, totalPrevious) }} vs previous {{ periodDays }} days
+      b-col(md="4")
+        b-card.h-100
+          small.text-muted Daily average
+          h4.mb-0 {{ avgPerDay | friendlyduration }}
+          div.small.mt-1(:class="deltaClass(avgDelta)")
+            | {{ formatDelta(avgPerDay, avgPerDayPrevious) }} per day
+      b-col(md="4")
+        b-card.h-100
+          small.text-muted Most-active day
+          h4.mb-0(v-if="busiestDay") {{ busiestDay.label }}
+          h4.mb-0.text-muted(v-else) —
+          div.small.text-muted.mt-1(v-if="busiestDay") {{ busiestDay.duration | friendlyduration }} on this day
+
+    h5.mt-3 Time per day
     aw-timeline-barchart(:datasets="datasets" :height="100")
 
-  div
-    hr
-    h5 Options
-
-    // TODO: Refactor options from Activity into component and reuse here
-
-    aw-devonly
-      b-btn(id="load-demo", @click="load_demo")
-        | Load demo data
+    h5.mt-4 Top changes by category
+    p.small.text-muted(v-if="categoryTrends.length === 0")
+      | No categorized data to compare.
+    b-table.mt-2(
+      v-else
+      small
+      hover
+      :items="categoryTrends"
+      :fields="categoryFields"
+      sort-by="absDelta"
+      :sort-desc="true"
+    )
+      template(#cell(category)="row")
+        | {{ row.item.category.join(' > ') || 'Uncategorized' }}
+      template(#cell(current)="row")
+        | {{ row.item.current | friendlyduration }}
+      template(#cell(previous)="row")
+        | {{ row.item.previous | friendlyduration }}
+      template(#cell(delta)="row")
+        span(:class="deltaClass(row.item.delta)")
+          | {{ formatDelta(row.item.current, row.item.previous) }}
 </template>
 
-<style lang="scss" scoped></style>
+<style scoped lang="scss">
+.h4 {
+  font-weight: 600;
+}
+</style>
 
 <script lang="ts">
 import moment from 'moment';
 import { get_today_with_offset } from '~/util/time';
 import { buildBarchartDataset } from '~/util/datasets';
-
+import { canonicalEvents } from '~/queries';
+import { getClient } from '~/util/awclient';
 import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
-import { useActivityStore, QueryOptions } from '~/stores/activity';
+import { useSettingsStore } from '~/stores/settings';
+
+interface CategoryTotals {
+  [key: string]: number;
+}
+
+interface CategoryTrend {
+  category: string[];
+  current: number;
+  previous: number;
+  delta: number;
+  absDelta: number;
+}
 
 export default {
   name: 'Trends',
-  props: {},
-  data: function () {
-    const today = get_today_with_offset();
-    const n_days = 7;
-    const since = moment(today).subtract(n_days, 'days');
+  data() {
     return {
       bucketsStore: useBucketsStore(),
       categoryStore: useCategoryStore(),
-      activityStore: useActivityStore(),
+      settingsStore: useSettingsStore(),
 
-      today,
-      timeperiod: { start: since, length: [n_days, 'day'] },
+      periodDays: 7,
+      periodOptions: [
+        { value: 7, text: '7 days' },
+        { value: 30, text: '30 days' },
+        { value: 90, text: '90 days' },
+      ],
+
+      loading: false,
+
+      // Per-day events for the current period (used for the barchart).
+      byPeriod: null as Record<string, any> | null,
+
+      // Per-category totals for current and previous periods.
+      currentTotals: {} as CategoryTotals,
+      previousTotals: {} as CategoryTotals,
+
+      categoryFields: [
+        { key: 'category', label: 'Category', sortable: true },
+        { key: 'current', label: 'Current', class: 'text-right', sortable: true },
+        { key: 'previous', label: 'Previous', class: 'text-right', sortable: true },
+        { key: 'delta', label: 'Change', class: 'text-right', sortable: true },
+        { key: 'absDelta', label: '', class: 'd-none', sortable: true },
+      ],
     };
   },
 
   computed: {
-    // Falls back to the first available host when /trends is opened without a
-    // :host param. Without this fallback ensure_loaded gets an undefined host
-    // and the generated query references `bid_window=undefined`, throwing.
-    host() {
+    host(): string | undefined {
       return this.$route.params.host || this.bucketsStore.hosts[0];
     },
-    datasets: function () {
-      return buildBarchartDataset(
-        this.activityStore.category.by_period,
-        this.categoryStore.classes
+
+    hostOptions(): { value: string; text: string }[] {
+      return this.bucketsStore.hosts.map(h => ({ value: h, text: h }));
+    },
+
+    today(): string {
+      return get_today_with_offset(this.settingsStore.startOfDay);
+    },
+
+    currentStart(): moment.Moment {
+      return moment(this.today).subtract(this.periodDays - 1, 'days');
+    },
+
+    currentRangeLabel(): string {
+      const start = this.currentStart.format('MMM D');
+      const end = moment(this.today).format('MMM D');
+      return `${start} – ${end}`;
+    },
+
+    previousRangeLabel(): string {
+      const start = this.currentStart.clone().subtract(this.periodDays, 'days').format('MMM D');
+      const end = moment(this.today).subtract(this.periodDays, 'days').format('MMM D');
+      return `${start} – ${end}`;
+    },
+
+    totalCurrent(): number {
+      return Object.values(this.currentTotals as CategoryTotals).reduce(
+        (a: number, b: number) => a + b,
+        0
       );
+    },
+
+    totalPrevious(): number {
+      return Object.values(this.previousTotals as CategoryTotals).reduce(
+        (a: number, b: number) => a + b,
+        0
+      );
+    },
+
+    totalDelta(): number {
+      return this.totalCurrent - this.totalPrevious;
+    },
+
+    avgPerDay(): number {
+      return this.periodDays > 0 ? this.totalCurrent / this.periodDays : 0;
+    },
+
+    avgPerDayPrevious(): number {
+      return this.periodDays > 0 ? this.totalPrevious / this.periodDays : 0;
+    },
+
+    avgDelta(): number {
+      return this.avgPerDay - this.avgPerDayPrevious;
+    },
+
+    busiestDay(): { label: string; duration: number } | null {
+      if (!this.byPeriod) return null;
+      let best: { label: string; duration: number } | null = null;
+      for (const [period, entry] of Object.entries(this.byPeriod)) {
+        const evts: any[] = (entry as any)?.cat_events || [];
+        const total = evts.reduce((a, e) => a + (e.duration || 0), 0);
+        if (!best || total > best.duration) {
+          const start = period.split('/')[0];
+          best = { label: moment(start).format('ddd, MMM D'), duration: total };
+        }
+      }
+      return best && best.duration > 0 ? best : null;
+    },
+
+    datasets(): any {
+      if (this.loading) return [];
+      if (!this.byPeriod) return null;
+      const built = buildBarchartDataset(this.byPeriod, this.categoryStore.classes);
+      return built.length > 0 ? built : null;
+    },
+
+    categoryTrends(): CategoryTrend[] {
+      const cats = new Set([
+        ...Object.keys(this.currentTotals),
+        ...Object.keys(this.previousTotals),
+      ]);
+      const rows: CategoryTrend[] = [];
+      for (const key of cats) {
+        const current = this.currentTotals[key] || 0;
+        const previous = this.previousTotals[key] || 0;
+        // Skip categories under 5 minutes in both windows — noise.
+        if (current < 300 && previous < 300) continue;
+        const delta = current - previous;
+        rows.push({
+          category: JSON.parse(key),
+          current,
+          previous,
+          delta,
+          absDelta: Math.abs(delta),
+        });
+      }
+      return rows;
     },
   },
 
-  mounted: async function () {
+  watch: {
+    host() {
+      this.refresh();
+    },
+  },
+
+  async mounted() {
     await this.bucketsStore.ensureLoaded();
-    this.categoryStore.load();
+    await this.categoryStore.load();
     await this.refresh();
   },
 
   methods: {
-    refresh: async function (force) {
-      if (!this.host) return;
-      const queryParams: QueryOptions = {
-        timeperiod: this.timeperiod,
-        host: this.host,
-        force,
-        filter_afk: this.filter_afk,
-        include_audible: this.include_audible,
-        filter_categories: this.filter_categories,
-        dont_query_inactive: false,
-      };
-      // ensure_loaded resolves bid_window/bid_afk from bucketsStore before
-      // composing queries; without it query_category_time_by_period sees
-      // empty buckets.window[] and crashes on bid.endsWith.
-      await this.activityStore.ensure_loaded(queryParams);
+    setPeriod(days: number) {
+      this.periodDays = days;
+      this.refresh();
     },
 
-    load_demo: async function () {
-      this.data = { '2021-01': 1000, '2021-02': 500 };
+    onHostChange(value: string) {
+      this.$router.replace(`/trends/${value}`);
+    },
+
+    deltaClass(delta: number): string {
+      if (delta > 0) return 'text-success';
+      if (delta < 0) return 'text-danger';
+      return 'text-muted';
+    },
+
+    formatDelta(current: number, previous: number): string {
+      const delta = current - previous;
+      if (previous === 0) return delta > 0 ? '+new' : '0';
+      const pct = (delta / previous) * 100;
+      const sign = delta >= 0 ? '+' : '';
+      return `${sign}${pct.toFixed(0)}%`;
+    },
+
+    async refresh() {
+      if (!this.host) return;
+      this.loading = true;
+      try {
+        const startCurrent = this.currentStart.clone();
+        const endCurrent = moment(this.today).add(1, 'day');
+        const startPrevious = startCurrent.clone().subtract(this.periodDays, 'days');
+        const endPrevious = startCurrent.clone();
+
+        const [currentByDay, previous] = await Promise.all([
+          this.queryByDay(startCurrent, endCurrent),
+          this.queryTotals(startPrevious, endPrevious),
+        ]);
+
+        this.byPeriod = currentByDay.byPeriod;
+        this.currentTotals = currentByDay.totals;
+        this.previousTotals = previous;
+      } catch (e) {
+        console.error('Trends refresh failed', e);
+        this.byPeriod = {};
+        this.currentTotals = {};
+        this.previousTotals = {};
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    // Returns { byPeriod, totals } where byPeriod is the per-day event list
+    // (for the barchart) and totals is the summed seconds per category over
+    // the whole window.
+    async queryByDay(
+      start: moment.Moment,
+      end: moment.Moment
+    ): Promise<{ byPeriod: Record<string, any>; totals: CategoryTotals }> {
+      const periods: string[] = [];
+      const day = start.clone();
+      while (day.isBefore(end)) {
+        const nextDay = day.clone().add(1, 'day');
+        periods.push(`${day.format()}/${nextDay.format()}`);
+        day.add(1, 'day');
+      }
+      const query = this.buildCategoryQuery();
+      const results: any[] = [];
+      for (const period of periods) {
+        const r = await getClient().query([period], query, { name: 'trendsByDay', verbose: true });
+        results.push(r[0]);
+      }
+      const byPeriod: Record<string, any> = {};
+      const totals: CategoryTotals = {};
+      periods.forEach((p, i) => {
+        const events = (results[i] && results[i].cat_events) || [];
+        // buildBarchartDataset expects entries of the shape { cat_events: [] }
+        byPeriod[p] = { cat_events: events };
+        for (const e of events) {
+          const key = JSON.stringify(e.data['$category'] || ['Uncategorized']);
+          totals[key] = (totals[key] || 0) + (e.duration || 0);
+        }
+      });
+      return { byPeriod, totals };
+    },
+
+    // Single-query totals (no day breakdown) for the previous window.
+    async queryTotals(start: moment.Moment, end: moment.Moment): Promise<CategoryTotals> {
+      const query = this.buildCategoryQuery();
+      const period = `${start.format()}/${end.format()}`;
+      const r = await getClient().query([period], query, { name: 'trendsTotals', verbose: true });
+      const events = (r[0] && r[0].cat_events) || [];
+      const totals: CategoryTotals = {};
+      for (const e of events) {
+        const key = JSON.stringify(e.data['$category'] || ['Uncategorized']);
+        totals[key] = (totals[key] || 0) + (e.duration || 0);
+      }
+      return totals;
+    },
+
+    buildCategoryQuery(): string[] {
+      const cats = this.categoryStore.classes_for_query;
+      const code =
+        canonicalEvents({
+          bid_window: 'aw-watcher-window_' + this.host,
+          bid_afk: 'aw-watcher-afk_' + this.host,
+          filter_afk: true,
+          categories: cats,
+          filter_categories: null,
+          always_active_pattern: this.settingsStore.always_active_pattern || undefined,
+        }) +
+        `
+        cat_events = sort_by_duration(merge_events_by_keys(events, ["$category"]));
+        RETURN = {"cat_events": cat_events};
+      `;
+      return code
+        .split(';')
+        .map(s => s.trim())
+        .filter(s => s)
+        .map(s => s + ';');
     },
   },
 };

--- a/src/views/Trends.vue
+++ b/src/views/Trends.vue
@@ -21,7 +21,7 @@ div
       li.list-group-item.pl-0.pr-3.py-0.border-0
         | #[b Host:] {{ host }}
 
-  b-alert(style="warning" show)
+  b-alert(variant="warning" show)
     | This feature is still in early development.
 
   div
@@ -67,8 +67,11 @@ export default {
   },
 
   computed: {
+    // Falls back to the first available host when /trends is opened without a
+    // :host param. Without this fallback ensure_loaded gets an undefined host
+    // and the generated query references `bid_window=undefined`, throwing.
     host() {
-      return this.$route.params.host;
+      return this.$route.params.host || this.bucketsStore.hosts[0];
     },
     datasets: function () {
       return buildBarchartDataset(
@@ -79,12 +82,14 @@ export default {
   },
 
   mounted: async function () {
+    await this.bucketsStore.ensureLoaded();
     this.categoryStore.load();
     await this.refresh();
   },
 
   methods: {
     refresh: async function (force) {
+      if (!this.host) return;
       const queryParams: QueryOptions = {
         timeperiod: this.timeperiod,
         host: this.host,
@@ -94,7 +99,10 @@ export default {
         filter_categories: this.filter_categories,
         dont_query_inactive: false,
       };
-      await this.activityStore.query_category_time_by_period(queryParams);
+      // ensure_loaded resolves bid_window/bid_afk from bucketsStore before
+      // composing queries; without it query_category_time_by_period sees
+      // empty buckets.window[] and crashes on bid.endsWith.
+      await this.activityStore.ensure_loaded(queryParams);
     },
 
     load_demo: async function () {

--- a/src/views/WorkReport.vue
+++ b/src/views/WorkReport.vue
@@ -10,7 +10,22 @@ div
 
     div.col-md-3
       b-form-group(label="Categories" label-class="font-weight-bold")
-        b-form-select(v-model="selectedCategories" :options="categoryOptions" multiple :select-size="3")
+        b-form-select(
+          :value="''"
+          :options="addableCategoryOptions"
+          size="sm"
+          @change="addCategory"
+        )
+        div.mt-2(v-if="selectedCategories.length > 0")
+          span.badge.badge-info.mr-1.mb-1(v-for="(cat, idx) in selectedCategories" :key="idx")
+            | {{ JSON.parse(cat).join(' > ') }}
+            button.ml-1.close.small(
+              type="button"
+              aria-label="Remove category"
+              style="font-size: 0.85rem; line-height: 1"
+              @click="removeCategory(idx)"
+            ) &times;
+        small.text-muted.d-block.mt-1 Subcategories are included automatically (e.g. "Work" also covers "Work > Programming").
 
     div.col-md-3
       b-form-group(label="Break Time" label-class="font-weight-bold")
@@ -139,6 +154,21 @@ export default {
         text: cat.join(' > '),
       }));
     },
+    // Hide categories that are already selected (or that are descendants of
+    // a selected category, since we auto-include subcategories anyway).
+    addableCategoryOptions() {
+      const selected: string[][] = this.selectedCategories.map(c => JSON.parse(c));
+      const isCoveredBySelected = (cat: string[]) =>
+        selected.some(sel => sel.every((seg, i) => cat[i] === seg));
+      return [
+        {
+          value: '',
+          text: this.selectedCategories.length === 0 ? 'Select category…' : 'Add category…',
+          disabled: true,
+        },
+        ...this.categoryOptions.filter(opt => !isCoveredBySelected(JSON.parse(opt.value))),
+      ];
+    },
     dateRangeOptions() {
       return [
         { value: 'last7d', text: 'Last 7 days' },
@@ -219,7 +249,35 @@ export default {
         );
         const timeperiods = this.getTimeperiods();
         const breakTimeSeconds = this.breakTime * 60;
-        const categoriesFilter = this.selectedCategories.map(c => JSON.parse(c));
+        // Auto-expand the selection to include subcategories. Selecting
+        // "Work" should also match "Work > Programming", "Work > Email",
+        // etc., which is what users intuitively expect — aw-query's
+        // filter_keyvals only does exact-array matches on $category.
+        const allCategories = (this.categoryStore.all_categories || []) as string[][];
+        const selected: string[][] = this.selectedCategories.map(c => JSON.parse(c));
+        const isDescendant = (sel: string[], cat: string[]) =>
+          cat.length >= sel.length && sel.every((seg, i) => cat[i] === seg);
+        const expanded: string[][] = [];
+        const seen = new Set<string>();
+        for (const cat of allCategories) {
+          if (selected.some(sel => isDescendant(sel, cat))) {
+            const key = JSON.stringify(cat);
+            if (!seen.has(key)) {
+              seen.add(key);
+              expanded.push(cat);
+            }
+          }
+        }
+        // Also keep the originally-selected categories even if they aren't
+        // in all_categories (defensive).
+        for (const sel of selected) {
+          const key = JSON.stringify(sel);
+          if (!seen.has(key)) {
+            seen.add(key);
+            expanded.push(sel);
+          }
+        }
+        const categoriesFilter = expanded;
 
         const categories = this.categoryStore.classes_for_query;
         const categoriesStr = JSON.stringify(categories).replace(/\\\\/g, '\\');
@@ -255,6 +313,17 @@ export default {
       } finally {
         this.loading = false;
       }
+    },
+
+    addCategory(value: string) {
+      if (!value) return;
+      if (!this.selectedCategories.includes(value)) {
+        this.selectedCategories = [...this.selectedCategories, value];
+      }
+    },
+
+    removeCategory(idx: number) {
+      this.selectedCategories = this.selectedCategories.filter((_c, i) => i !== idx);
     },
 
     getTimeperiods(): string[] {

--- a/src/views/WorkReport.vue
+++ b/src/views/WorkReport.vue
@@ -80,6 +80,7 @@ import {
   getSupportedWorkReportHosts,
   getWorkReportHostOptions,
   getUnsupportedWorkReportHosts,
+  buildWorkReportQuery,
 } from '~/util/workReport';
 
 import 'vue-awesome/icons/sync';
@@ -91,6 +92,21 @@ interface DailyData {
   sessions: number;
   avgSession: number;
   events: any[];
+}
+
+// Sum of gaps between adjacent events that are <= breakTimeSeconds.
+function bridgeGaps(events: any[], breakTimeSeconds: number): number {
+  if (!events || events.length < 2 || breakTimeSeconds <= 0) return 0;
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+  let extra = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const prevEnd = new Date(sorted[i - 1].timestamp).getTime() + sorted[i - 1].duration * 1000;
+    const gap = (new Date(sorted[i].timestamp).getTime() - prevEnd) / 1000;
+    if (gap > 0 && gap <= breakTimeSeconds) extra += gap;
+  }
+  return extra;
 }
 
 export default {
@@ -208,50 +224,26 @@ export default {
         const categories = this.categoryStore.classes_for_query;
         const categoriesStr = JSON.stringify(categories).replace(/\\\\/g, '\\');
 
-        // Build multi-device query with flood-based gap merging and AFK filtering
-        let query = '';
-
-        // Use indexed variable names to avoid collisions when hostnames
-        // differ only in non-alphanumeric chars (e.g., "my-laptop" vs "mylaptop").
-        for (let hi = 0; hi < hostsToQuery.length; hi++) {
-          const hostname = hostsToQuery[hi];
-          query += `
-            events_${hi} = flood(query_bucket("aw-watcher-window_${hostname}"), ${breakTimeSeconds});
-            not_afk_${hi} = flood(query_bucket("aw-watcher-afk_${hostname}"));
-            not_afk_${hi} = filter_keyvals(not_afk_${hi}, "status", ["not-afk"]);
-            events_${hi} = filter_period_intersect(events_${hi}, not_afk_${hi});
-            events_${hi} = categorize(events_${hi}, ${categoriesStr});
-            events_${hi} = filter_keyvals(events_${hi}, "$category", ${JSON.stringify(
-            categoriesFilter
-          )});
-          `;
-        }
-
-        // Combine events from all hosts
-        query += '\nevents = [];';
-        for (let hi = 0; hi < hostsToQuery.length; hi++) {
-          query += `\nevents = union_no_overlap(events, events_${hi});`;
-        }
-
-        query += `
-          duration = sum_durations(events);
-          RETURN = {"events": events, "duration": duration};
-        `;
+        const query = buildWorkReportQuery(hostsToQuery, categoriesStr, categoriesFilter);
 
         const results = await client.query(timeperiods, [query]);
 
         this.dailyData = timeperiods.map((tp, i) => {
           const result = results[i];
           const events = result.events || [];
-          const duration = result.duration || 0;
+          const baseDuration = result.duration || 0;
+          // Bridge sub-breakTime gaps between adjacent events so a quick
+          // context-switch still counts as continuous work time. aw-query's
+          // flood() only deduplicates overlap, so we add the bridging here.
+          const bridged = baseDuration + bridgeGaps(events, breakTimeSeconds);
 
           const startDate = tp.split('/')[0];
 
           return {
             date: moment(startDate).format('YYYY-MM-DD'),
-            duration,
+            duration: bridged,
             sessions: events.length,
-            avgSession: events.length > 0 ? duration / events.length : 0,
+            avgSession: events.length > 0 ? bridged / events.length : 0,
             events,
           };
         });
@@ -269,20 +261,25 @@ export default {
       const offset = this.settingsStore.startOfDay;
       const timeperiods: string[] = [];
 
-      let days: number;
+      // Resolve to an inclusive [startDate, today] window. For "thisWeek" and
+      // "thisMonth" the start anchors to the calendar boundary (not "N days
+      // ago"), so on a Wednesday "thisMonth" gives Mar 1..Mar 5, not Mar 1..N.
+      let startDate: moment.Moment;
+      const today = moment().startOf('day');
 
       if (this.dateRange === 'last7d') {
-        days = 7;
+        startDate = today.clone().subtract(6, 'days');
       } else if (this.dateRange === 'last30d') {
-        days = 30;
+        startDate = today.clone().subtract(29, 'days');
       } else if (this.dateRange === 'thisWeek') {
-        days = moment().isoWeekday(); // Mon=1 .. Sun=7
+        startDate = moment().startOf('isoWeek');
       } else if (this.dateRange === 'thisMonth') {
-        days = moment().date(); // 1-based day of month
+        startDate = moment().startOf('month');
       } else {
-        days = 7;
+        startDate = today.clone().subtract(6, 'days');
       }
 
+      const days = today.diff(startDate, 'days') + 1;
       for (let i = days - 1; i >= 0; i--) {
         const date = moment().subtract(i, 'days');
         const start = get_day_start_with_offset(date, offset);

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -18,32 +18,44 @@ div
         b.mr-1 Query range:
         span {{ periodReadableRange }}
 
-  div.mb-2.d-flex
-    div
-      b-input-group
-        b-input-group-prepend
-          b-button.px-2(:to="link_prefix + '/' + previousPeriod() + '/' + subview + '/' + currentViewId",
-                   variant="outline-dark")
-            icon(name="arrow-left")
-        b-select.pl-2.pr-3(:value="periodLength", :options="periodLengths",
-                 @change="(periodLength) => setDate(_date, periodLength)")
-        b-input-group-append
-          b-button.px-2(:to="link_prefix + '/' + nextPeriod() + '/' + subview + '/' + currentViewId",
-                        :disabled="nextPeriod() > today", variant="outline-dark")
-            icon(name="arrow-right")
+  div.mb-2.d-flex.flex-wrap.align-items-center
+    b-button-group.mr-2.mb-2
+      b-button.px-3(
+        v-for="opt in periodLengthsButtons"
+        :key="opt.value"
+        :pressed="periodLength === opt.value"
+        @click="setDate(_date, opt.value)"
+        variant="outline-dark"
+        size="sm"
+      ) {{ opt.text }}
 
-    div.mx-2(v-if="periodLength === 'day'")
-      input.form-control.px-2(id="date" type="date" :value="_date" :max="today"
-                         @change="setDate($event.target.value, periodLength)")
+    b-input-group.mr-2.mb-2(size="sm" style="width: auto")
+      b-input-group-prepend
+        b-button.px-2(:to="link_prefix + '/' + previousPeriod() + '/' + subview + '/' + currentViewId",
+                 variant="outline-dark",
+                 :title="'Previous ' + periodLength",
+                 :aria-label="'Previous ' + periodLength")
+          icon(name="arrow-left")
+      input.form-control.form-control-sm(v-if="periodLength === 'day'" type="date" :value="_date" :max="today"
+                       @change="setDate($event.target.value, periodLength)"
+                       style="min-width: 9em")
+      b-input-group-text(v-else style="background: #fff")
+        | {{ periodReadableRange }}
+      b-input-group-append
+        b-button.px-2(:to="link_prefix + '/' + nextPeriod() + '/' + subview + '/' + currentViewId",
+                      :disabled="nextPeriod() > today", variant="outline-dark",
+                      :title="'Next ' + periodLength",
+                      :aria-label="'Next ' + periodLength")
+          icon(name="arrow-right")
 
-    div.ml-auto
-      b-button-group
-        b-button.px-2(:pressed.sync="showOptions", variant="outline-dark")
+    div.ml-auto.mb-2
+      b-button-group(size="sm")
+        b-button.px-2(:pressed.sync="showOptions", variant="outline-dark", title="Filters", aria-label="Filters")
           icon(name="filter")
           span.d-none.d-md-inline
             |  Filters
             b-badge(pill, variant="secondary" v-if="filters_set > 0").ml-2 {{ filters_set }}
-        b-button.px-2(@click="refresh(true)", variant="outline-dark")
+        b-button.px-2(@click="refresh(true)", variant="outline-dark", title="Refresh", aria-label="Refresh")
           icon(name="sync")
           span.d-none.d-md-inline
             |  Refresh
@@ -247,6 +259,9 @@ export default {
       };
       return periods;
     },
+    periodLengthsButtons: function () {
+      return Object.entries(this.periodLengths).map(([value, text]) => ({ value, text }));
+    },
     periodIsBrowseable: function () {
       return ['day', 'week', 'month', 'year'].includes(this.periodLength);
     },
@@ -391,16 +406,33 @@ export default {
         return;
       }
 
+      // When switching between period buttons (day/week/month/year), prefer
+      // today's date if today falls inside the source period. Otherwise the
+      // user gets thrown across the calendar — e.g. year(2026) → month →
+      // week lands on 2025-12-29 because startOf("week") of Jan 1 walks
+      // back into the previous year.
+      let anchorDate = momentJsDate;
+      const today = moment(get_today_with_offset(this.settingsStore.startOfDay));
+      if (this.periodIsBrowseable) {
+        const sourceStart = momentJsDate
+          .clone()
+          .startOf(periodLengthConvertMoment(this.periodLength));
+        const sourceEnd = sourceStart.clone().add(1, periodLengthConvertMoment(this.periodLength));
+        if (today.isSameOrAfter(sourceStart) && today.isBefore(sourceEnd)) {
+          anchorDate = today;
+        }
+      }
+
       let new_date;
       if (periodLength == '7 days') {
         periodLength = 'last7d';
-        new_date = momentJsDate.add(1, 'days').format('YYYY-MM-DD');
+        new_date = anchorDate.clone().add(1, 'days').format('YYYY-MM-DD');
       } else if (periodLength == '30 days') {
         periodLength = 'last30d';
-        new_date = momentJsDate.add(1, 'days').format('YYYY-MM-DD');
+        new_date = anchorDate.clone().add(1, 'days').format('YYYY-MM-DD');
       } else {
         const new_period_length_moment = periodLengthConvertMoment(periodLength);
-        new_date = momentJsDate.startOf(new_period_length_moment).format('YYYY-MM-DD');
+        new_date = anchorDate.clone().startOf(new_period_length_moment).format('YYYY-MM-DD');
       }
       const path = `/activity/${this.host}/${periodLength}/${new_date}/${this.subview}/${this.currentViewId}`;
       if (this.$route.path !== path) {

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -36,11 +36,13 @@ div
                  :title="'Previous ' + periodLength",
                  :aria-label="'Previous ' + periodLength")
           icon(name="arrow-left")
-      input.form-control.form-control-sm(v-if="periodLength === 'day'" type="date" :value="_date" :max="today"
-                       @change="setDate($event.target.value, periodLength)"
-                       style="min-width: 9em")
-      b-input-group-text(v-else style="background: #fff")
-        | {{ periodReadableRange }}
+      input.form-control.form-control-sm.activity-dateinput(
+        type="date"
+        :value="_date"
+        :max="today"
+        :title="periodIsBrowseable ? periodReadableRange : ''"
+        @change="setDate($event.target.value, periodLength)"
+      )
       b-input-group-append
         b-button.px-2(:to="link_prefix + '/' + nextPeriod() + '/' + subview + '/' + currentViewId",
                       :disabled="nextPeriod() > today", variant="outline-dark",
@@ -117,6 +119,15 @@ div
 
 <style lang="scss" scoped>
 @import '../../style/globals';
+
+.activity-dateinput {
+  // Keep the date picker compact and aligned with the period button-group
+  // regardless of mode (day / week / month / year / N days). The full
+  // human-readable range remains available via the input's tooltip and the
+  // page heading.
+  width: 9.5rem;
+  min-width: 9.5rem;
+}
 
 .nav {
   border-bottom: 1px solid $lightBorderColor;

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -18,8 +18,8 @@ div
         b.mr-1 Query range:
         span {{ periodReadableRange }}
 
-  div.mb-2.d-flex.flex-wrap.align-items-center
-    div.d-flex.mr-2.mb-2
+  div.activity-toolbar.d-flex.flex-wrap.align-items-center
+    div.d-flex.mr-2
       b-button-group
         b-button.px-3(
           v-for="opt in primaryPeriods"
@@ -50,7 +50,7 @@ div
           @click="setDate(_date, opt.value)"
         ) {{ opt.text }}
 
-    b-input-group.mr-2.mb-2(size="sm" style="width: auto")
+    b-input-group.mr-2(size="sm" style="width: auto")
       b-input-group-prepend
         b-button.px-2(:to="link_prefix + '/' + previousPeriod() + '/' + subview + '/' + currentViewId",
                  variant="outline-dark",
@@ -71,7 +71,7 @@ div
                       :aria-label="'Next ' + periodLength")
           icon(name="arrow-right")
 
-    div.ml-auto.mb-2
+    div.ml-auto
       b-button-group(size="sm")
         b-button.px-2(:pressed.sync="showOptions", variant="outline-dark", title="Filters", aria-label="Filters")
           icon(name="filter")
@@ -107,7 +107,7 @@ div
         b-form-select(v-model="filter_category", :options="categoryStore.category_select(true)" size="sm")
 
 
-  aw-periodusage.mt-2(:periodusage_arr="periodusage", @update="setDate")
+  aw-periodusage(:periodusage_arr="periodusage", @update="setDate")
 
   aw-uncategorized-notification(:periodLength="periodLength")
 
@@ -140,6 +140,13 @@ div
 
 <style lang="scss" scoped>
 @import '../../style/globals';
+
+.activity-toolbar {
+  // row-gap kicks in only when items wrap to a second line, so the
+  // single-row case stays compact without piling mb-2 on every child.
+  row-gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
 
 .activity-dateinput {
   // Keep the date picker compact and aligned with the period button-group

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -262,7 +262,14 @@ export default {
       showOptions: false,
 
       include_audible: true,
-      include_stopwatch: false,
+      // Include stopwatch events when a stopwatch bucket exists. The
+      // store query falls back to noop if no bucket is present, so this
+      // is safe for users without stopwatch data. Enabling by default
+      // means the "Top Stopwatch Events" visualization shows real
+      // numbers as soon as a user records a session; previously a
+      // stopwatch run produced "No data" unless they also flipped the
+      // dev-only "Include manually logged events" checkbox.
+      include_stopwatch: true,
       filter_afk: true,
       new_view: {},
     };

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -414,10 +414,13 @@ export default {
       let anchorDate = momentJsDate;
       const today = moment(get_today_with_offset(this.settingsStore.startOfDay));
       if (this.periodIsBrowseable) {
-        const sourceStart = momentJsDate
+        const sourceUnit = periodLengthConvertMoment(this.periodLength);
+        const sourceStart = momentJsDate.clone().startOf(sourceUnit);
+        // moment.add() rejects "isoWeek" as a DurationConstructor (even
+        // though startOf() accepts it). Cast — runtime handles both spellings.
+        const sourceEnd = sourceStart
           .clone()
-          .startOf(periodLengthConvertMoment(this.periodLength));
-        const sourceEnd = sourceStart.clone().add(1, periodLengthConvertMoment(this.periodLength));
+          .add(1, sourceUnit as moment.unitOfTime.DurationConstructor);
         if (today.isSameOrAfter(sourceStart) && today.isBefore(sourceEnd)) {
           anchorDate = today;
         }

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -21,13 +21,33 @@ div
   div.mb-2.d-flex.flex-wrap.align-items-center
     b-button-group.mr-2.mb-2
       b-button.px-3(
-        v-for="opt in periodLengthsButtons"
+        v-for="opt in primaryPeriods"
         :key="opt.value"
         :pressed="periodLength === opt.value"
         @click="setDate(_date, opt.value)"
         variant="outline-dark"
         size="sm"
       ) {{ opt.text }}
+      // Extended range picker. Kebab keeps the primary pill row uncluttered;
+      // adding e.g. "Custom range" later just drops in as another item.
+      b-dropdown.kebab-dropdown(
+        size="sm"
+        variant="outline-dark"
+        toggle-class="border-0 px-2"
+        no-caret
+        right
+        :pressed="!isPrimaryPeriod"
+        :title="extendedPeriodLabel || 'More ranges'"
+        aria-label="More date ranges"
+      )
+        template(v-slot:button-content)
+          icon(name="ellipsis-v")
+        b-dropdown-item-button(
+          v-for="opt in extendedPeriods"
+          :key="opt.value"
+          :active="periodLength === opt.value"
+          @click="setDate(_date, opt.value)"
+        ) {{ opt.text }}
 
     b-input-group.mr-2.mb-2(size="sm" style="width: auto")
       b-input-group-prepend
@@ -186,6 +206,7 @@ import 'vue-awesome/icons/times';
 import 'vue-awesome/icons/save';
 import 'vue-awesome/icons/question-circle';
 import 'vue-awesome/icons/filter';
+import 'vue-awesome/icons/ellipsis-v';
 
 import { useSettingsStore } from '~/stores/settings';
 import { useCategoryStore } from '~/stores/categories';
@@ -272,6 +293,24 @@ export default {
     },
     periodLengthsButtons: function () {
       return Object.entries(this.periodLengths).map(([value, text]) => ({ value, text }));
+    },
+    // Rolling windows ("Last N days") are surfaced as primary buttons —
+    // they always represent a full period of data, whereas calendar
+    // periods (week/month/year) show only a partial range until the
+    // boundary is reached. Calendar periods stay in the kebab for users
+    // who need exact week/month boundaries (week-over-week comparisons).
+    primaryPeriods: function () {
+      return this.periodLengthsButtons.filter(p => ['day', 'last7d', 'last30d'].includes(p.value));
+    },
+    extendedPeriods: function () {
+      return this.periodLengthsButtons.filter(p => !['day', 'last7d', 'last30d'].includes(p.value));
+    },
+    isPrimaryPeriod: function () {
+      return ['day', 'last7d', 'last30d'].includes(this.periodLength);
+    },
+    extendedPeriodLabel: function () {
+      const opt = this.extendedPeriods.find(p => p.value === this.periodLength);
+      return opt ? opt.text : '';
     },
     periodIsBrowseable: function () {
       return ['day', 'week', 'month', 'year'].includes(this.periodLength);

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -29,16 +29,26 @@ div
           variant="outline-dark"
           size="sm"
         ) {{ opt.text }}
-      // Kebab sits outside the b-button-group so the last primary pill
-      // keeps its rounded right corner. Slight negative margin makes them
-      // still visually adjacent.
+        // If an extended period is active (week/month/year), surface it as
+        // an extra pressed pill so the user sees what's selected — the kebab
+        // alone wouldn't communicate that. Click toggles it back off (back
+        // to "day") so it's not stuck.
+        b-button.px-3(
+          v-if="!isPrimaryPeriod"
+          pressed
+          variant="outline-dark"
+          size="sm"
+          @click="setDate(_date, 'day')"
+        ) {{ extendedPeriodLabel }}
+      // Kebab sits outside the b-button-group so the last pressed pill
+      // (whichever it is) keeps its rounded right corner.
       b-dropdown.kebab-dropdown.ml-1(
         size="sm"
         variant="outline-secondary"
         toggle-class="border-0"
         no-caret
         right
-        :title="extendedPeriodLabel || 'More ranges'"
+        title="More ranges"
         aria-label="More date ranges"
       )
         template(v-slot:button-content)

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -19,24 +19,25 @@ div
         span {{ periodReadableRange }}
 
   div.mb-2.d-flex.flex-wrap.align-items-center
-    b-button-group.mr-2.mb-2
-      b-button.px-3(
-        v-for="opt in primaryPeriods"
-        :key="opt.value"
-        :pressed="periodLength === opt.value"
-        @click="setDate(_date, opt.value)"
-        variant="outline-dark"
+    div.d-flex.mr-2.mb-2
+      b-button-group
+        b-button.px-3(
+          v-for="opt in primaryPeriods"
+          :key="opt.value"
+          :pressed="periodLength === opt.value"
+          @click="setDate(_date, opt.value)"
+          variant="outline-dark"
+          size="sm"
+        ) {{ opt.text }}
+      // Kebab sits outside the b-button-group so the last primary pill
+      // keeps its rounded right corner. Slight negative margin makes them
+      // still visually adjacent.
+      b-dropdown.kebab-dropdown.ml-1(
         size="sm"
-      ) {{ opt.text }}
-      // Extended range picker. Kebab keeps the primary pill row uncluttered;
-      // adding e.g. "Custom range" later just drops in as another item.
-      b-dropdown.kebab-dropdown(
-        size="sm"
-        variant="outline-dark"
-        toggle-class="border-0 px-2"
+        variant="outline-secondary"
+        toggle-class="border-0"
         no-caret
         right
-        :pressed="!isPrimaryPeriod"
         :title="extendedPeriodLabel || 'More ranges'"
         aria-label="More date ranges"
       )

--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -1,5 +1,12 @@
 <template lang="pug">
-div(v-if="view")
+div(v-if="viewMissing")
+  b-alert.mt-3(show variant="warning")
+    | This view ("#[code {{ view_id }}]") doesn't exist on this dashboard.
+    |
+    router-link(:to="{ name: 'activity-view', params: {...$route.params, view_id: 'default'} }")
+      | Go to the default view
+    | .
+div(v-else-if="view")
   draggable.row(v-model="elements" handle=".handle")
     // TODO: Handle large/variable sized visualizations better
     div.col-md-6.col-lg-4.p-3(v-for="el, index in elements", :key="index", :class="{'col-md-12': isVisLarge(el), 'col-lg-12': isVisLarge(el)}")
@@ -22,13 +29,28 @@ div(v-if="view")
       b-button(variant="warning" size="sm" @click="restoreDefaults();")
         icon(name="undo")
         span Restore defaults
-      b-button.mr-2(variant="danger" size="sm" @click="remove();")
+      b-button.mr-2(variant="danger" size="sm" v-b-modal="'remove-view-modal-' + view.id")
         icon(name="trash")
         span Remove
   div(v-else).d-flex.flex-row-reverse.mt-2
     b-button(variant="outline-dark" size="sm" @click="editing = !editing")
       icon(name="edit")
       span Edit view
+
+  b-modal(
+    v-if="view"
+    :id="'remove-view-modal-' + view.id"
+    title="Remove this view?"
+    centered
+    ok-title="Remove view"
+    ok-variant="danger"
+    cancel-variant="outline-secondary"
+    @ok="remove"
+  )
+    | Are you sure you want to remove "#[b {{ view.name || view.id }}]"?
+    br
+    br
+    | This will delete the view's configuration. You can run #[b Restore defaults] to bring built-in views back.
 </template>
 
 <script lang="ts">
@@ -61,6 +83,12 @@ export default {
       } else {
         return this.views.find(v => v.id == this.view_id);
       }
+    },
+    viewMissing: function (): boolean {
+      // True only once views have loaded but the requested id doesn't exist.
+      // Without this guard, navigating to a stale URL (e.g. /view/category)
+      // silently rendered the default view's content under the wrong tab.
+      return this.views.length > 0 && this.view_id !== 'default' && !this.view;
     },
     elements: {
       get() {

--- a/src/views/settings/ActivePatternSettings.vue
+++ b/src/views/settings/ActivePatternSettings.vue
@@ -4,7 +4,7 @@ div
     div
       h5.mb-2.mb-sm-0 Always count as active pattern
 
-      small
+      small.text-muted
         | Apps or titles matching this regular expression will never be counted as AFK.
         |
         | Can be used to count time as active, despite no input (like meetings, or games with controllers). An empty string disables it.

--- a/src/views/settings/ActivePatternSettings.vue
+++ b/src/views/settings/ActivePatternSettings.vue
@@ -15,10 +15,10 @@ div
     div
       b-form-input(size="sm" v-model="always_active_pattern_editing" :state="(enabled || null) && valid")
       small.text-right
-        div(v-if="enabled && valid" style="color: #0A0") Enabled
-        div(v-else-if="enabled" style="color: #A00") Invalid pattern
-        div(v-else, style="color: gray") Disabled
-        div(v-if="enabled && valid && broad_pattern" style="color: #A00") Pattern too broad
+        div.text-success(v-if="enabled && valid") Enabled
+        div.text-danger(v-else-if="enabled") Invalid pattern
+        div.text-muted(v-else) Disabled
+        div.text-danger(v-if="enabled && valid && broad_pattern") Pattern too broad
 
 </template>
 

--- a/src/views/settings/ActivePatternSettings.vue
+++ b/src/views/settings/ActivePatternSettings.vue
@@ -10,7 +10,7 @@ div
         | Can be used to count time as active, despite no input (like meetings, or games with controllers). An empty string disables it.
         |
         | Example expression:&nbsp;
-        code(style="background-color: rgba(200, 200, 200, 0.3); padding: 2px; border-radius: 2px;")
+        code.d-inline-block(style="background-color: rgba(200, 200, 200, 0.3); padding: 2px 4px; border-radius: 2px; white-space: nowrap;")
           | Zoom Meeting|Google Meet|Microsoft Teams
     div
       b-form-input(size="sm" v-model="always_active_pattern_editing" :state="(enabled || null) && valid")

--- a/src/views/settings/ActivePatternSettings.vue
+++ b/src/views/settings/ActivePatternSettings.vue
@@ -9,9 +9,10 @@ div
         |
         | Can be used to count time as active, despite no input (like meetings, or games with controllers). An empty string disables it.
         |
-        | Example expression:&nbsp;
-        code.d-inline-block(style="background-color: rgba(200, 200, 200, 0.3); padding: 2px 4px; border-radius: 2px; white-space: nowrap;")
-          | Zoom Meeting|Google Meet|Microsoft Teams
+        span.text-nowrap
+          | Example expression:&nbsp;
+          code(style="background-color: rgba(200, 200, 200, 0.3); padding: 2px 4px; border-radius: 2px;")
+            | Zoom Meeting|Google Meet|Microsoft Teams
     div
       b-form-input(size="sm" v-model="always_active_pattern_editing" :state="(enabled || null) && valid")
       small.text-right

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -48,6 +48,27 @@ div
     div.mt-1.small.text-muted(v-if="categoryStore.category_sets.length > 1")
       | {{ categoryStore.category_sets.length }} sets available — switch sets to use different rule profiles.
 
+  // Category Builder lives above the rules tree so it's easy to find
+  // (the rules list can be long enough to bury anything below it).
+  // It stays collapsed by default so the words query doesn't fire for
+  // users who only came to edit rules; once opened it mounts lazily.
+  div.my-3
+    div.d-flex.align-items-center.flex-wrap
+      h5.mb-0 Category builder
+      small.text-muted.ml-2 Generate rules from uncategorized activity
+      b-btn.ml-auto(
+        variant="outline-primary"
+        size="sm"
+        @click="builderOpen = !builderOpen"
+        :aria-expanded="builderOpen ? 'true' : 'false'"
+        aria-controls="category-builder-collapse"
+      )
+        icon.mr-1(:name="builderOpen ? 'angle-double-up' : 'angle-double-down'")
+        | {{ builderOpen ? 'Hide builder' : 'Open builder' }}
+    b-collapse#category-builder-collapse(v-model="builderOpen")
+      div.mt-3(v-if="builderMounted")
+        CategoryBuilder(embedded)
+
   div.my-4
     b-alert(variant="warning" :show="classes_unsaved_changes")
       | You have unsaved changes!
@@ -68,29 +89,6 @@ div
         | Add category
       b-btn.float-right(@click="saveClasses", variant="success" :disabled="!classes_unsaved_changes")
         | Save
-
-  hr.mt-4
-
-  // Embedded Category Builder. Mounted only after the user opens it so
-  // the words query doesn't fire for users who just came to edit rules.
-  // Edits made via the builder show up in the rule tree above without
-  // navigating away.
-  div.mt-3
-    div.d-flex.align-items-center.flex-wrap
-      h5.mb-0 Category builder
-      small.text-muted.ml-2 Generate rules from uncategorized activity
-      b-btn.ml-auto(
-        variant="outline-primary"
-        size="sm"
-        @click="builderOpen = !builderOpen"
-        :aria-expanded="builderOpen ? 'true' : 'false'"
-        aria-controls="category-builder-collapse"
-      )
-        icon.mr-1(:name="builderOpen ? 'angle-double-up' : 'angle-double-down'")
-        | {{ builderOpen ? 'Hide builder' : 'Open builder' }}
-    b-collapse#category-builder-collapse(v-model="builderOpen")
-      div.mt-3(v-if="builderMounted")
-        CategoryBuilder(embedded)
 </template>
 <script lang="ts">
 import { mapState, mapGetters } from 'pinia';

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -74,7 +74,7 @@ div
   // ActivePatternSettings panel below the group). Collapsed by default
   // so the words query doesn't fire for users who only came to edit
   // rules; once opened it mounts lazily.
-  div.mt-4
+  div.mt-4(ref="builderSection")
     div.d-flex.align-items-center.flex-wrap
       h5.mb-0 Category builder
       small.text-muted.ml-2 Generate rules from uncategorized activity
@@ -146,6 +146,19 @@ export default {
     // Route navigation guard is handled by the parent Settings.vue component
     // using beforeRouteLeave (automatically cleaned up by Vue Router).
     window.addEventListener('beforeunload', this.beforeUnload);
+
+    // Deep-link from UncategorizedNotification ("Category Builder" link) lands
+    // on /settings/categorization?builder=open — open the builder and scroll
+    // it into view so the user can act immediately.
+    if (this.$route.query.builder === 'open') {
+      this.builderOpen = true;
+      this.$nextTick(() => {
+        const el = this.$refs.builderSection as HTMLElement | undefined;
+        if (el && typeof el.scrollIntoView === 'function') {
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+    }
   },
   beforeDestroy() {
     window.removeEventListener('beforeunload', this.beforeUnload);

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -18,8 +18,10 @@ div
     | You can also find and share categorization rule presets on #[a(href="https://forum.activitywatch.net/c/projects/category-rules") the forum].
     | For help on how to write categorization rules, see #[a(href="https://docs.activitywatch.net/en/latest/features/categorization.html") the documentation].
 
-  // Category set switcher
-  div.my-3.p-3(style="background: var(--bs-light, #f8f9fa); border-radius: 4px;")
+  // Category set switcher. bg-light + .rounded so dark.css's .bg-light
+  // override flips the background in dark mode instead of leaving an
+  // inline white block on a dark canvas.
+  div.my-3.p-3.bg-light.rounded
     div.d-flex.align-items-center.flex-wrap(style="gap: 0.5rem;")
       span.font-weight-bold(style="white-space: nowrap") Category set:
       b-select(
@@ -44,10 +46,7 @@ div
         variant="outline-danger"
         size="sm"
       ) Delete set
-    div.mt-1(
-      v-if="categoryStore.category_sets.length > 1"
-      style="font-size: 0.85em; color: var(--bs-secondary, #6c757d);"
-    )
+    div.mt-1.small.text-muted(v-if="categoryStore.category_sets.length > 1")
       | {{ categoryStore.category_sets.length }} sets available — switch sets to use different rule profiles.
 
   div.my-4

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -1,17 +1,6 @@
 <template lang="pug">
 div
-  h5.d-inline-block
-    div Categorization
-  div.float-right
-    b-btn.ml-1(@click="restoreDefaultClasses", variant="outline-warning" size="sm")
-      icon(name="undo")
-      | Restore defaults
-    label.btn.btn-sm.ml-1.btn-outline-primary(style="margin: 0")
-      | Import
-      input(type="file" @change="importCategories" hidden)
-    b-btn.ml-1(@click="exportClasses", variant="outline-primary" size="sm")
-      | Export
-  p
+  p.mb-2
     | Rules for categorizing events. An event can only have one category. If several categories match, the deepest one will be chosen.
   p
     | Find and share categorization rule presets on #[a(href="https://forum.activitywatch.net/c/projects/category-rules") the forum].
@@ -48,28 +37,19 @@ div
     div.mt-1.small.text-muted(v-if="categoryStore.category_sets.length > 1")
       | {{ categoryStore.category_sets.length }} sets available — switch sets to use different rule profiles.
 
-  // Category Builder lives above the rules tree so it's easy to find
-  // (the rules list can be long enough to bury anything below it).
-  // It stays collapsed by default so the words query doesn't fire for
-  // users who only came to edit rules; once opened it mounts lazily.
-  div.my-3
-    div.d-flex.align-items-center.flex-wrap
-      h5.mb-0 Category builder
-      small.text-muted.ml-2 Generate rules from uncategorized activity
-      b-btn.ml-auto(
-        variant="outline-primary"
-        size="sm"
-        @click="builderOpen = !builderOpen"
-        :aria-expanded="builderOpen ? 'true' : 'false'"
-        aria-controls="category-builder-collapse"
-      )
-        icon.mr-1(:name="builderOpen ? 'angle-double-up' : 'angle-double-down'")
-        | {{ builderOpen ? 'Hide builder' : 'Open builder' }}
-    b-collapse#category-builder-collapse(v-model="builderOpen")
-      div.mt-3(v-if="builderMounted")
-        CategoryBuilder(embedded)
+  div.d-flex.align-items-center.flex-wrap.mt-4
+    h5.mb-0 Categories
+    div.ml-auto
+      b-btn.ml-1(@click="restoreDefaultClasses", variant="outline-warning" size="sm")
+        icon(name="undo")
+        | Restore defaults
+      label.btn.btn-sm.ml-1.btn-outline-primary(style="margin: 0")
+        | Import
+        input(type="file" @change="importCategories" hidden)
+      b-btn.ml-1(@click="exportClasses", variant="outline-primary" size="sm")
+        | Export
 
-  div.my-4
+  div.my-3
     b-alert(variant="warning" :show="classes_unsaved_changes")
       | You have unsaved changes!
       div.float-right(style="margin-top: -0.15em; margin-right: -0.6em")
@@ -89,6 +69,27 @@ div
         | Add category
       b-btn.float-right(@click="saveClasses", variant="success" :disabled="!classes_unsaved_changes")
         | Save
+
+  // Category Builder sits at the end of the categories list (above the
+  // ActivePatternSettings panel below the group). Collapsed by default
+  // so the words query doesn't fire for users who only came to edit
+  // rules; once opened it mounts lazily.
+  div.mt-4
+    div.d-flex.align-items-center.flex-wrap
+      h5.mb-0 Category builder
+      small.text-muted.ml-2 Generate rules from uncategorized activity
+      b-btn.ml-auto(
+        variant="outline-primary"
+        size="sm"
+        @click="builderOpen = !builderOpen"
+        :aria-expanded="builderOpen ? 'true' : 'false'"
+        aria-controls="category-builder-collapse"
+      )
+        icon.mr-1(:name="builderOpen ? 'angle-double-up' : 'angle-double-down'")
+        | {{ builderOpen ? 'Hide builder' : 'Open builder' }}
+    b-collapse#category-builder-collapse(v-model="builderOpen")
+      div.mt-3(v-if="builderMounted")
+        CategoryBuilder(embedded)
 </template>
 <script lang="ts">
 import { mapState, mapGetters } from 'pinia';

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -14,8 +14,7 @@ div
   p
     | Rules for categorizing events. An event can only have one category. If several categories match, the deepest one will be chosen.
   p
-    | You can use the #[router-link(:to="{ path: '/settings/category-builder' }") Category Builder] to quickly create categories from uncategorized activity.
-    | You can also find and share categorization rule presets on #[a(href="https://forum.activitywatch.net/c/projects/category-rules") the forum].
+    | Find and share categorization rule presets on #[a(href="https://forum.activitywatch.net/c/projects/category-rules") the forum].
     | For help on how to write categorization rules, see #[a(href="https://docs.activitywatch.net/en/latest/features/categorization.html") the documentation].
 
   // Category set switcher. bg-light + .rounded so dark.css's .bg-light
@@ -69,12 +68,37 @@ div
         | Add category
       b-btn.float-right(@click="saveClasses", variant="success" :disabled="!classes_unsaved_changes")
         | Save
+
+  hr.mt-4
+
+  // Embedded Category Builder. Mounted only after the user opens it so
+  // the words query doesn't fire for users who just came to edit rules.
+  // Edits made via the builder show up in the rule tree above without
+  // navigating away.
+  div.mt-3
+    div.d-flex.align-items-center.flex-wrap
+      h5.mb-0 Category builder
+      small.text-muted.ml-2 Generate rules from uncategorized activity
+      b-btn.ml-auto(
+        variant="outline-primary"
+        size="sm"
+        @click="builderOpen = !builderOpen"
+        :aria-expanded="builderOpen ? 'true' : 'false'"
+        aria-controls="category-builder-collapse"
+      )
+        icon.mr-1(:name="builderOpen ? 'angle-double-up' : 'angle-double-down'")
+        | {{ builderOpen ? 'Hide builder' : 'Open builder' }}
+    b-collapse#category-builder-collapse(v-model="builderOpen")
+      div.mt-3(v-if="builderMounted")
+        CategoryBuilder(embedded)
 </template>
 <script lang="ts">
 import { mapState, mapGetters } from 'pinia';
 import CategoryEditTree from '~/components/CategoryEditTree.vue';
 import CategoryEditModal from '~/components/CategoryEditModal.vue';
 import 'vue-awesome/icons/undo';
+import 'vue-awesome/icons/angle-double-down';
+import 'vue-awesome/icons/angle-double-up';
 
 import { useCategoryStore } from '~/stores/categories';
 
@@ -88,17 +112,25 @@ export default {
   components: {
     CategoryEditTree,
     CategoryEditModal,
+    // Lazy-load the builder so visiting Categorization without opening
+    // the builder doesn't drag in its query/word-list code.
+    CategoryBuilder: () => import('~/views/settings/CategoryBuilder.vue'),
   },
   data: () => ({
     categoryStore: useCategoryStore(),
     editingId: null,
     activeSetId: 'default',
+    builderOpen: false,
+    builderMounted: false,
   }),
   computed: {
     ...mapState(useCategoryStore, ['classes_unsaved_changes']),
     ...mapGetters(useCategoryStore, ['classes_hierarchy']),
   },
   watch: {
+    builderOpen(v: boolean) {
+      if (v) this.builderMounted = true;
+    },
     'categoryStore.active_set_ids': {
       handler(newIds: string[]) {
         if (newIds && newIds.length > 0) {

--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  h1 Categorization helper
+  h3 Categorization helper
   div
     p
       | This tool will help you create categories from your uncategorized time.
@@ -38,7 +38,13 @@ div
 
   h5 Common words in "{{category.join(" > ")}}" events
   div(v-if="loading")
-    | Loading...
+    b-spinner.mr-2(small)
+    span.text-muted Loading...
+  div(v-else-if="!queryOptions.hostname")
+    p.text-muted.mb-0
+      | No host with window/AFK buckets is available. Install
+      | #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") a watcher]
+      | to start collecting data.
   div(v-else)
     div(v-if="words_by_duration.length == 0")
       | No words with significant duration. You're good to go!
@@ -90,8 +96,8 @@ div
       b-form-group(label="Word")
         b-form-input(v-model="append.word")
         small
-          div(v-if="validPattern" style="color: green") Valid
-          div(v-else style="color: red") Invalid pattern
+          div.text-success(v-if="validPattern") Valid
+          div.text-danger(v-else) Invalid pattern
           div(v-if="validPattern && broad_pattern" style="color: orange") Pattern too broad
 </template>
 

--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -1,20 +1,16 @@
 <template lang="pug">
 div
-  h3 Categorization helper
-  div
+  // Standalone mode prints the full intro; embedded mode (used inside
+  // CategorizationSettings) omits the header so it doesn't double up
+  // with the section title that wraps the embed.
+  div(v-if="!embedded")
+    h3 Categorization helper
     p
-      | This tool will help you create categories from your uncategorized time.
-
-    p
-      | It works by fetching all uncategorized time for a recent timeperiod,
-      | and then finds the most common words (by time, not count) each of
-      | which may then either be ignored (if too broad/irrelevant), or used
-      | to create a new (sub)category, or to append the word to a pre-existing category rule.
-      | Words with less than 60s of time will not be shown.
-
-    p
-      | When you're done, you can inspect the categories in the #[router-link(:to="{ path: '/settings' }") Settings] page.
-
+      | This tool helps you create categories from your uncategorized time.
+      | It scans a recent window for the most common app/title words (by
+      | time, not count) so you can promote each one into a new category,
+      | append it to an existing rule, or ignore it. Words under 60s are
+      | hidden.
 
   div.d-flex
     div.flex-grow-1
@@ -122,9 +118,13 @@ import { isRegexBroad, validateRegex } from '~/util/validate';
 import { findCommonPhrases } from '~/util/categorization';
 
 export default {
-  name: 'aw-category-builder',
+  name: 'CategoryBuilder',
   components: { CategoryEditModal },
-  props: {},
+  props: {
+    // When embedded inside CategorizationSettings, drop the standalone
+    // page chrome so the embed reads as a subsection of the parent.
+    embedded: { type: Boolean, default: false },
+  },
   data() {
     return {
       loading: true,

--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -45,7 +45,7 @@ div
     div(v-if="words_by_duration.length == 0")
       | No words with significant duration. You're good to go!
     div(v-else)
-      div.row.category-builder-word(v-for="word in words_by_duration")
+      div.row.category-builder-word(v-for="word in words_visible" :key="word.word")
         div.col.hover-highlight
           div.d-flex.flex-row.py-2
             div.flex-grow-1
@@ -69,11 +69,14 @@ div
                 td {{ event.data.title }}
                 td.text-right {{ Math.round(event.duration) }}s
             hr
-      //hr
-      //div.d-flex
-        div.flex-grow-1
-        div.flex-grow-0
-          b-button(size="sm" @click="days_back += 7; fetchWords()") Load more
+      div.d-flex.align-items-center.mt-3(v-if="hasMoreWords")
+        small.text-muted
+          | Showing {{ words_visible.length }} of {{ words_by_duration.length }} words
+        b-button.ml-auto(
+          size="sm"
+          variant="outline-primary"
+          @click="visible_count += page_size"
+        ) Show more
 
   div(v-if="create.categoryId !== null")
     CategoryEditModal(:categoryId="create.categoryId",
@@ -131,6 +134,12 @@ export default {
 
       categoryStore: useCategoryStore(),
 
+      // Pagination for the words list. Showing the full list directly
+      // produced a 2+ screen wall of buttons on most users' data; this
+      // shows page_size at a time with a "Show more" button.
+      page_size: 10,
+      visible_count: 10,
+
       // Options
       show_options: false,
       queryOptions: {
@@ -166,6 +175,12 @@ export default {
         .filter(word => word.duration > 60)
         .filter(word => !this.ignored_words.includes(word.word));
     },
+    words_visible: function () {
+      return this.words_by_duration.slice(0, this.visible_count);
+    },
+    hasMoreWords: function () {
+      return this.words_by_duration.length > this.visible_count;
+    },
     valid: function () {
       return this.validPattern && this.validCategory;
     },
@@ -197,6 +212,9 @@ export default {
   methods: {
     async fetchWords() {
       this.loading = true;
+      // Reset pagination so the user sees the top of the new ranking
+      // after every requery.
+      this.visible_count = this.page_size;
       if (!this.queryOptions.hostname) {
         // Try to resolve hostname from loaded buckets
         // Don't ever return the "unknown" hostname

--- a/src/views/settings/ColorSettings.vue
+++ b/src/views/settings/ColorSettings.vue
@@ -2,7 +2,7 @@
 div.d-flex.justify-content-between
   div
     h5.mb-0 Use fallback colors
-    small
+    small.text-muted
       | Uses the old coloring style for some visualizations when uncategorized or no category color.
   div
     b-form-checkbox(v-model="useColorFallback", switch)

--- a/src/views/settings/DaystartSettings.vue
+++ b/src/views/settings/DaystartSettings.vue
@@ -5,7 +5,7 @@ div
       h5.mt-1.mb-2.mb-sm-0 Start of day
     div
       b-input(type="time" size="sm" :value="startOfDay" @change="startOfDay = $event")
-  small
+  small.text-muted
     | The time at which days "start", since humans don't always go to bed before midnight.
     | Set to 04:00 by default.
 
@@ -14,7 +14,7 @@ div
       h5.mt-1.mb-2.mb-sm-0 Start of week
     div
       b-form-select(:text="startOfWeek", size="sm" v-model="startOfWeek" variant="outline-dark" :options="['Saturday', 'Sunday', 'Monday']")
-  small
+  small.text-muted
     | The weekday which starts a new week.
 </template>
 <script lang="ts">

--- a/src/views/settings/DeveloperSettings.vue
+++ b/src/views/settings/DeveloperSettings.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 div
-  h4.mb-3 Developer settings
-  b-alert(show) #[b Note:] These settings are meant for developers who (hopefully) know what they are doing, and as such, may break things unexpectedly.
+  b-alert(show variant="warning") #[b Note:] These settings are meant for developers who (hopefully) know what they are doing, and as such, may break things unexpectedly.
 
   b-form-group(label="Force devmode" label-cols-md=3 description="Devmode enables some features that are still work-in-progress.")
     div

--- a/src/views/settings/LandingPageSettings.vue
+++ b/src/views/settings/LandingPageSettings.vue
@@ -10,7 +10,7 @@ div
         option(value="/timeline") Timeline
       span(v-else)
         .aw-loading Loading...
-  small
+  small.text-muted
     | The page to open when opening ActivityWatch, or clicking the logo in the top menu.
 </template>
 

--- a/src/views/settings/PrivacyFilterSettings.vue
+++ b/src/views/settings/PrivacyFilterSettings.vue
@@ -12,7 +12,7 @@ div
     | Regex-based rules that drop or redact sensitive event data before it is stored.
     | Rules are saved to the server setting #[code privacy_filters] and used by aw-server-rust.
   small.text-muted
-    | Leave the editor empty or save #[code []] to disable the feature.
+    | Leave the editor empty or save <code>[]</code> to disable the feature.
 
   b-alert.mt-3(:show="saveError !== ''" variant="danger")
     | {{ saveError }}

--- a/src/views/settings/ReleaseNotificationSettings.vue
+++ b/src/views/settings/ReleaseNotificationSettings.vue
@@ -1,12 +1,12 @@
 <template lang="pug">
 div
-  div.d-flex.justify-content-between
+  div.d-flex.justify-content-between.align-items-center
     div
-      h5.mb-0 New release notification
+      h5.mb-0 Check for new releases
     div
       b-form-checkbox(v-model="isEnabled" switch)
-  small
-    | We will send you a notification if there is a new release available for download, this check will happen at most once per day.
+  small.text-muted
+    | When enabled, the web UI checks once per day for a new ActivityWatch release and shows a hint if one is available.
 </template>
 
 <script lang="ts">

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -29,6 +29,7 @@ import { useCategoryStore } from '~/stores/categories';
 import DaystartSettings from '~/views/settings/DaystartSettings.vue';
 import TimelineDurationSettings from '~/views/settings/TimelineDurationSettings.vue';
 import ReleaseNotificationSettings from '~/views/settings/ReleaseNotificationSettings.vue';
+import UncategorizedHintSettings from '~/views/settings/UncategorizedHintSettings.vue';
 import CategorizationSettings from '~/views/settings/CategorizationSettings.vue';
 import LandingPageSettings from '~/views/settings/LandingPageSettings.vue';
 import DeveloperSettings from '~/views/settings/DeveloperSettings.vue';
@@ -50,6 +51,7 @@ export default {
     DaystartSettings,
     TimelineDurationSettings,
     ReleaseNotificationSettings,
+    UncategorizedHintSettings,
     CategorizationSettings,
     LandingPageSettings,
     Theme,
@@ -89,6 +91,7 @@ export default {
           { name: 'DaystartSettings' },
           { name: 'TimelineDurationSettings' },
           { name: 'LandingPageSettings' },
+          { name: 'UncategorizedHintSettings' },
           // Release-notification check folded in here so it doesn't
           // need its own one-setting "Updates" panel.
           ...(this.$isAndroid ? [] : [{ name: 'ReleaseNotificationSettings' }]),

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -173,10 +173,10 @@ export default {
 }
 
 .settings-section {
-  // Breathing room at the end of each panel so long subviews don't
-  // crash into the card border (and short ones don't end abruptly
-  // just above the sticky nav's last item).
-  padding-bottom: 3rem;
+  // Modest breathing room at the end of each panel — keeps long
+  // subviews from crashing into the card border without making
+  // short ones feel overly padded.
+  padding-bottom: 1rem;
 }
 
 .settings-section__title {

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -92,9 +92,9 @@ export default {
         help: 'Theme and visualization colors.',
         components: [{ name: 'Theme' }, { name: 'ColorSettings' }],
       };
-      const notifications: Group = {
-        id: 'notifications',
-        label: 'Notifications',
+      const updates: Group = {
+        id: 'updates',
+        label: 'Updates',
         components: [{ name: 'ReleaseNotificationSettings' }],
       };
       const categorization: Group = {
@@ -116,7 +116,7 @@ export default {
       };
 
       const groups: Group[] = [general, appearance];
-      if (!this.$isAndroid) groups.push(notifications);
+      if (!this.$isAndroid) groups.push(updates);
       groups.push(categorization, privacy, developer);
       return groups;
     },

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -106,7 +106,10 @@ export default {
         id: 'categorization',
         label: 'Categorization',
         help: 'Rules that classify events into categories, plus AFK/active-pattern overrides.',
-        components: [{ name: 'ActivePatternSettings' }, { name: 'CategorizationSettings' }],
+        // CategorizationSettings (rules) is the primary content; the
+        // ActivePatternSettings AFK override is an advanced edge-case
+        // setting so it lives at the bottom of the group.
+        components: [{ name: 'CategorizationSettings' }, { name: 'ActivePatternSettings' }],
       };
       const privacy: Group = {
         id: 'privacy',

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -1,46 +1,24 @@
 <template lang="pug">
 div
-  h3 Settings
+  h3.mb-3 Settings
 
-  hr
+  div.settings-layout
+    nav.settings-nav
+      b-nav(pills vertical)
+        b-nav-item(
+          v-for="group in groups"
+          :key="group.id"
+          :active="activeGroup === group.id"
+          @click="activeGroup = group.id"
+          link-classes="settings-nav__link"
+        ) {{ group.label }}
 
-  DaystartSettings
-
-  hr
-
-  TimelineDurationSettings
-
-  hr
-
-  LandingPageSettings
-
-  hr
-
-  Theme
-
-  hr
-
-  div(v-if="!$isAndroid")
-    ReleaseNotificationSettings
-    hr
-
-  ColorSettings
-
-  hr
-
-  ActivePatternSettings
-
-  hr
-
-  PrivacyFilterSettings
-
-  hr
-
-  CategorizationSettings
-
-  hr
-
-  DeveloperSettings
+    div.settings-content
+      template(v-for="group in groups")
+        section.settings-section(v-show="activeGroup === group.id" :key="group.id")
+          h4.settings-section__title {{ group.label }}
+          p.text-muted.small.mb-3(v-if="group.help") {{ group.help }}
+          component(v-for="comp in group.components" :key="comp.name" :is="comp.name")
 </template>
 
 <script lang="ts">
@@ -57,6 +35,13 @@ import Theme from '~/views/settings/Theme.vue';
 import ColorSettings from '~/views/settings/ColorSettings.vue';
 import ActivePatternSettings from '~/views/settings/ActivePatternSettings.vue';
 import PrivacyFilterSettings from '~/views/settings/PrivacyFilterSettings.vue';
+
+interface Group {
+  id: string;
+  label: string;
+  help?: string;
+  components: { name: string }[];
+}
 
 export default {
   name: 'Settings',
@@ -84,6 +69,58 @@ export default {
       next();
     }
   },
+  data() {
+    return {
+      activeGroup: 'general',
+    };
+  },
+  computed: {
+    groups(): Group[] {
+      const general: Group = {
+        id: 'general',
+        label: 'General',
+        help: 'Defaults that shape how time periods, the timeline, and landing page behave.',
+        components: [
+          { name: 'DaystartSettings' },
+          { name: 'TimelineDurationSettings' },
+          { name: 'LandingPageSettings' },
+        ],
+      };
+      const appearance: Group = {
+        id: 'appearance',
+        label: 'Appearance',
+        help: 'Theme and visualization colors.',
+        components: [{ name: 'Theme' }, { name: 'ColorSettings' }],
+      };
+      const notifications: Group = {
+        id: 'notifications',
+        label: 'Notifications',
+        components: [{ name: 'ReleaseNotificationSettings' }],
+      };
+      const categorization: Group = {
+        id: 'categorization',
+        label: 'Categorization',
+        help: 'Rules that classify events into categories, plus AFK/active-pattern overrides.',
+        components: [{ name: 'ActivePatternSettings' }, { name: 'CategorizationSettings' }],
+      };
+      const privacy: Group = {
+        id: 'privacy',
+        label: 'Privacy',
+        help: 'Filters that drop or redact sensitive event data before it is stored.',
+        components: [{ name: 'PrivacyFilterSettings' }],
+      };
+      const developer: Group = {
+        id: 'developer',
+        label: 'Developer',
+        components: [{ name: 'DeveloperSettings' }],
+      };
+
+      const groups: Group[] = [general, appearance];
+      if (!this.$isAndroid) groups.push(notifications);
+      groups.push(categorization, privacy, developer);
+      return groups;
+    },
+  },
   async created() {
     await this.init();
   },
@@ -95,3 +132,57 @@ export default {
   },
 };
 </script>
+
+<style scoped lang="scss">
+.settings-layout {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) 1fr;
+  gap: 1.5rem;
+}
+
+.settings-nav {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+}
+
+::v-deep .settings-nav .nav-link {
+  color: #495057;
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+}
+
+::v-deep .settings-nav .nav-link:hover {
+  background-color: #f0f1f3;
+}
+
+::v-deep .settings-nav .nav-link.active,
+::v-deep .settings-nav .nav-link.active:hover {
+  background-color: #495057 !important;
+  color: #fff !important;
+}
+
+.settings-section__title {
+  margin-bottom: 0.25rem;
+}
+
+@media (max-width: 767px) {
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-nav {
+    position: static;
+  }
+
+  ::v-deep .settings-nav .nav {
+    flex-direction: row !important;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  ::v-deep .settings-nav__link {
+    white-space: nowrap;
+  }
+}
+</style>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -9,8 +9,9 @@ div
           v-for="group in groups"
           :key="group.id"
           :active="activeGroup === group.id"
-          @click="activeGroup = group.id"
+          :to="`/settings/${group.id}`"
           link-classes="settings-nav__link"
+          replace
         ) {{ group.label }}
 
     div.settings-content
@@ -69,12 +70,16 @@ export default {
       next();
     }
   },
-  data() {
-    return {
-      activeGroup: 'general',
-    };
+  props: {
+    // Hydrated from the /settings/:group route param so reloads / direct
+    // links preserve which panel is open.
+    group: { type: String, default: '' },
   },
   computed: {
+    activeGroup(): string {
+      const requested = this.group || 'general';
+      return this.groups.some(g => g.id === requested) ? requested : 'general';
+    },
     groups(): Group[] {
       const general: Group = {
         id: 'general',
@@ -185,7 +190,7 @@ export default {
   margin: 1.5rem 0;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
   .settings-layout {
     grid-template-columns: 1fr;
     gap: 1rem;
@@ -193,17 +198,25 @@ export default {
 
   .settings-nav {
     position: static;
+    // Keep the nav fully inside the layout so the horizontal pill row
+    // doesn't push the page to overflow at xs widths.
+    min-width: 0;
+    max-width: 100%;
   }
 
+  // Flex-wrap the pills onto multiple rows instead of overflow-x: auto.
+  // The hidden horizontal scrollbar produced "incorrect" extra horizontal
+  // scroll space on xs viewports and let pills like "Developer" hide
+  // off-screen — both of which break discoverability.
   ::v-deep .settings-nav .nav {
     flex-direction: row !important;
-    overflow-x: auto;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: 0.25rem;
   }
 
   ::v-deep .settings-nav .nav-link {
     white-space: nowrap;
+    padding: 0.375rem 0.625rem;
   }
 }
 </style>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -89,6 +89,9 @@ export default {
           { name: 'DaystartSettings' },
           { name: 'TimelineDurationSettings' },
           { name: 'LandingPageSettings' },
+          // Release-notification check folded in here so it doesn't
+          // need its own one-setting "Updates" panel.
+          ...(this.$isAndroid ? [] : [{ name: 'ReleaseNotificationSettings' }]),
         ],
       };
       const appearance: Group = {
@@ -96,11 +99,6 @@ export default {
         label: 'Appearance',
         help: 'Theme and visualization colors.',
         components: [{ name: 'Theme' }, { name: 'ColorSettings' }],
-      };
-      const updates: Group = {
-        id: 'updates',
-        label: 'Updates',
-        components: [{ name: 'ReleaseNotificationSettings' }],
       };
       const categorization: Group = {
         id: 'categorization',
@@ -123,9 +121,7 @@ export default {
         components: [{ name: 'DeveloperSettings' }],
       };
 
-      const groups: Group[] = [general, appearance];
-      if (!this.$isAndroid) groups.push(updates);
-      groups.push(categorization, privacy, developer);
+      const groups: Group[] = [general, appearance, categorization, privacy, developer];
       return groups;
     },
   },

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -137,7 +137,8 @@ export default {
 .settings-layout {
   display: grid;
   grid-template-columns: minmax(180px, 220px) 1fr;
-  gap: 1.5rem;
+  gap: 2rem;
+  margin-top: 0.5rem;
 }
 
 .settings-nav {
@@ -150,6 +151,7 @@ export default {
   color: #495057;
   border-radius: 0.25rem;
   padding: 0.5rem 0.75rem;
+  margin-bottom: 0.125rem;
 }
 
 ::v-deep .settings-nav .nav-link:hover {
@@ -162,13 +164,31 @@ export default {
   color: #fff !important;
 }
 
+.settings-content {
+  min-width: 0; // prevent grid blowout from long content
+}
+
 .settings-section__title {
   margin-bottom: 0.25rem;
+}
+
+.settings-section ::v-deep > * + * {
+  margin-top: 1.25rem;
+}
+
+.settings-section ::v-deep .form-group,
+.settings-section ::v-deep .b-form-group {
+  margin-bottom: 0;
+}
+
+.settings-section ::v-deep hr {
+  margin: 1.5rem 0;
 }
 
 @media (max-width: 767px) {
   .settings-layout {
     grid-template-columns: 1fr;
+    gap: 1rem;
   }
 
   .settings-nav {
@@ -179,9 +199,10 @@ export default {
     flex-direction: row !important;
     overflow-x: auto;
     flex-wrap: nowrap;
+    gap: 0.25rem;
   }
 
-  ::v-deep .settings-nav__link {
+  ::v-deep .settings-nav .nav-link {
     white-space: nowrap;
   }
 }

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -176,6 +176,13 @@ export default {
   min-width: 0; // prevent grid blowout from long content
 }
 
+.settings-section {
+  // Breathing room at the end of each panel so long subviews don't
+  // crash into the card border (and short ones don't end abruptly
+  // just above the sticky nav's last item).
+  padding-bottom: 3rem;
+}
+
 .settings-section__title {
   margin-bottom: 0.25rem;
 }

--- a/src/views/settings/Theme.vue
+++ b/src/views/settings/Theme.vue
@@ -1,17 +1,21 @@
 <template lang="pug">
 div
-  div.d-sm-flex.justify-content-between
+  div.d-sm-flex.justify-content-between.align-items-center
     div
       h5.mt-1.mb-2.mb-sm-0 Theme
     div
-      b-select.landingpage(v-if="_loaded" size="sm" :value="theme", @change="theme = $event")
-        option(value="auto") Auto (System)
-        option(value="light") Light
-        option(value="dark") Dark
+      b-button-group(v-if="_loaded" size="sm")
+        b-button(
+          v-for="opt in themeOptions"
+          :key="opt.value"
+          :pressed="theme === opt.value"
+          @click="theme = opt.value"
+          variant="outline-dark"
+        ) {{ opt.label }}
       span(v-else)
         .aw-loading Loading...
-  small
-    | Change color theme of the application (you need to change categories colors manually to be suitable with dark mode).
+  small.text-muted
+    | Change the color theme. Category colors are picked separately — you may want to adjust them when switching to dark mode.
 </template>
 
 <script lang="ts">
@@ -21,6 +25,15 @@ import { detectPreferredTheme } from '~/util/theme';
 
 export default {
   name: 'Theme',
+  data() {
+    return {
+      themeOptions: [
+        { value: 'auto', label: 'Auto' },
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+      ],
+    };
+  },
   computed: {
     ...mapState(useSettingsStore, ['_loaded']),
     theme: {

--- a/src/views/settings/Theme.vue
+++ b/src/views/settings/Theme.vue
@@ -11,7 +11,9 @@ div
           :pressed="theme === opt.value"
           @click="theme = opt.value"
           variant="outline-dark"
-        ) {{ opt.label }}
+        )
+          icon.mr-1(:name="opt.icon")
+          | {{ opt.label }}
       span(v-else)
         .aw-loading Loading...
   small.text-muted
@@ -19,6 +21,9 @@ div
 </template>
 
 <script lang="ts">
+import 'vue-awesome/icons/desktop';
+import 'vue-awesome/icons/sun';
+import 'vue-awesome/icons/moon';
 import { mapState } from 'pinia';
 import { useSettingsStore } from '~/stores/settings';
 import { detectPreferredTheme } from '~/util/theme';
@@ -28,9 +33,9 @@ export default {
   data() {
     return {
       themeOptions: [
-        { value: 'auto', label: 'Auto' },
-        { value: 'light', label: 'Light' },
-        { value: 'dark', label: 'Dark' },
+        { value: 'auto', label: 'Auto', icon: 'desktop' },
+        { value: 'light', label: 'Light', icon: 'sun' },
+        { value: 'dark', label: 'Dark', icon: 'moon' },
       ],
     };
   },

--- a/src/views/settings/Theme.vue
+++ b/src/views/settings/Theme.vue
@@ -33,7 +33,7 @@ export default {
   data() {
     return {
       themeOptions: [
-        { value: 'auto', label: 'Auto', icon: 'desktop' },
+        { value: 'auto', label: 'System', icon: 'desktop' },
         { value: 'light', label: 'Light', icon: 'sun' },
         { value: 'dark', label: 'Dark', icon: 'moon' },
       ],

--- a/src/views/settings/TimelineDurationSettings.vue
+++ b/src/views/settings/TimelineDurationSettings.vue
@@ -13,7 +13,7 @@ div
           option(:value="6*60*60") 6h
           option(:value="12*60*60") 12h
           option(:value="24*60*60") 24h
-  small
+  small.text-muted
     | The default duration used for 'show last' in the timeline view.
 </template>
 <script lang="ts">

--- a/src/views/settings/UncategorizedHintSettings.vue
+++ b/src/views/settings/UncategorizedHintSettings.vue
@@ -1,0 +1,69 @@
+<template lang="pug">
+div
+  div.d-sm-flex.justify-content-between.align-items-center
+    div
+      h5.mb-0 Uncategorized-time hint
+    div
+      b-form-checkbox(v-model="isEnabled" switch)
+  small.text-muted
+    | Shows a banner on the Activity view when too much of your tracked
+    | time falls into the Uncategorized bucket — handy for noticing when
+    | you need to refine your categorization rules.
+
+  div.mt-3(v-if="isEnabled")
+    b-form-group(label="Minimum total tracked time" label-cols-md=4 label-class="small text-muted"
+                 description="The hint stays hidden when total tracked time in the period is below this many minutes.")
+      b-input(type="number" min="0" size="sm" v-model.number="minTotalMinutes")
+
+    b-form-group.mb-0(label="Minimum uncategorized share" label-cols-md=4 label-class="small text-muted"
+                     description="The hint appears once the uncategorized fraction crosses this percentage.")
+      b-input-group(size="sm" append="%")
+        b-input(type="number" min="0" max="100" v-model.number="minRatioPct")
+</template>
+
+<script lang="ts">
+import { useSettingsStore } from '~/stores/settings';
+
+export default {
+  name: 'UncategorizedHintSettings',
+  computed: {
+    config(): { isEnabled: boolean; minTotalSeconds: number; minRatio: number } {
+      return useSettingsStore().uncategorizedNotificationData;
+    },
+    isEnabled: {
+      get(): boolean {
+        return !!this.config?.isEnabled;
+      },
+      set(v: boolean) {
+        this.update({ isEnabled: v });
+      },
+    },
+    minTotalMinutes: {
+      get(): number {
+        return Math.round((this.config?.minTotalSeconds ?? 3600) / 60);
+      },
+      set(v: number) {
+        const minutes = Number.isFinite(v) ? Math.max(0, v) : 0;
+        this.update({ minTotalSeconds: minutes * 60 });
+      },
+    },
+    minRatioPct: {
+      get(): number {
+        return Math.round((this.config?.minRatio ?? 0.3) * 100);
+      },
+      set(v: number) {
+        const pct = Number.isFinite(v) ? Math.min(100, Math.max(0, v)) : 0;
+        this.update({ minRatio: pct / 100 });
+      },
+    },
+  },
+  methods: {
+    update(patch: Record<string, unknown>) {
+      const settingsStore = useSettingsStore();
+      settingsStore.update({
+        uncategorizedNotificationData: { ...this.config, ...patch },
+      });
+    },
+  },
+};
+</script>

--- a/src/visualizations/Score.vue
+++ b/src/visualizations/Score.vue
@@ -1,41 +1,54 @@
 <template lang="pug">
 div
-  div(style="text-align: center")
-    | Your total score for {{ score_period_label }} is:
-    div(:style="'font-size: 2em; color: ' + (score >= 0 ? '#0A0' : '#F00')")
+  div.text-center
+    div.d-inline-flex.align-items-center.justify-content-center
+      | Your total score for {{ score_period_label }} is
+      icon#scoreHelp.ml-1.text-muted(name="question-circle" style="cursor: help")
+      b-tooltip(target="scoreHelp" placement="top")
+        | Sum of (hours &times; category score). Set category scores in #[b Settings &gt; Categories]. Positive scores reward activities you want to do more of; negative ones penalize distractions.
+    div.score-value(:class="score >= 0 ? 'text-success' : 'text-danger'")
       | {{score >= 0 ? '+' : ''}}{{ (Math.round(score * 10) / 10).toFixed(1) }}
-    div.small.text-muted
-      | ({{score_productive_percent.toFixed(1)}}% productive)
+    div.small.text-muted(v-if="!isNaN(score_productive_percent)")
+      | {{score_productive_percent.toFixed(1)}}% productive
   hr
   div
-    b Top productive:
-    div.mt-2(v-for="cat in top_productive")
-      div.d-flex
+    b Top productive
+    div.mt-2(v-for="cat in top_productive" :key="cat.data.$category.join('>')")
+      div.d-flex.align-items-center
         div
-          div
-            | {{cat.data.$category.slice(-1)[0]}}
-          div(style="font-size: 0.7em; color: #666;")
+          div {{cat.data.$category.slice(-1)[0]}}
+          div.small.text-muted(v-if="cat.data.$category.length > 1")
             | {{cat.data.$category.slice(0, -1).join(" > ")}}
-        div.ml-auto
-          span(style="font-size: 1.2em; color: #0A0")
-            | +{{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+        div.ml-auto.text-success.h5.mb-0
+          | +{{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+    p.text-muted.small.mb-0.mt-2(v-if="top_productive.length === 0")
+      | No productive categories recorded yet.
   hr
   div
-    b Top distracting:
-    div.mt-2(v-for="cat in top_distracting")
-      div.d-flex
+    b Top distracting
+    div.mt-2(v-for="cat in top_distracting" :key="cat.data.$category.join('>')")
+      div.d-flex.align-items-center
         div
-          div
-            | {{cat.data.$category.slice(-1)[0]}}
-          div(style="font-size: 0.7em; color: #666;")
+          div {{cat.data.$category.slice(-1)[0]}}
+          div.small.text-muted(v-if="cat.data.$category.length > 1")
             | {{cat.data.$category.slice(0, -1).join(" > ")}}
-        div.ml-auto
-          span(style="font-size: 1.2em; color: #F00")
-            | {{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+        div.ml-auto.text-danger.h5.mb-0
+          | {{ (Math.round(cat.data.$total_score * 10) / 10).toFixed(1) }}
+    p.text-muted.small.mb-0.mt-2(v-if="top_distracting.length === 0")
+      | No distracting activity in this period.
 </template>
+
+<style scoped>
+.score-value {
+  font-size: 2em;
+  font-weight: 600;
+  line-height: 1.1;
+}
+</style>
 
 <script lang="ts">
 import _ from 'lodash';
+import 'vue-awesome/icons/question-circle';
 import { useActivityStore } from '~/stores/activity';
 import { IEvent } from '~/util/interfaces';
 import { periodReadable } from '~/util/timeperiod';

--- a/src/visualizations/Score.vue
+++ b/src/visualizations/Score.vue
@@ -1,11 +1,15 @@
 <template lang="pug">
 div
-  div.text-center
-    div.d-inline-flex.align-items-center.justify-content-center
-      | Your total score for {{ score_period_label }} is
-      icon#scoreHelp.ml-1.text-muted(name="question-circle" style="cursor: help")
-      b-tooltip(target="scoreHelp" placement="top")
-        | Sum of (hours &times; category score). Set category scores in #[b Settings &gt; Categories]. Positive scores reward activities you want to do more of; negative ones penalize distractions.
+  div.text-center.position-relative
+    button.score__help-btn(
+      id="scoreHelp"
+      type="button"
+      aria-label="How is the score calculated?"
+    )
+      icon(name="question-circle" scale="0.9")
+    b-tooltip(target="scoreHelp" placement="left" triggers="hover focus")
+      | Sum of (hours &times; category score). Set category scores in #[b Settings &gt; Categories]. Positive scores reward activities you want to do more of; negative ones penalize distractions.
+    div.small.text-muted Score for {{ score_period_label }}
     div.score-value(:class="score >= 0 ? 'text-success' : 'text-danger'")
       | {{score >= 0 ? '+' : ''}}{{ (Math.round(score * 10) / 10).toFixed(1) }}
     div.small.text-muted(v-if="!isNaN(score_productive_percent)")
@@ -43,6 +47,25 @@ div
   font-size: 2em;
   font-weight: 600;
   line-height: 1.1;
+}
+
+.score__help-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: transparent;
+  border: 0;
+  padding: 0.25rem;
+  color: inherit;
+  opacity: 0.45;
+  cursor: help;
+  line-height: 1;
+}
+
+.score__help-btn:hover,
+.score__help-btn:focus {
+  opacity: 0.85;
+  outline: none;
 }
 </style>
 

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -59,7 +59,7 @@ import { buildTooltip } from '../util/tooltip.js';
 import { getCategoryColorFromEvent, getTitleAttr } from '../util/color';
 import { getSwimlane } from '../util/swimlane.js';
 import { IEvent } from '../util/interfaces';
-import { formatTimelineBucketLabelHtml } from '../util/timelineLabels';
+import { formatTimelineBucketLabelHtml, shortenBucketLabel } from '../util/timelineLabels';
 
 import { Timeline } from 'vis-timeline/esnext';
 import 'vis-timeline/styles/vis-timeline-graph2d.css';
@@ -227,9 +227,19 @@ export default {
           this.openEditor();
         });
         if (!isAlertWarningShown) {
-          alert(
-            "Note: Changes won't be reflected in the timeline until the page is refreshed. This will be improved in a future version."
-          );
+          // Show a one-time inline toast instead of a blocking alert(),
+          // which fired on top of the editor and rudely interrupted the
+          // edit flow. Persist the dismissal via localStorage so the user
+          // doesn't see it every session.
+          if (!this.editRefreshHintDismissed()) {
+            this.$bvToast.toast('Your edit is saved. Refresh the timeline to see it reflected.', {
+              title: 'Heads up',
+              variant: 'info',
+              autoHideDelay: 6000,
+              solid: true,
+            });
+            this.markEditRefreshHintDismissed();
+          }
           isAlertWarningShown = true;
         }
       } else {
@@ -237,9 +247,24 @@ export default {
       }
     },
     abbreviateBucketName(bucketId: string): string {
-      // Abbreviate synced bucket names which can be extremely long (#682)
-      // e.g. "aw-watcher-window_host-synced-from-remotehost" -> "aw-watcher-window (synced from remotehost)"
+      // Kept for callers that don't know about multi-host. update() builds
+      // labels directly via formatTimelineBucketLabelHtml so it can pass
+      // the multi-host hint.
       return formatTimelineBucketLabelHtml(bucketId);
+    },
+    editRefreshHintDismissed(): boolean {
+      try {
+        return localStorage.getItem('aw.timeline.editRefreshHintDismissed') === '1';
+      } catch (e) {
+        return false;
+      }
+    },
+    markEditRefreshHintDismissed(): void {
+      try {
+        localStorage.setItem('aw.timeline.editRefreshHintDismissed', '1');
+      } catch (e) {
+        /* localStorage disabled — fine, fall back to the in-memory flag */
+      }
     },
     ensureUpdate() {
       // Will only run update() if data available and never ran before
@@ -259,6 +284,19 @@ export default {
 
       // Build groups
       const buckets = this.bucketsFromEither;
+
+      // Disambiguate per-row labels by hostname only when two buckets
+      // would otherwise share the same shortened label (e.g. a "window"
+      // bucket on two different hosts). Buckets with no host collision
+      // keep the clean short form like "window" or "afk".
+      const labelCounts: Record<string, number> = {};
+      _.each(buckets, b => {
+        if (b && b.id) {
+          const short = shortenBucketLabel(b.id) || b.id;
+          labelCounts[short] = (labelCounts[short] || 0) + 1;
+        }
+      });
+
       let groups = _.map(buckets, bucket => {
         // If bucket id is not set, then if only one bucket is given, assume result of a search/query and set a constant placeholder one.
         // Otherwise, log a warning.
@@ -271,7 +309,16 @@ export default {
             );
           }
         }
-        const label = this.showRowLabels ? this.abbreviateBucketName(bucket.id) : '';
+        let label = '';
+        if (this.showRowLabels) {
+          const short = shortenBucketLabel(bucket.id) || bucket.id;
+          const collides = labelCounts[short] > 1;
+          label = formatTimelineBucketLabelHtml(bucket.id, {
+            hostname: collides
+              ? bucket.hostname || (bucket.data && bucket.data.hostname)
+              : undefined,
+          });
+        }
         return { id: bucket.id, content: label };
       });
 

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -285,17 +285,28 @@ export default {
       // Build groups
       const buckets = this.bucketsFromEither;
 
-      // Disambiguate per-row labels by hostname only when two buckets
-      // would otherwise share the same shortened label (e.g. a "window"
-      // bucket on two different hosts). Buckets with no host collision
-      // keep the clean short form like "window" or "afk".
+      // Decide whether to surface hostnames on labels. We do it
+      // all-or-nothing: if ANY two host-attributed buckets share the same
+      // shortened label (e.g. two "window" buckets on different hosts),
+      // every host-attributed row gets the "@ host" suffix for
+      // consistency. Buckets without a real hostname (stopwatch /
+      // aw-watcher-web-*, which aren't per-host yet — see
+      // https://github.com/ActivityWatch/activitywatch/issues/ for
+      // host attribution of these watchers) are always shown bare.
+      // TODO: drop the hostnameless-exception branch once
+      // stopwatch/browser buckets are migrated to per-host ids.
+      const realHost = (b: any): string | undefined => {
+        const h = b && (b.hostname || (b.data && b.data.hostname));
+        return h && h !== 'unknown' ? h : undefined;
+      };
       const labelCounts: Record<string, number> = {};
       _.each(buckets, b => {
-        if (b && b.id) {
+        if (b && b.id && realHost(b)) {
           const short = shortenBucketLabel(b.id) || b.id;
           labelCounts[short] = (labelCounts[short] || 0) + 1;
         }
       });
+      const hasCollision = _.some(labelCounts, c => c > 1);
 
       let groups = _.map(buckets, bucket => {
         // If bucket id is not set, then if only one bucket is given, assume result of a search/query and set a constant placeholder one.
@@ -311,12 +322,9 @@ export default {
         }
         let label = '';
         if (this.showRowLabels) {
-          const short = shortenBucketLabel(bucket.id) || bucket.id;
-          const collides = labelCounts[short] > 1;
+          const host = realHost(bucket);
           label = formatTimelineBucketLabelHtml(bucket.id, {
-            hostname: collides
-              ? bucket.hostname || (bucket.data && bucket.data.hostname)
-              : undefined,
+            hostname: hasCollision && host ? host : undefined,
           });
         }
         return { id: bucket.id, content: label };

--- a/src/visualizations/VisTimeline.vue
+++ b/src/visualizations/VisTimeline.vue
@@ -248,6 +248,12 @@ export default {
       }
     },
     update() {
+      // Guard against the buckets/events watch firing before mounted's
+      // $nextTick has constructed the vis Timeline. Otherwise revisiting
+      // the route with the keep-alive cache cleared throws
+      // "can't access property setData, this.timeline is null".
+      if (!this.timeline) return;
+
       // Used by unsureUpdate to check if ran
       this.updateHasRun = true;
 
@@ -331,11 +337,14 @@ export default {
         this.items = items;
         this.groups = groups;
       } else {
-        // update the timeline range
-        this.options.min = this.queriedInterval[0];
-        this.options.max = this.queriedInterval[1];
-        this.timeline.setOptions(this.options);
-        this.timeline.setWindow(this.queriedInterval[0], this.queriedInterval[1]);
+        // update the timeline range (only if a queried interval is provided;
+        // some callers like the Bucket detail view don't pass one)
+        if (this.queriedInterval) {
+          this.options.min = this.queriedInterval[0];
+          this.options.max = this.queriedInterval[1];
+          this.timeline.setOptions(this.options);
+          this.timeline.setWindow(this.queriedInterval[0], this.queriedInterval[1]);
+        }
 
         // clear the data
         this.timeline.setData({ groups: [], items: [] });

--- a/src/visualizations/summary.ts
+++ b/src/visualizations/summary.ts
@@ -107,11 +107,18 @@ function update(container: HTMLElement, apps: Entry[]) {
       .attr('height', barHeight)
       .style('fill', appcolor);
 
-    // App name
+    // App name. Truncate long titles so wide window titles don't run
+    // visually past their bar; full text remains in the hover tooltip
+    // (the <title> appended above) so no information is hidden.
+    const maxNameChars = 80;
+    const displayName =
+      app.name && app.name.length > maxNameChars
+        ? app.name.slice(0, maxNameChars - 1) + '…'
+        : app.name;
     eg.append('text')
       .attr('x', 5)
       .attr('y', curr_y + 1.4 * textSize)
-      .text(app.name)
+      .text(displayName)
       .attr('font-family', 'sans-serif')
       .attr('font-size', textSize + 'px')
       .attr('fill', textColor);

--- a/static/dark.css
+++ b/static/dark.css
@@ -55,6 +55,17 @@ hr {
   color: #e9ebf0 !important;
 }
 
+/* Keep destructive items obviously red even in dark mode. */
+.dropdown-menu .dropdown-item.text-danger,
+.dropdown-menu .dropdown-item .text-danger {
+  color: #ff6b6b !important;
+}
+
+.dropdown-menu .dropdown-item.text-danger:hover,
+.dropdown-menu .dropdown-item .text-danger:hover {
+  color: #ff8585 !important;
+}
+
 .dropdown-menu .dropdown-item:hover {
   background-color: #282c32 !important;
 }
@@ -264,4 +275,83 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: hsl(355, 70%, 90%);
   background-color: hsl(355, 60%, 30%);
   border-color: hsl(355, 60%, 25%);
+}
+
+/* ---- Components introduced by the pre-release polish PR ---- */
+
+/* Timeline toolbar chips + filter popover */
+.timeline-chip {
+  background: #1a1d24 !important;
+  border-color: #282c32 !important;
+  color: #e9ebf0 !important;
+}
+
+.timeline-chip--clickable:hover {
+  background: #282c32 !important;
+}
+
+.timeline-filters-panel {
+  background: #1a1d24 !important;
+  border-color: #282c32 !important;
+  color: #e9ebf0 !important;
+}
+
+/* Quick-range chips (InputTimeInterval) */
+.input-time-interval .btn-group .btn-light {
+  background: #1a1d24 !important;
+  border-color: #282c32 !important;
+  color: #e9ebf0 !important;
+}
+
+.input-time-interval .btn-group input[type='radio']:checked + label {
+  background: #e9ebf0 !important;
+  border-color: #e9ebf0 !important;
+  color: #1a1d24 !important;
+}
+
+/* Buckets: ghost kebab + "unknown" device card */
+.kebab-dropdown > .btn {
+  background: transparent !important;
+  color: #adb5bd !important;
+}
+
+.kebab-dropdown > .btn:hover,
+.kebab-dropdown > .btn:focus,
+.kebab-dropdown.show > .btn {
+  background: #282c32 !important;
+  color: #e9ebf0 !important;
+}
+
+.bucket-card--unknown {
+  background: #15181e !important;
+}
+
+/* Settings vertical pill nav */
+.settings-nav .nav-link {
+  color: #c5cad3 !important;
+}
+
+.settings-nav .nav-link:hover {
+  background-color: #282c32 !important;
+}
+
+.settings-nav .nav-link.active,
+.settings-nav .nav-link.active:hover {
+  background-color: #e9ebf0 !important;
+  color: #0f131a !important;
+}
+
+/* Activity period button-group */
+.btn-outline-dark {
+  color: #e9ebf0 !important;
+  border-color: #3d444d !important;
+}
+
+.btn-outline-dark:hover,
+.btn-outline-dark.active,
+.btn-outline-dark:not(:disabled):not(.disabled).active,
+.btn-outline-dark:not(:disabled):not(.disabled):active {
+  background-color: #e9ebf0 !important;
+  color: #0f131a !important;
+  border-color: #e9ebf0 !important;
 }

--- a/static/dark.css
+++ b/static/dark.css
@@ -139,8 +139,10 @@ hr {
 }
 
 .card {
-  background-color: #1a1d24 !important;
-  border-color: #282c32 !important;
+  /* Slightly lighter than the aw-container background (#1a1d24) so cards
+     read as elevated surfaces rather than blending with the page. */
+  background-color: #21252c !important;
+  border-color: #2f343c !important;
 }
 
 .custom-file-label {
@@ -194,6 +196,16 @@ hr {
 svg text {
   fill: #fff !important;
   text-shadow: #000 0.5px 0.5px 0.5px;
+}
+
+/* Timespiral labels are drawn via D3 .style('fill', '#888'), which loses
+   to the generic svg text rule above via !important — but the inner
+   textPath elements (date rings) inherit a dim parent and need their own
+   bump. Brighten the clock labels and date rings explicitly. */
+svg#timespiral text,
+svg#timespiral textPath {
+  fill: #d8dbe1 !important;
+  opacity: 0.95;
 }
 
 svg.appsummary g rect[style="fill: rgb(204, 204, 204);"] {
@@ -279,6 +291,25 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   color: hsl(355, 70%, 90%);
   background-color: hsl(355, 60%, 30%);
   border-color: hsl(355, 60%, 25%);
+}
+
+/* Links inside dark-mode colored alerts inherit Bootstrap's default
+   darker variant which sits ~equal-luminance with the alert background.
+   Push them brighter and underline so they read clearly. */
+.alert-success a,
+.alert-info a,
+.alert-warning a,
+.alert-danger a {
+  color: #fff !important;
+  text-decoration: underline;
+}
+
+.alert-success a:hover,
+.alert-info a:hover,
+.alert-warning a:hover,
+.alert-danger a:hover {
+  color: #fff !important;
+  opacity: 0.85;
 }
 
 /* ---- Components introduced by the pre-release polish PR ---- */

--- a/static/dark.css
+++ b/static/dark.css
@@ -51,6 +51,47 @@ hr {
   border-color: #282c32 !important;
 }
 
+/* Bootstrap popovers/tooltips render white-on-white in dark mode because
+   .popover .popover-body inherits .body color but keeps its default
+   white background. Patch all three layers (arrow, header, body). */
+.popover {
+  background-color: #21252c !important;
+  border-color: #2f343c !important;
+}
+
+.popover .popover-header {
+  background-color: #1a1d24 !important;
+  border-bottom-color: #2f343c !important;
+  color: #e9ebf0 !important;
+}
+
+.popover .popover-body {
+  background-color: #21252c !important;
+  color: #e9ebf0 !important;
+}
+
+.popover .arrow::before {
+  border-color: #2f343c !important;
+}
+
+.popover .arrow::after {
+  border-color: #21252c !important;
+}
+
+.popover.bs-popover-bottom .arrow::after,
+.popover.bs-popover-auto[x-placement^='bottom'] .arrow::after {
+  border-bottom-color: #1a1d24 !important;
+}
+
+.tooltip .tooltip-inner {
+  background-color: #2f343c !important;
+  color: #e9ebf0 !important;
+}
+
+.tooltip .arrow::before {
+  border-color: #2f343c !important;
+}
+
 .dropdown-menu .dropdown-item {
   color: #e9ebf0 !important;
 }

--- a/static/dark.css
+++ b/static/dark.css
@@ -423,6 +423,49 @@ div[style="color: rgb(85, 85, 85); font-size: 0.9em;"] {
   border-color: #3d444d !important;
 }
 
+/* Outline buttons need explicit color overrides — the generic
+   `button { color: #e9ebf0 !important }` rule above wipes Bootstrap's
+   variant text colors on <button>s, while <label class="btn">s
+   (e.g. the file-input "Import" button) escape that rule and keep
+   the Bootstrap defaults. Pin every outline-* variant explicitly so
+   they match across both element types. */
+.btn-outline-primary,
+label.btn-outline-primary {
+  color: #5cb3ff !important;
+  border-color: #5cb3ff !important;
+}
+
+.btn-outline-primary:hover,
+label.btn-outline-primary:hover,
+.btn-outline-primary:not(:disabled):not(.disabled).active,
+.btn-outline-primary:not(:disabled):not(.disabled):active {
+  background-color: #5cb3ff !important;
+  color: #0f131a !important;
+  border-color: #5cb3ff !important;
+}
+
+.btn-outline-warning,
+label.btn-outline-warning {
+  color: #ffd84d !important;
+  border-color: #ffd84d !important;
+}
+
+.btn-outline-warning:not(:hover) {
+  background-color: transparent !important;
+}
+
+.btn-outline-danger,
+label.btn-outline-danger {
+  color: #ff6b6b !important;
+  border-color: #ff6b6b !important;
+}
+
+.btn-outline-danger:hover {
+  background-color: #ff6b6b !important;
+  color: #0f131a !important;
+  border-color: #ff6b6b !important;
+}
+
 .btn-outline-dark:hover,
 .btn-outline-dark.active,
 .btn-outline-dark:not(:disabled):not(.disabled).active,

--- a/static/dark.css
+++ b/static/dark.css
@@ -116,15 +116,19 @@ hr {
   color: #212529 !important;
 }
 
-[class*=table-responsive-] > .table {
+[class*=table-responsive-] > .table,
+.table {
   color: #e9ebf0 !important;
 }
 
-[class*=table-responsive-] > .table * {
+[class*=table-responsive-] > .table *,
+.table * {
   border-color: #454d55 !important;
 }
 
-[class*=table-responsive-] > .table tr:hover:not(thead tr) {
+[class*=table-responsive-] > .table tr:hover:not(thead tr),
+.table.b-table.table-hover tbody tr:hover,
+.table-hover tbody tr:hover {
   color: #fff !important;
   background-color: hsla(0, 0%, 100%, .075) !important;
 }

--- a/test/unit/Trends.test.js
+++ b/test/unit/Trends.test.js
@@ -1,0 +1,62 @@
+import Trends from '~/views/Trends.vue';
+
+describe('Trends view', () => {
+  describe('host computed', () => {
+    test('returns the :host route param when present', () => {
+      const vm = {
+        $route: { params: { host: 'laptop' } },
+        bucketsStore: { hosts: ['desktop'] },
+      };
+      expect(Trends.computed.host.call(vm)).toBe('laptop');
+    });
+
+    test('falls back to the first available host when no :host param', () => {
+      // Regression: navigating to /trends without :host used to throw
+      // "TypeError: can't access property endsWith, bid is undefined"
+      // because the route param was undefined and queries got built with
+      // bid_window=undefined.
+      const vm = {
+        $route: { params: {} },
+        bucketsStore: { hosts: ['desktop', 'laptop'] },
+      };
+      expect(Trends.computed.host.call(vm)).toBe('desktop');
+    });
+
+    test('returns undefined when there are no hosts at all', () => {
+      const vm = {
+        $route: { params: {} },
+        bucketsStore: { hosts: [] },
+      };
+      expect(Trends.computed.host.call(vm)).toBeUndefined();
+    });
+  });
+
+  describe('refresh', () => {
+    test('bails out without querying when no host is resolvable', async () => {
+      const ensureLoaded = jest.fn();
+      const vm = {
+        host: undefined,
+        activityStore: { ensure_loaded: ensureLoaded },
+        timeperiod: { start: new Date(), length: [7, 'day'] },
+      };
+      await Trends.methods.refresh.call(vm);
+      expect(ensureLoaded).not.toHaveBeenCalled();
+    });
+
+    test('calls ensure_loaded (not just query_category_time_by_period) so buckets are populated first', async () => {
+      // Regression: refresh() previously called query_category_time_by_period
+      // directly, but that store action assumes `buckets.window/afk` are
+      // already populated. Without ensure_loaded the bucket arrays stay []
+      // and the generated query references bid_window=undefined.
+      const ensureLoaded = jest.fn();
+      const vm = {
+        host: 'laptop',
+        activityStore: { ensure_loaded: ensureLoaded },
+        timeperiod: { start: new Date(), length: [7, 'day'] },
+      };
+      await Trends.methods.refresh.call(vm);
+      expect(ensureLoaded).toHaveBeenCalledTimes(1);
+      expect(ensureLoaded.mock.calls[0][0].host).toBe('laptop');
+    });
+  });
+});

--- a/test/unit/Trends.test.js
+++ b/test/unit/Trends.test.js
@@ -43,20 +43,10 @@ describe('Trends view', () => {
       expect(ensureLoaded).not.toHaveBeenCalled();
     });
 
-    test('calls ensure_loaded (not just query_category_time_by_period) so buckets are populated first', async () => {
-      // Regression: refresh() previously called query_category_time_by_period
-      // directly, but that store action assumes `buckets.window/afk` are
-      // already populated. Without ensure_loaded the bucket arrays stay []
-      // and the generated query references bid_window=undefined.
-      const ensureLoaded = jest.fn();
-      const vm = {
-        host: 'laptop',
-        activityStore: { ensure_loaded: ensureLoaded },
-        timeperiod: { start: new Date(), length: [7, 'day'] },
-      };
-      await Trends.methods.refresh.call(vm);
-      expect(ensureLoaded).toHaveBeenCalledTimes(1);
-      expect(ensureLoaded.mock.calls[0][0].host).toBe('laptop');
-    });
+    // Regression for the original bid.endsWith crash used to assert that
+    // refresh() forwarded to activityStore.ensure_loaded. That code path
+    // no longer exists — Trends now queries the aw-server directly via
+    // getClient() and ensure_loaded() is not involved. The host-fallback
+    // and no-host-bail-out tests above still cover the bug class.
   });
 });

--- a/test/unit/__snapshots__/workReport.test.node.ts.snap
+++ b/test/unit/__snapshots__/workReport.test.node.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`workReport host helpers buildWorkReportQuery produces a snapshot-stable query for multiple hosts 1`] = `
+"
+            events_0 = flood(query_bucket("aw-watcher-window_laptop"));
+            not_afk_0 = flood(query_bucket("aw-watcher-afk_laptop"));
+            not_afk_0 = filter_keyvals(not_afk_0, "status", ["not-afk"]);
+            events_0 = filter_period_intersect(events_0, not_afk_0);
+            events_0 = categorize(events_0, []);
+            events_0 = filter_keyvals(events_0, "$category", [["Work"]]);
+
+            events_1 = flood(query_bucket("aw-watcher-window_desktop"));
+            not_afk_1 = flood(query_bucket("aw-watcher-afk_desktop"));
+            not_afk_1 = filter_keyvals(not_afk_1, "status", ["not-afk"]);
+            events_1 = filter_period_intersect(events_1, not_afk_1);
+            events_1 = categorize(events_1, []);
+            events_1 = filter_keyvals(events_1, "$category", [["Work"]]);
+
+events = [];
+events = union_no_overlap(events, events_0);
+events = union_no_overlap(events, events_1);
+          duration = sum_durations(events);
+          RETURN = {"events": events, "duration": duration};
+        "
+`;

--- a/test/unit/__snapshots__/workReport.test.node.ts.snap
+++ b/test/unit/__snapshots__/workReport.test.node.ts.snap
@@ -21,5 +21,5 @@ events = union_no_overlap(events, events_0);
 events = union_no_overlap(events, events_1);
           duration = sum_durations(events);
           RETURN = {"events": events, "duration": duration};
-        "
+"
 `;

--- a/test/unit/timelineLabels.test.node.ts
+++ b/test/unit/timelineLabels.test.node.ts
@@ -1,25 +1,50 @@
-import { formatTimelineBucketLabelHtml } from '~/util/timelineLabels';
+import { formatTimelineBucketLabelHtml, shortenBucketLabel } from '~/util/timelineLabels';
+
+describe('shortenBucketLabel', () => {
+  it('strips the aw-watcher- prefix and the host suffix', () => {
+    expect(shortenBucketLabel('aw-watcher-window_erb-m2.localdomain')).toBe('window');
+    expect(shortenBucketLabel('aw-watcher-afk_erb-m2.localdomain')).toBe('afk');
+  });
+
+  it('keeps the browser sub-type', () => {
+    expect(shortenBucketLabel('aw-watcher-web-firefox_host')).toBe('web-firefox');
+  });
+
+  it('returns null when no aw-watcher-/aw- prefix is present', () => {
+    expect(shortenBucketLabel('custom-bucket')).toBeNull();
+  });
+
+  it('strips aw- prefix even for bucket ids without a host suffix', () => {
+    expect(shortenBucketLabel('aw-stopwatch')).toBe('stopwatch');
+  });
+});
 
 describe('formatTimelineBucketLabelHtml', () => {
-  it('should add word-break opportunities after separators', () => {
-    expect(formatTimelineBucketLabelHtml('aw-watcher-window_host')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window_host">aw-\u200Bwatcher-\u200Bwindow_\u200Bhost</span>'
+  it('shortens conventional bucket ids in the label and preserves the full id in the tooltip', () => {
+    expect(formatTimelineBucketLabelHtml('aw-watcher-window_erb-m2.localdomain')).toBe(
+      '<span class="timeline-label" title="aw-watcher-window_erb-m2.localdomain">window</span>'
     );
   });
 
-  it('should abbreviate synced bucket names', () => {
+  it('shortens but keeps wrap opportunities for multi-part subtypes', () => {
+    expect(formatTimelineBucketLabelHtml('aw-watcher-web-firefox_host')).toBe(
+      '<span class="timeline-label" title="aw-watcher-web-firefox_host">web-​firefox</span>'
+    );
+  });
+
+  it('falls back to the full id when no convention matches', () => {
+    expect(formatTimelineBucketLabelHtml('custom-bucket')).toBe(
+      '<span class="timeline-label" title="custom-bucket">custom-​bucket</span>'
+    );
+  });
+
+  it('abbreviates synced bucket names', () => {
     expect(formatTimelineBucketLabelHtml('aw-watcher-window_host-synced-from-remote-host')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window_host-synced-from-remote-host">aw-\u200Bwatcher-\u200Bwindow (synced from remote-\u200Bhost)</span>'
+      '<span class="timeline-label" title="aw-watcher-window_host-synced-from-remote-host">aw-​watcher-​window (synced from remote-​host)</span>'
     );
   });
 
-  it('should handle slashes', () => {
-    expect(formatTimelineBucketLabelHtml('aw-watcher-window/host/session')).toBe(
-      '<span class="timeline-label" title="aw-watcher-window/host/session">aw-\u200Bwatcher-\u200Bwindow/\u200Bhost/\u200Bsession</span>'
-    );
-  });
-
-  it('should escape HTML in bucket IDs', () => {
+  it('escapes HTML in bucket IDs', () => {
     expect(formatTimelineBucketLabelHtml('bucket<script>')).toBe(
       '<span class="timeline-label" title="bucket&lt;script&gt;">bucket&lt;script&gt;</span>'
     );

--- a/test/unit/workReport.test.node.ts
+++ b/test/unit/workReport.test.node.ts
@@ -1,4 +1,5 @@
 import {
+  buildWorkReportQuery,
   getSupportedWorkReportHosts,
   getUnsupportedWorkReportHosts,
   getWorkReportHostOptions,
@@ -42,6 +43,23 @@ describe('workReport host helpers', () => {
 
   test('getSupportedWorkReportHosts returns only hosts with AFK buckets', () => {
     expect(getSupportedWorkReportHosts(['laptop', 'phone'], buckets as any)).toEqual(['laptop']);
+  });
+
+  test('buildWorkReportQuery uses single-arg flood() for both window and afk buckets', () => {
+    // Regression: aw-query's flood() takes one argument. A previous version
+    // passed breakTimeSeconds as a second argument, which made aw-server
+    // respond with HTTP 400 "Tried to call function flood with invalid amount
+    // of arguments" and broke the whole report.
+    const query = buildWorkReportQuery(['laptop'], '[]', []);
+    expect(query).toContain('events_0 = flood(query_bucket("aw-watcher-window_laptop"));');
+    expect(query).toContain('not_afk_0 = flood(query_bucket("aw-watcher-afk_laptop"));');
+    // Must NOT contain flood() with two arguments
+    expect(query).not.toMatch(/flood\([^)]+,[^)]+\)/);
+  });
+
+  test('buildWorkReportQuery produces a snapshot-stable query for multiple hosts', () => {
+    const query = buildWorkReportQuery(['laptop', 'desktop'], '[]', [['Work']]);
+    expect(query).toMatchSnapshot();
   });
 
   test('getSupportedWorkReportHosts preserves selected host order', () => {


### PR DESCRIPTION
## Summary

Comprehensive pre-stable-release polish pass driven by an audit of every view at multiple widths. Fixes 5 runtime bugs, adds regression tests for the worst three (which had zero coverage), and revamps the weakest views — Timeline, Buckets, Activity, and Settings.

### Phase A — Runtime bug fixes + regression tests

- **Bucket detail view** stopped crashing with `queriedInterval is undefined` (`VisTimeline.vue`).
- **Bucket-revisit** stopped crashing with `this.timeline is null` race (`VisTimeline.vue`).
- **Work Time Report** stopped 400-ing with `flood with invalid amount of arguments` — `flood()` is single-arg; break-time gap-bridging moved client-side so the slider still works. `thisWeek`/`thisMonth` now snap to actual calendar/ISO boundaries instead of \"N days ending today\" (`WorkReport.vue`, `util/workReport.ts`).
- **Trends** stopped crashing with `bid.endsWith is undefined` — `refresh()` now calls `ensure_loaded()` so buckets are populated before queries; falls back to first host when `:host` is absent (`Trends.vue`).
- **Timeline** dupe \"Events shown\" block removed; misplaced Duration filter (a `<tr>` indented one level too shallow in #679) moved into the filter panel where it belongs; \"No events match\" no longer flashes during loading (`Timeline.vue`).
- **Alerts** stopped picking a stale hostname with no AFK bucket. Hostname list now filters to hosts with both window+AFK; friendly empty-state when none qualify (`Alerts.vue`).
- **Buckets store** host sort priority is now (matches-server-hostname, has window+afk, recency) instead of recency-only — fixes downstream views picking a stale legacy host (`stores/buckets.ts`).
- **Buckets view** \"Last updated 0s ago\" / blank Updated column for empty buckets (which was `moment(undefined).fromNow()`) replaced with explicit \"No events recorded yet\" / \"no events\". Also fixes the `dismissable`→`dismissible` typo on the import error alert (`Buckets.vue`).
- **Report** copy fix: `events.slice(0, 500)` on a desc-sorted list is the *most recent* 500, not the *last* 500 (`Report.vue`).
- **Activity dashboard period-switch** no longer throws the user across the calendar when going year → month → week. If today falls inside the source period, anchor on today instead of the source start (`Activity.vue`).
- **ActivityView \"Remove\"** is now guarded by a confirmation modal; visiting a route with a stale `view_id` shows an explicit \"this view doesn't exist\" fallback instead of silently rendering the default view's content under the wrong tab (`ActivityView.vue`).
- **Stopwatch** unreachable `v-else` removed; horizontal-overflow on narrow widths fixed; Enter-to-start added; dev-internal \"Using bucket\" line dropped (`Stopwatch.vue`).
- **Home** invalid `<p><ul>` nesting removed; API browser link resolved relative to document path (works behind reverse proxies) (`Home.vue`).
- **CategoryBuilder** stuck \"Loading…\" replaced with empty-state when no host has window/AFK buckets (`settings/CategoryBuilder.vue`).
- Stale `activitywatch.readthedocs.io` URLs swapped for `docs.activitywatch.net` across 6 files.

**Tests (none of these views had any before):**
- `workReport.test.node.ts` — snapshot of generated aw-query string + explicit assertion that `flood()` stays single-arg.
- `Trends.test.js` — host fallback + `refresh()` calls `ensure_loaded`.

### Phase B — Visual consistency pass

- `b-alert(style=\"warning\")` → `variant=\"warning\"` across 5 files. The prop typo meant every \"early development\" banner was rendering as default info-blue instead of yellow.
- Page titles standardized on `h3` (Timeline / Buckets / Stopwatch / Timespiral / CategoryBuilder were h2/h1).
- \"Danger!\" modal titles → descriptive (\"Delete bucket?\", \"Delete all buckets for <host>?\").
- Inline `color: #XXX` hex / named colors replaced with `.text-success` / `.text-danger` / `.text-muted` / `.text-warning` across 11 files. Theme/dark-mode safe.
- Empty states added to Score (Top productive/distracting), Alerts, Timespiral.
- Timespiral default range now last-7-days (was hard-coded `2022-08-08`).
- Low-contrast `#aaa` selected-chip background (failed WCAG AA) replaced.
- `.mr-1` icon spacing added in Search/Graph/Report/Buckets button labels.

### Phase C — View-level revamps

- **Timeline:** toolbar rebuilt as a flex row; filter dropdown is a styled popover with shadow; Duration sits with the other filters; keyboard hint right-aligned and wraps cleanly. `InputTimeInterval` collapses the three near-duplicate \"Show last\" controls into a single Mode pill plus the existing quick-range chips.
- **Buckets:** card header is a 2-column key/value grid with a clear \"this device\" badge; uniform column widths across all device tables via `fields.thStyle`; row actions right-aligned with ghost-styled kebab dropdowns (borderless until hover); \"Delete host\" returned to the kebab menu. Dropped the `b-table responsive` wrapper (which was clipping the popovers) — `table-layout: fixed` makes it unnecessary anyway.
- **Activity:** period selector promoted to a pill button-group; tooltips + aria-labels on icon-only Filters/Refresh; long window titles truncated at 80 chars (full text remains in SVG `<title>` tooltip); Score widget rebuilt with a (?) tooltip explaining the formula and proper empty-state copy.
- **Settings:** flat list of 10+ `<hr>`-separated rows replaced with a vertical pill navigation (General / Appearance / Notifications / Categorization / Privacy / Developer). Sticky on wide screens; collapses to a horizontal scrollable pill row on mobile.

## Test plan

- [x] `npx jest` passes (94/94, 3 snapshots).
- [x] `npx vue-cli-service lint` clean (3 pre-existing config-file warnings unrelated to this PR).
- [x] Manual verification at 1400px and 800px on Timeline, Buckets, Activity, Settings, Alerts, Home, Stopwatch.
- [x] Visited every view that the audit covered (Search, Trends, Graph, Timespiral, QueryExplorer, Report, WorkReport, Alerts, all Activity subviews) with the dev build to confirm no rendering regressions.
- [x] Reviewer to verify the Buckets `last_updated` logic against an aw-server-rust backend (the fix uses `bucket.last_updated`, which the store harmonization populates from `metadata.end` for the rust backend — see `update_buckets` in `stores/buckets.ts`).
- [ ] Reviewer to sanity-check the host-priority change in `stores/buckets.ts` against a multi-device setup.

---

## Post-open updates

Iterations driven by review feedback. Listed by area, not chronologically.

### Trends — rebuilt instead of band-aided

Trends previously showed a duplicate of the Activity Summary's barchart and got stuck on `Loading…` because the per-day events were stored in a shape `buildBarchartDataset()` didn't recognize. Replaced with a real comparison view:

- Three summary cards: **Active time** (vs previous N days), **Daily average**, **Most-active day**.
- Per-day stacked barchart (now actually shaped correctly).
- **Top changes by category** table sorted by absolute delta.
- 7 / 30 / 90 day windows; host selector when multiple hosts exist.
- Compared against an equal-length previous window; deltas labelled `+12%` / `-8%` / `+new`.

### Activity dashboard

- Rolling ranges (**day / 7 days / 30 days**) promoted to primary pills; calendar periods (week / month / year) moved into a ghost kebab. Active extended-range pill surfaces alongside the primary row so the selection is always visible.
- Date input unified across all modes — same compact `<input type="date">` instead of switching to a wide read-only range display for non-day modes.
- `include_stopwatch=true` by default, so the "Top Stopwatch Events" visualization shows real data instead of "No data" once the user starts a stopwatch session. (Was hidden behind a dev-only filter checkbox.)

### Settings

- Vertical pill nav restructured to **General / Appearance / Categorization / Privacy / Developer**. URL-routed (`/settings/categorization` etc.) so reloads keep the panel; wraps onto multiple rows below 768px instead of overflow-scrolling.
- "Updates" panel removed — its one setting (new-release check) folded into General.
- Theme as a button-group with icons (System / Light / Dark) instead of a dropdown.
- Help text standardized on `.text-muted` (some panels were rendering body text color, jarring in dark mode).
- Category Builder embedded inside Categorization (lazy-loaded behind a collapse) — clicking the "Category Builder" link from the uncategorized-time banner now opens the collapse and scrolls it into view.
- Category Builder words list paginated (10 at a time with "Show more") — was producing 2+ screen walls.
- **High uncategorized time** banner is now dismissible + configurable (threshold + ratio sliders under General). A small ⚙ icon links to the settings.

### Timeline

- Bucket labels shortened — `aw-watcher-window_host.local` → `window`, with the full id in the tooltip. Multi-host collisions get `window @ host` consistently across all rows; hostnameless watchers (stopwatch, aw-watcher-web-\*) stay bare. TODO left in code to migrate those to per-host bucket ids.
- Blocking `alert("Changes won't be reflected…")` after each event edit replaced with a one-time dismissible toast (persisted in localStorage).
- Filter icon next to "Filters:" matches the Activity view's Filters button.
- Toolbar reorder: Filters → Display kebab (Swimlanes options) → event count → keyboard hint.

### Dark mode sweep

- Popovers and tooltips now themed (previously white-on-white).
- Alert links pinned to white + underline (Bootstrap defaults were near-iso-luminant with the alert background).
- Card backgrounds bumped one shade lighter so cards on Trends/Activity/Buckets read as elevated surfaces.
- Timespiral SVG labels brightened from `#888` to `#d8dbe1`.
- `.bg-light` regions (e.g. the "Category set:" switcher) now correctly flip in dark mode — was bleeding inline `style="background: var(--bs-light)"`.
- Outline buttons (`.btn-outline-primary`, `-warning`, `-danger`) consistent across `<button>` and `<label class="btn">` — file-input "Import" had been rendering as Bootstrap blue while sibling buttons rendered white.
- Hover row legibility on non-responsive `.table-hover` tables (Buckets after dropping the responsive wrapper).
- Destructive dropdown items kept obviously red in dark mode.

### Other polish

- Stopwatch banner replaced with a small (?) icon next to the title that pops up the same help on hover/focus/tap.
- Score widget (?) icon moved to the top-right corner of the widget instead of inline with the heading.
- Buckets ghost kebabs (borderless until hover) on both device-level and row-level menus.
- Buckets "Last updated 0s ago" / "0s ago" on empty buckets replaced with "No events recorded yet" / "no events" (was `moment(undefined).fromNow()`).
- Work Report category picker rebuilt: badges-style multi-select with subcategory auto-inclusion (selecting "Work" also covers "Work > Programming"), matching the Timeline filter pattern.
- Categorization restructure: drop the redundant top "Categorization" h5, rename inner heading to "Categories", move ActivePatternSettings to the bottom of the group as advanced.
