### PR TITLE
[codex] fix(activity): widen timeline barchart card

### DIFF
--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -120,7 +120,9 @@ export default {
       await useViewsStore().removeVisualization({ view_id: this.view.id, el_id: id });
     },
     isVisLarge(el) {
-      return el.type == 'sunburst_clock' || el.type == 'vis_timeline';
+      return (
+        el.type == 'sunburst_clock' || el.type == 'vis_timeline' || el.type == 'timeline_barchart'
+      );
     },
   },
 };

--- a/test/unit/ActivityView.test.js
+++ b/test/unit/ActivityView.test.js
@@ -1,0 +1,10 @@
+import ActivityView from '~/views/activity/ActivityView.vue';
+
+describe('ActivityView isVisLarge', () => {
+  test('treats wide visualizations as full-width cards', () => {
+    expect(ActivityView.methods.isVisLarge({ type: 'sunburst_clock' })).toBe(true);
+    expect(ActivityView.methods.isVisLarge({ type: 'vis_timeline' })).toBe(true);
+    expect(ActivityView.methods.isVisLarge({ type: 'timeline_barchart' })).toBe(true);
+    expect(ActivityView.methods.isVisLarge({ type: 'top_apps' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- widen `timeline_barchart` cards to the full-width layout in activity views
- add a focused unit test for `ActivityView.isVisLarge` so the layout rule does not regress

## Why
Issue #850 reports that the timeline barchart becomes too cramped in the summary grid. The root cause is that `ActivityView` only treated `sunburst_clock` and `vis_timeline` as wide visualizations, so the timeline barchart stayed in the narrow card layout even though it is much harder to read there.

## Verification
- `npx jest --selectProjects jsdom test/unit/ActivityView.test.js --runInBand`
- `npx eslint src/views/activity/ActivityView.vue test/unit/ActivityView.test.js`
- `git diff --check`

Closes #850
