### PR TITLE
fix(summary): outline dark-mode summary labels

### DIFF
--- a/static/dark.css
+++ b/static/dark.css
@@ -239,6 +239,13 @@ svg text {
   text-shadow: #000 0.5px 0.5px 0.5px;
 }
 
+svg.appsummary text {
+  paint-order: stroke fill;
+  stroke: #000;
+  stroke-linejoin: round;
+  stroke-width: 2px;
+}
+
 /* Timespiral labels are drawn via D3 .style('fill', '#888'), which loses
    to the generic svg text rule above via !important — but the inner
    textPath elements (date rings) inherit a dim parent and need their own


### PR DESCRIPTION
## Problem

In dark mode, `dark.css` applies `svg text { fill: #fff !important }` globally. The summary visualization renders app-name and duration labels over category-colored bars. On light-colored bars, white text can be hard to read.

Reported in ActivityWatch/aw-server-rust#621.

## Fix

Add a dark outline scoped to `svg.appsummary text` in `static/dark.css` using SVG stroke properties:

- Keeps label fill consistent in dark mode instead of alternating text colors by bar luminosity
- Makes white labels readable on light category bars
- Still works when labels overflow outside short bars, because the outline travels with the text
- Leaves the TypeScript summary rendering logic unchanged

## Testing

- `npm run lint -- --no-fix` — passes, with existing no-shadow warnings in `vite.config.js` and `vue.config.js`
- `npm run build` — passes, with existing asset-size warnings and dependency deprecation warnings
