### PR TITLE
fix(ci): restore Dependabot auto-merge on master

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -27,7 +27,12 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const prNumber = context.payload.workflow_run.pull_requests[0].number;
+            const triggeredPullRequests = context.payload.workflow_run.pull_requests;
+            if (!triggeredPullRequests || triggeredPullRequests.length === 0) {
+              core.info('No associated pull request on the triggering workflow run. Skipping.');
+              return;
+            }
+            const prNumber = triggeredPullRequests[0].number;
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,11 +1,5 @@
 name: Dependabot Auto-merge
 
-# NOTE: `merge-me-action` still needs the bot PAT here.
-# Using `secrets.GITHUB_TOKEN` fails on `workflow_run` with
-# "Resource not accessible by integration" when the action queries
-# branch protection rules over GraphQL.
-# See: https://github.com/ridedott/merge-me-action/issues/1581
-
 on:
   workflow_run:
     types:
@@ -14,16 +8,56 @@ on:
       # List all required workflow names here.
       - Build
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto_merge:
-    name: Auto-merge
+    name: Enable auto-merge
     runs-on: ubuntu-latest
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.actor == 'dependabot[bot]'
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.pull_requests[0].number
 
     steps:
-      - uses: ridedott/merge-me-action@bb09d7d3c3504d3837816cc4eb821e663dc7ffde
+      - name: Enable GitHub auto-merge for the triggering PR
+        uses: actions/github-script@v8
         with:
-          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}
+          script: |
+            const prNumber = context.payload.workflow_run.pull_requests[0].number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.user.login !== 'dependabot[bot]' || pr.state !== 'open' || pr.draft) {
+              core.info('PR is not an open Dependabot PR. Skipping.');
+              return;
+            }
+
+            if (pr.auto_merge) {
+              core.info('Auto-merge is already enabled.');
+              return;
+            }
+
+            await github.graphql(
+              `mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: $mergeMethod
+                }) {
+                  clientMutationId
+                }
+              }`,
+              {
+                pullRequestId: pr.node_id,
+                mergeMethod: 'SQUASH',
+              }
+            );
+
+            core.info(`Enabled auto-merge for PR #${prNumber}.`);

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Enable GitHub auto-merge for the triggering PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
             const triggeredPullRequests = context.payload.workflow_run.pull_requests;


### PR DESCRIPTION
## Summary
- replace the stale `AWBOT_GH_TOKEN` + `ridedott/merge-me-action` path in `dependabot-automerge.yml`
- enable native GitHub auto-merge for the triggering Dependabot PR after a successful `Build` workflow run
- keep the workflow guarded to open Dependabot pull requests only, using squash merge like before

## Why
`Dependabot Auto-merge` is currently failing on `master` with `Bad credentials` because the PAT-backed action path is dead. The PR checks are already green (for example #888), but auto-merge never gets enabled.
