### PR TITLE
fix(deps): override vulnerable d3-color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23356,12 +23356,6 @@
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/vue-d3-sunburst/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vue-d3-sunburst/node_modules/d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
   },
   "overrides": {
     "@tootallnate/once": "^2.0.1",
+    "d3-color": "^3.1.0",
     "editorconfig": {
       "minimatch": "^9.0.7"
     },

--- a/test/unit/SunburstCategories.test.js
+++ b/test/unit/SunburstCategories.test.js
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SunburstCategories from '~/visualizations/SunburstCategories.vue';
+import { useCategoryStore } from '~/stores/categories';
+import { useSettingsStore } from '~/stores/settings';
+
+jest.mock('vue-d3-sunburst/dist/vue-d3-sunburst.css', () => ({}));
+
+describe('SunburstCategories', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+
+    useSettingsStore().theme = 'light';
+    useCategoryStore().load([
+      {
+        name: ['Work'],
+        rule: { type: 'none' },
+        data: { color: '#336699' },
+      },
+      {
+        name: ['Work', 'Code'],
+        rule: { type: 'none' },
+        data: { color: '#669933' },
+      },
+      {
+        name: ['Code'],
+        rule: { type: 'none' },
+        data: { color: '#669933' },
+      },
+    ]);
+  });
+
+  test('renders the vue-d3-sunburst graph with the overridden d3-color dependency', async () => {
+    const wrapper = mount(SunburstCategories, {
+      attachTo: document.body,
+      propsData: {
+        data: {
+          name: 'All',
+          children: [
+            {
+              name: 'Work',
+              children: [{ name: 'Code', size: 3600 }],
+            },
+          ],
+        },
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.findAll('path').length).toBeGreaterThan(0);
+
+    wrapper.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

- add an npm override forcing `d3-color` to the patched `^3.1.0` line
- regenerate `package-lock.json` so the nested vulnerable `vue-d3-sunburst/node_modules/d3-color@1.4.1` copy is removed

This unblocks the Dependabot security update job `#1400960543`, which failed because `vue-d3-sunburst@1.9.1` depends on old D3 packages that require `d3-color@1`.

## Verification

- `npm install --package-lock-only --ignore-scripts`
- `npm ci`
- `npm ls d3-color`
- `npm audit --omit=dev --json | jq -r '.vulnerabilities["d3-color"] // "no d3-color audit finding"'`
- `make build`
- `make build-vite`
- `make lint`
- `git diff --check -- package.json package-lock.json`
