### PR TITLE
fix(activity): revert timeline_barchart as wide vis — breaks default 3-vis layout

### DIFF
--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -148,9 +148,7 @@ export default {
       await useViewsStore().removeVisualization({ view_id: this.view.id, el_id: id });
     },
     isVisLarge(el) {
-      return (
-        el.type == 'sunburst_clock' || el.type == 'vis_timeline' || el.type == 'timeline_barchart'
-      );
+      return el.type == 'sunburst_clock' || el.type == 'vis_timeline';
     },
   },
 };

--- a/test/unit/ActivityView.test.js
+++ b/test/unit/ActivityView.test.js
@@ -4,7 +4,7 @@ describe('ActivityView isVisLarge', () => {
   test('treats wide visualizations as full-width cards', () => {
     expect(ActivityView.methods.isVisLarge({ type: 'sunburst_clock' })).toBe(true);
     expect(ActivityView.methods.isVisLarge({ type: 'vis_timeline' })).toBe(true);
-    expect(ActivityView.methods.isVisLarge({ type: 'timeline_barchart' })).toBe(true);
+    expect(ActivityView.methods.isVisLarge({ type: 'timeline_barchart' })).toBe(false);
     expect(ActivityView.methods.isVisLarge({ type: 'top_apps' })).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

PR #859 added `timeline_barchart` to `isVisLarge()`, treating it as a full-width card like `sunburst_clock` and `vis_timeline`. This caused the default Activity view's 3-vis top row to render as 1+1+3 wide, overflowing into two rows with an empty top-right slot.

Reported by @ErikBjare in #859.

## Fix

Remove `timeline_barchart` from `isVisLarge`. The timeline barchart does not require full-width treatment the way `sunburst_clock` (circular) and `vis_timeline` (timeline sweep) do — it fits fine in the standard narrow card.

Also updates the unit test added in #859 to assert `timeline_barchart` is narrow (expected: false).

## Related

- Reverts the layout part of #859
- Fixes the regression reported in #859 comment thread