### PR TITLE
fix(buckets): surface real server error message on import failure

### DIFF
--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -138,6 +138,8 @@ div
     b-card(header="Import buckets")
       b-alert(v-if="import_error" show variant="danger" dismissible)
         | {{ import_error }}
+      b-alert(v-if="import_success" show variant="success" dismissible)
+        | Import completed successfully!
       b-form-file(v-model="import_file"
                   placeholder="Choose or drop a file here..."
                   drop-placeholder="Drop file here...")
@@ -263,6 +265,7 @@ export default {
 
       import_file: null,
       import_error: null,
+      import_success: false,
       delete_bucket_selected: null,
       delete_host_selected: null,
       deleting_host: false,
@@ -301,14 +304,19 @@ export default {
     import_file: async function (_new_value, _old_value) {
       if (this.import_file != null) {
         console.log('Importing file');
+        this.import_error = null;
+        this.import_success = false;
         try {
           await this.importBuckets(this.import_file);
           console.log('Import successful');
-          this.import_error = null;
+          this.import_success = true;
         } catch (err) {
-          console.log('Import failed');
-          // TODO: Make aw-server report error message so it can be shown in the web-ui
-          this.import_error = 'Import failed, see aw-server logs for more info';
+          console.log('Import failed', err);
+          if (err.response && err.response.data && err.response.data.message) {
+            this.import_error = err.response.data.message;
+          } else {
+            this.import_error = 'Import failed, see aw-server logs for more info';
+          }
         }
         // We need to reload buckets even if we fail because imports can be partial
         // (first bucket succeeds, second fails for example when importing multiple)


### PR DESCRIPTION
## Summary

Bucket import in the web UI always showed the generic message
`Import failed, see aw-server logs for more info` on any failure, even
though aw-server-rust has returned the actual error in the JSON
response body (`{"message": "..."}`) since `HttpErrorJson` was
introduced — the code just never read it (there's a `// TODO: Make
aw-server report error message so it can be shown in the web-ui` left
in `Buckets.vue`, but the server side of that TODO was already done).

- Read `err.response.data.message` when present and show it, falling
  back to the generic message otherwise. Same pattern already used in
  `Search.vue`, `QueryExplorer.vue`, `Graph.vue`, `Report.vue`,
  `Alerts.vue`, and `ErrorBoundary.vue`.
- Also show a success alert ("Import completed successfully!") after a
  successful import — previously nothing was displayed on success at
  all, which was part of the original feature request too.

Fixes #394

## Test plan

- [x] `npx vue-cli-service lint` on the changed file — no errors
- [x] `npm run build` — full production build completes with no errors
- [ ] Manual click-through (import a valid file, an invalid file, and
      re-import an existing bucket) — not run here; happy to do so if a
      maintainer wants a screenshot/GIF before merge