### PR TITLE
fix(i18n): use Intl.DateTimeFormat for locale-aware date/time display

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -112,3 +112,25 @@ export function get_short_month_labels(locale?: string | string[]) {
     new Intl.DateTimeFormat(locale, { month: 'short' }).format(new Date(2020, month, 1, 12))
   );
 }
+
+// Format a date as locale-aware short date (e.g. "Jun 15" in en-US, "15 jun" in sv-SE)
+export function format_date_short(date: Date | string, locale?: string | string[]) {
+  const d = date instanceof Date ? date : new Date(date);
+  return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(d);
+}
+
+// Format a date with weekday prefix (e.g. "Mon, Jun 15" in en-US, "mån 15 jun" in sv-SE)
+export function format_date_with_weekday(date: Date | string, locale?: string | string[]) {
+  const d = date instanceof Date ? date : new Date(date);
+  return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric' }).format(d);
+}
+
+// Format a time-of-day string locale-aware (e.g. "14:30:05" or "2:30:05 PM" per browser locale)
+export function format_time_of_day(date: Date | string, locale?: string | string[]) {
+  const d = date instanceof Date ? date : new Date(date);
+  return new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(d);
+}

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -122,7 +122,11 @@ export function format_date_short(date: Date | string, locale?: string | string[
 // Format a date with weekday prefix (e.g. "Mon, Jun 15" in en-US, "mån 15 jun" in sv-SE)
 export function format_date_with_weekday(date: Date | string, locale?: string | string[]) {
   const d = date instanceof Date ? date : new Date(date);
-  return new Intl.DateTimeFormat(locale, { weekday: 'short', month: 'short', day: 'numeric' }).format(d);
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }).format(d);
 }
 
 // Format a time-of-day string locale-aware (e.g. "14:30:05" or "2:30:05 PM" per browser locale)

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -133,7 +133,7 @@ export function format_date_with_weekday(date: Date | string, locale?: string | 
 export function format_time_of_day(date: Date | string, locale?: string | string[]) {
   const d = date instanceof Date ? date : new Date(date);
   return new Intl.DateTimeFormat(locale, {
-    hour: 'numeric',
+    hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
   }).format(d);

--- a/src/views/Trends.vue
+++ b/src/views/Trends.vue
@@ -89,7 +89,7 @@ div
 
 <script lang="ts">
 import moment from 'moment';
-import { get_today_with_offset } from '~/util/time';
+import { get_today_with_offset, format_date_short, format_date_with_weekday } from '~/util/time';
 import { buildBarchartDataset } from '~/util/datasets';
 import { canonicalEvents } from '~/queries';
 import { getClient } from '~/util/awclient';
@@ -161,14 +161,14 @@ export default {
     },
 
     currentRangeLabel(): string {
-      const start = this.currentStart.format('MMM D');
-      const end = moment(this.today).format('MMM D');
+      const start = format_date_short(this.currentStart.toDate());
+      const end = format_date_short(moment(this.today).toDate());
       return `${start} – ${end}`;
     },
 
     previousRangeLabel(): string {
-      const start = this.currentStart.clone().subtract(this.periodDays, 'days').format('MMM D');
-      const end = moment(this.today).subtract(this.periodDays, 'days').format('MMM D');
+      const start = format_date_short(this.currentStart.clone().subtract(this.periodDays, 'days').toDate());
+      const end = format_date_short(moment(this.today).subtract(this.periodDays, 'days').toDate());
       return `${start} – ${end}`;
     },
 
@@ -210,7 +210,7 @@ export default {
         const total = evts.reduce((a, e) => a + (e.duration || 0), 0);
         if (!best || total > best.duration) {
           const start = period.split('/')[0];
-          best = { label: moment(start).format('ddd, MMM D'), duration: total };
+          best = { label: format_date_with_weekday(new Date(start)), duration: total };
         }
       }
       return best && best.duration > 0 ? best : null;

--- a/src/views/Trends.vue
+++ b/src/views/Trends.vue
@@ -167,7 +167,9 @@ export default {
     },
 
     previousRangeLabel(): string {
-      const start = format_date_short(this.currentStart.clone().subtract(this.periodDays, 'days').toDate());
+      const start = format_date_short(
+        this.currentStart.clone().subtract(this.periodDays, 'days').toDate()
+      );
       const end = format_date_short(moment(this.today).subtract(this.periodDays, 'days').toDate());
       return `${start} – ${end}`;
     },

--- a/src/visualizations/timeline.ts
+++ b/src/visualizations/timeline.ts
@@ -8,7 +8,7 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import { getColorFromString } from '../util/color';
-import { seconds_to_duration } from '../util/time';
+import { seconds_to_duration, format_time_of_day } from '../util/time';
 import { IEvent } from '../util/interfaces';
 
 function show_info(container: HTMLElement, elem_id: string): void {
@@ -148,7 +148,7 @@ function update(
     _.each(e.data.subevents, function (t: IEvent) {
       const inforow = infolist.append('tr');
       // Clocktime
-      const clocktime = moment(t.timestamp).format('HH:mm:ss');
+      const clocktime = format_time_of_day(new Date(t.timestamp));
       inforow.append('td').text(clocktime);
       // Duration
       const duration = seconds_to_duration(t.duration);


### PR DESCRIPTION
## Summary

Fixes inconsistent date/time display that hardcoded English (moment format strings) instead of respecting the browser's locale. Reported in ActivityWatch/aw-server-rust#602.

**Changed files:**
- `src/util/time.ts` — adds three new locale-aware helpers using `Intl.DateTimeFormat`
- `src/views/Trends.vue` — range labels ("Jun 15 – Jul 2") and busiest-day label ("Mon, Jun 15") now use the browser locale
- `src/visualizations/timeline.ts` — event clocktime popup now respects locale time format

**New helpers in `time.ts`:**
- `format_date_short(date, locale?)` — replaces `moment.format('MMM D')`, produces e.g. "15 jun" in sv-SE
- `format_date_with_weekday(date, locale?)` — replaces `moment.format('ddd, MMM D')`, produces e.g. "mån 15 jun" in sv-SE
- `format_time_of_day(date, locale?)` — replaces `moment.format('HH:mm:ss')`, produces 12h or 24h per locale

**Out of scope (for follow-ups):**
- Clock face labels in Timespiral/sunburst visualizations (decorative, lower priority)
- `periodReadable()` week labels in timeperiod.ts

The existing `format_weekday_short`, `format_day_of_month`, and `get_short_month_labels` in `time.ts` already used `Intl.DateTimeFormat` — this PR extends that pattern to the remaining display-facing call sites.

## Test plan
- [ ] Build passes: `npm ci && make build`
- [ ] Lint passes: `make lint`
- [ ] Visual check: Trends view date range labels render in correct locale
- [ ] Visual check: Timeline event popup shows locale-appropriate time format