### PR TITLE
fix(tests): skip cross-locale assertions when Node lacks full-icu

### DIFF
--- a/test/unit/time.test.js
+++ b/test/unit/time.test.js
@@ -31,6 +31,20 @@ describe('seconds_to_duration', () => {
   });
 });
 
+// Node builds without full ICU data silently fall back to the default locale
+// for any non-English locale, which breaks cross-locale assertions. This is
+// common in distro-packaged Node (Debian, Fedora, Arch). Detect it so we can
+// skip the cross-locale comparisons in those environments. See issue #871.
+function hasLocale(locale) {
+  try {
+    return new Intl.DateTimeFormat(locale).resolvedOptions().locale === locale;
+  } catch (_) {
+    return false;
+  }
+}
+
+const HAS_SV_SE = hasLocale('sv-SE');
+
 describe('locale-aware time labels', () => {
   test('should format weekday labels using the supplied locale', () => {
     const monday = new Date(2026, 4, 18, 12);
@@ -41,7 +55,9 @@ describe('locale-aware time labels', () => {
     expect(format_weekday_short(monday, 'sv-SE')).toBe(
       new Intl.DateTimeFormat('sv-SE', { weekday: 'short' }).format(monday)
     );
-    expect(format_weekday_short(monday, 'sv-SE')).not.toBe(format_weekday_short(monday, 'en-US'));
+    if (HAS_SV_SE) {
+      expect(format_weekday_short(monday, 'sv-SE')).not.toBe(format_weekday_short(monday, 'en-US'));
+    }
   });
 
   test('should format month-day labels without hardcoded english ordinals', () => {
@@ -62,6 +78,8 @@ describe('locale-aware time labels', () => {
         new Intl.DateTimeFormat('sv-SE', { month: 'short' }).format(new Date(2020, month, 1, 12))
       )
     );
-    expect(svSEMonths).not.toEqual(enUSMonths);
+    if (HAS_SV_SE) {
+      expect(svSEMonths).not.toEqual(enUSMonths);
+    }
   });
 });


### PR DESCRIPTION
Fixes #871.

When Node.js is built without full ICU data (the default on Debian/Fedora/Arch distro packages), `Intl.DateTimeFormat('sv-SE', …)` silently falls back to the default locale. The output then matches `'en-US'`, so the `.not.toBe` / `.not.toEqual` assertions in `test/unit/time.test.js` fail when building from source. CI is green because GitHub Actions runners ship full-icu.

Picked option A from @TimeToBuildBob's analysis in the issue — gate the two cross-locale assertions on a runtime ICU check, no new dependency. Positive assertions still run, so behavior on full-icu builds is unchanged.

Tested locally (Node 22 with full-icu): 24/24 tests pass.

```js
function hasLocale(locale) {
  try { return new Intl.DateTimeFormat(locale).resolvedOptions().locale === locale; }
  catch (_) { return false; }
}
```