### PR TITLE
feat(i18n): add vue-i18n infrastructure with Simplified Chinese locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "vue-color": "^2.8.1",
         "vue-d3-sunburst": "git+https://github.com/ErikBjare/Vue.D3.sunburst.git#patch-1",
         "vue-datetime": "^1.0.0-beta.13",
+        "vue-i18n": "^8.28.2",
         "vuedraggable": "^2.24.3",
         "weekstart": "^1.0.1",
         "xss": "^1.0.14"
@@ -23561,6 +23562,13 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-i18n": {
+      "version": "8.28.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.28.2.tgz",
+      "integrity": "sha512-C5GZjs1tYlAqjwymaaCPDjCyGo10ajUphiwA922jKt9n7KPpqR7oM1PCwYzhB/E7+nT3wfdG3oRre5raIT1rKA==",
+      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
       "license": "MIT"
     },
     "node_modules/vue-loader": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vue-color": "^2.8.1",
     "vue-d3-sunburst": "git+https://github.com/ErikBjare/Vue.D3.sunburst.git#patch-1",
     "vue-datetime": "^1.0.0-beta.13",
+    "vue-i18n": "^8.28.2",
     "vuedraggable": "^2.24.3",
     "weekstart": "^1.0.1",
     "xss": "^1.0.14"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -15,21 +15,21 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
         b-nav-item(v-if="activityViews && activityViews.length === 1", v-for="view in activityViews", :key="view.name", :to="view.pathUrl")
           div.px-2.px-lg-1
             icon(name="calendar-day")
-            | Activity
+            | {{ $t('nav.activity') }}
 
         // If multiple (or no) activity views are available
         b-nav-item-dropdown(v-if="!activityViews || activityViews.length !== 1")
           template(slot="button-content")
             div.d-inline.px-2.px-lg-1
               icon(name="calendar-day")
-              | Activity
+              | {{ $t('nav.activity') }}
           b-dropdown-item(v-if="activityViews === null", disabled)
-            span.text-muted Loading...
+            span.text-muted {{ $t('nav.loading') }}
             br
           b-dropdown-item(v-else-if="activityViews && activityViews.length <= 0", disabled)
-            | No activity reports available
+            | {{ $t('nav.noActivityReports') }}
             br
-            small Make sure you have both an AFK and window watcher running
+            small {{ $t('nav.noActivityReportsHint') }}
           b-dropdown-item(v-for="view in activityViews", :key="view.name", :to="view.pathUrl")
             icon(:name="view.icon")
             | {{ view.name }}
@@ -37,12 +37,12 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
         b-nav-item(to="/timeline" style="font-color: #000;")
           div.px-2.px-lg-1
             icon(name="stream")
-            | Timeline
+            | {{ $t('nav.timeline') }}
 
         b-nav-item(to="/stopwatch")
           div.px-2.px-lg-1
             icon(name="stopwatch")
-            | Stopwatch
+            | {{ $t('nav.stopwatch') }}
 
       // Brand on large screens (centered)
       b-navbar-nav.abs-center.d-none.d-lg-block
@@ -55,41 +55,41 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
           template(slot="button-content")
             div.d-inline.px-2.px-lg-1
               icon(name="tools")
-              | Tools
+              | {{ $t('nav.tools') }}
           b-dropdown-item(to="/search")
             icon(name="search")
-            | Search
+            | {{ $t('nav.search') }}
           b-dropdown-item(to="/work-report")
             icon(name="briefcase")
-            | Work Report
+            | {{ $t('nav.workReport') }}
           b-dropdown-item(to="/trends" v-if="devmode")
             icon(name="chart-line")
-            | Trends
+            | {{ $t('nav.trends') }}
           b-dropdown-item(to="/report" v-if="devmode")
             icon(name="chart-pie")
-            | Report
+            | {{ $t('nav.report') }}
           b-dropdown-item(to="/alerts" v-if="devmode")
             icon(name="flag-checkered")
-            | Alerts
+            | {{ $t('nav.alerts') }}
           b-dropdown-item(to="/timespiral" v-if="devmode")
             icon(name="history")
-            | Timespiral
+            | {{ $t('nav.timespiral') }}
           b-dropdown-item(to="/query")
             icon(name="code")
-            | Query
+            | {{ $t('nav.query') }}
           b-dropdown-item(to="/graph" v-if="devmode")
             // TODO: use circle-nodes instead in the future
             icon(name="project-diagram")
-            | Graph
+            | {{ $t('nav.graph') }}
 
         b-nav-item(to="/buckets")
           div.px-2.px-lg-1
             icon(name="database")
-            | Raw Data
+            | {{ $t('nav.rawData') }}
         b-nav-item(to="/settings")
           div.px-2.px-lg-1
             icon(name="cog")
-            | Settings
+            | {{ $t('nav.settings') }}
 </template>
 
 <style lang="scss" scoped>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,25 @@ Vue.use(VueI18n);
 
 const LOCALE_KEY = 'aw-locale';
 
-const savedLocale = localStorage.getItem(LOCALE_KEY) || 'en';
+export const SUPPORTED_LOCALES = [
+  { code: 'en', label: 'English' },
+  { code: 'zh-CN', label: '中文（简体）' },
+];
+
+function isSupportedLocale(locale) {
+  return SUPPORTED_LOCALES.some(l => l.code === locale);
+}
+
+function readStoredLocale() {
+  try {
+    const locale = localStorage.getItem(LOCALE_KEY);
+    return isSupportedLocale(locale) ? locale : 'en';
+  } catch {
+    return 'en';
+  }
+}
+
+const savedLocale = readStoredLocale();
 
 export const i18n = new VueI18n({
   locale: savedLocale,
@@ -19,11 +37,15 @@ export const i18n = new VueI18n({
 });
 
 export function setLocale(locale) {
-  i18n.locale = locale;
-  localStorage.setItem(LOCALE_KEY, locale);
-}
+  if (!isSupportedLocale(locale)) {
+    console.warn(`[i18n] Unsupported locale: ${locale}`);
+    return;
+  }
 
-export const SUPPORTED_LOCALES = [
-  { code: 'en', label: 'English' },
-  { code: 'zh-CN', label: '中文（简体）' },
-];
+  i18n.locale = locale;
+  try {
+    localStorage.setItem(LOCALE_KEY, locale);
+  } catch {
+    // Storage can be blocked in private browsing or hardened browser profiles.
+  }
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,29 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+import en from './locales/en.json';
+import zhCN from './locales/zh-CN.json';
+
+Vue.use(VueI18n);
+
+const LOCALE_KEY = 'aw-locale';
+
+const savedLocale = localStorage.getItem(LOCALE_KEY) || 'en';
+
+export const i18n = new VueI18n({
+  locale: savedLocale,
+  fallbackLocale: 'en',
+  messages: {
+    en,
+    'zh-CN': zhCN,
+  },
+});
+
+export function setLocale(locale) {
+  i18n.locale = locale;
+  localStorage.setItem(LOCALE_KEY, locale);
+}
+
+export const SUPPORTED_LOCALES = [
+  { code: 'en', label: 'English' },
+  { code: 'zh-CN', label: '中文（简体）' },
+];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,11 @@
     "client": "Client:",
     "duration": "Duration:",
     "afk": "AFK:",
-    "all": "All"
+    "all": "All",
+    "filterAFK": "AFK filtered",
+    "filterMerged": "merged by app",
+    "filterNone": "none",
+    "filterCategories": "{count} category | {count} categories"
   },
   "buckets": {
     "title": "Buckets",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,10 @@
     "filterAFK": "AFK filtered",
     "filterMerged": "merged by app",
     "filterNone": "none",
-    "filterCategories": "{count} category | {count} categories"
+    "filterCategories": "{count} category | {count} categories",
+    "swimlaneNone": "None",
+    "swimlaneCategory": "Group by category",
+    "swimlaneBucketType": "Group by bucket type"
   },
   "buckets": {
     "title": "Buckets",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,66 @@
+{
+  "nav": {
+    "activity": "Activity",
+    "timeline": "Timeline",
+    "stopwatch": "Stopwatch",
+    "tools": "Tools",
+    "search": "Search",
+    "workReport": "Work Report",
+    "trends": "Trends",
+    "report": "Report",
+    "alerts": "Alerts",
+    "timespiral": "Timespiral",
+    "query": "Query",
+    "graph": "Graph",
+    "rawData": "Raw Data",
+    "settings": "Settings",
+    "noActivityReports": "No activity reports available",
+    "noActivityReportsHint": "Make sure you have both an AFK and window watcher running",
+    "loading": "Loading..."
+  },
+  "home": {
+    "title": "Welcome to ActivityWatch",
+    "survey": "Fill out our user survey",
+    "voteFeatures": "vote on features on the forum",
+    "spreadWord": "Spread the word",
+    "support": "Support us!"
+  },
+  "timeline": {
+    "title": "Timeline",
+    "filters": "Filters",
+    "host": "Host:",
+    "client": "Client:",
+    "duration": "Duration:",
+    "afk": "AFK:",
+    "all": "All"
+  },
+  "buckets": {
+    "title": "Buckets",
+    "docsHint": "Are you looking to collect more data? Check out {link} for more watchers.",
+    "docsLinkText": "the docs",
+    "lastUpdated": "Last updated",
+    "noEvents": "No events recorded yet",
+    "thisDevice": "this device"
+  },
+  "settings": {
+    "title": "Settings",
+    "groups": {
+      "general": "General",
+      "generalHelp": "Defaults that shape how time periods, the timeline, and landing page behave.",
+      "appearance": "Appearance",
+      "appearanceHelp": "Theme and visualization colors.",
+      "categorization": "Categorization",
+      "categorizationHelp": "Rules that classify events into categories, plus AFK/active-pattern overrides.",
+      "privacy": "Privacy",
+      "privacyHelp": "Filters that drop or redact sensitive event data before it is stored.",
+      "developer": "Developer",
+      "language": "Language",
+      "languageHelp": "Choose the display language for ActivityWatch."
+    }
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "zh-CN": "中文（简体）"
+  }
+}

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -36,7 +36,10 @@
     "filterAFK": "AFK 过滤",
     "filterMerged": "按应用合并",
     "filterNone": "无",
-    "filterCategories": "{count} 个分类"
+    "filterCategories": "{count} 个分类",
+    "swimlaneNone": "无",
+    "swimlaneCategory": "按分类分组",
+    "swimlaneBucketType": "按数据桶类型分组"
   },
   "buckets": {
     "title": "数据桶",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -32,7 +32,11 @@
     "client": "客户端：",
     "duration": "持续时间：",
     "afk": "离开状态：",
-    "all": "全部"
+    "all": "全部",
+    "filterAFK": "AFK 过滤",
+    "filterMerged": "按应用合并",
+    "filterNone": "无",
+    "filterCategories": "{count} 个分类"
   },
   "buckets": {
     "title": "数据桶",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,0 +1,66 @@
+{
+  "nav": {
+    "activity": "活动",
+    "timeline": "时间线",
+    "stopwatch": "秒表",
+    "tools": "工具",
+    "search": "搜索",
+    "workReport": "工作报告",
+    "trends": "趋势",
+    "report": "报告",
+    "alerts": "提醒",
+    "timespiral": "时间螺旋",
+    "query": "查询",
+    "graph": "图表",
+    "rawData": "原始数据",
+    "settings": "设置",
+    "noActivityReports": "暂无活动报告",
+    "noActivityReportsHint": "请确保 AFK 监控器和窗口监控器均已运行",
+    "loading": "加载中..."
+  },
+  "home": {
+    "title": "欢迎使用 ActivityWatch",
+    "survey": "填写用户调查",
+    "voteFeatures": "在论坛中为功能投票",
+    "spreadWord": "传播",
+    "support": "支持我们！"
+  },
+  "timeline": {
+    "title": "时间线",
+    "filters": "筛选",
+    "host": "主机：",
+    "client": "客户端：",
+    "duration": "持续时间：",
+    "afk": "离开状态：",
+    "all": "全部"
+  },
+  "buckets": {
+    "title": "数据桶",
+    "docsHint": "想收集更多数据？请查阅 {link} 获取更多监控器。",
+    "docsLinkText": "文档",
+    "lastUpdated": "最后更新",
+    "noEvents": "暂无事件记录",
+    "thisDevice": "此设备"
+  },
+  "settings": {
+    "title": "设置",
+    "groups": {
+      "general": "通用",
+      "generalHelp": "影响时间段、时间线和落地页行为的默认设置。",
+      "appearance": "外观",
+      "appearanceHelp": "主题与可视化颜色。",
+      "categorization": "分类",
+      "categorizationHelp": "将事件分类的规则，以及 AFK/活跃模式覆盖设置。",
+      "privacy": "隐私",
+      "privacyHelp": "在存储前过滤或遮盖敏感事件数据的过滤器。",
+      "developer": "开发者",
+      "language": "语言",
+      "languageHelp": "选择 ActivityWatch 的界面语言。"
+    }
+  },
+  "language": {
+    "label": "语言",
+    "en": "English",
+    "zh-CN": "中文（简体）"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,9 @@ Vue.prototype.$isAndroid = process.env.VUE_APP_ON_ANDROID;
 import { createClient, getClient, configureClient } from './util/awclient';
 createClient();
 
+// Setup i18n
+import { i18n } from './i18n';
+
 // Setup Vue app
 import App from './App.vue';
 new Vue({
@@ -88,6 +91,7 @@ new Vue({
   router: router,
   render: h => h(App),
   pinia,
+  i18n,
 });
 
 // Set the $aw global

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  h3 Buckets
+  h3 {{ $t('buckets.title') }}
 
   b-alert(show)
     | Are you looking to collect more data? Check out #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") the docs] for more watchers.
@@ -17,17 +17,17 @@ div
         icon.mr-2.text-secondary(v-else, name="desktop" scale="1.2")
         div
           span.font-weight-bold {{ device.hostname }}
-          b-badge.ml-2(v-if="serverStore.info.hostname == device.hostname" variant="info") this device
+          b-badge.ml-2(v-if="serverStore.info.hostname == device.hostname" variant="info") {{ $t('buckets.thisDevice') }}
           div.small.text-muted(v-if="device.hostname !== device.device_id")
             | ID: {{ device.id }}
           div.small(v-if="deviceHasEvents(device)")
-            span.text-muted Last updated&nbsp;
+            span.text-muted {{ $t('buckets.lastUpdated') }}&nbsp;
             time(:class="{'text-success': isRecent(device.last_updated)}",
                  :datetime="device.last_updated",
                  :title="device.last_updated")
               | {{ device.last_updated | friendlytime }}
           div.small.text-muted(v-else)
-            | No events recorded yet
+            | {{ $t('buckets.noEvents') }}
       b-dropdown.kebab-dropdown(
         size="sm",
         variant="outline-secondary",

--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -3,7 +3,8 @@ div
   h3 {{ $t('buckets.title') }}
 
   b-alert(show)
-    | Are you looking to collect more data? Check out #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") the docs] for more watchers.
+    i18n(path="buckets.docsHint" tag="span")
+      a(place="link" href="https://docs.activitywatch.net/en/latest/watchers.html") {{ $t('buckets.docsLinkText') }}
 
   // By device
   b-card.bucket-card.mb-3(

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@ div
   b-alert(v-if="$isAndroid" show)
     | #[b Note:] ActivityWatch on Android is in a very early stage of development. There will be bugs, but we hope you bear with us as we refine things and get it on par with the desktop version of ActivityWatch (which you should try!).
 
-  h3 Welcome to ActivityWatch
+  h3 {{ $t('home.title') }}
   p
     | We've come a long way#[span(v-if="$isAndroid") (especially on Android!)] but we still need users (like you!) to provide feedback and help us turn ActivityWatch into a successful project.
     | We'd love to hear any ideas you have for improvements.

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,16 +11,16 @@ div
     | If you are a developer, we hope you can contribute by writing a watcher, visualization, or something else, and share it with us on the forum!
   p.mb-0 Thank you for using ActivityWatch!
   p
-    a(href="https://forms.gle/q2N9K5RoERBV8kqPA") Fill out our user survey
+    a(href="https://forms.gle/q2N9K5RoERBV8kqPA") {{ $t('home.survey') }}
     | &nbsp;or&nbsp;
-    a(href="https://forum.activitywatch.net/c/features") vote on features on the forum
+    a(href="https://forum.activitywatch.net/c/features") {{ $t('home.voteFeatures') }}
     | &nbsp;to help shape what comes next.
 
   hr
 
   div.row
     div.col-md-6
-      h4 Spread the word
+      h4 {{ $t('home.spreadWord') }}
       p
         | Nothing is as motivating as getting ActivityWatch into the hands of users.
         | By sharing it you get us to make ActivityWatch even better!
@@ -31,7 +31,7 @@ div
         li Star us on #[a(href="https://github.com/ActivityWatch/activitywatch") GitHub]
 
     div.col-md-6
-      h4 Support us!
+      h4 {{ $t('home.support') }}
       p
         | Do you like ActivityWatch? Has it helped you? Help us help you by donating!
         | You can donate to us via:

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -138,11 +138,6 @@ export default {
       filter_merge_similar: false,
       filter_categories: [],
       swimlane: null,
-      swimlaneOptions: [
-        { value: null, text: 'None' },
-        { value: 'category', text: 'Group by category' },
-        { value: 'bucketType', text: 'Group by bucket type' },
-      ],
       updateTimelineWindow: true,
     };
   },
@@ -159,6 +154,13 @@ export default {
     category_options() {
       const categoryStore = useCategoryStore();
       return categoryStore.allCategoriesSelect;
+    },
+    swimlaneOptions() {
+      return [
+        { value: null, text: this.$t('timeline.swimlaneNone') },
+        { value: 'category', text: this.$t('timeline.swimlaneCategory') },
+        { value: 'bucketType', text: this.$t('timeline.swimlaneBucketType') },
+      ];
     },
     filter_summary() {
       const desc = [];

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  h3 Timeline
+  h3 {{ $t('timeline.title') }}
 
   input-timeinterval(v-model="daterange", :defaultDuration="timeintervalDefaultDuration", :maxDuration="maxDuration").mb-3
 
@@ -10,29 +10,29 @@ div
     details.timeline-filters.mr-2(ref="filtersDetails")
       summary.timeline-chip.timeline-chip--clickable
         icon.mr-1(name="filter")
-        b Filters: {{ filter_summary }}
+        b {{ $t('timeline.filters') }}: {{ filter_summary }}
       div.timeline-filters-panel.shadow-sm
         table
           tr
             th.pt-2.pr-3
-              label(for="timeline-filter-host") Host:
+              label(for="timeline-filter-host") {{ $t('timeline.host') }}
             td
               select#timeline-filter-host.form-control.form-control-sm(v-model="filter_hostname")
-                option(:value='null') All
+                option(:value='null') {{ $t('timeline.all') }}
                 option(v-for="host in hosts", :value="host") {{ host }}
           tr
             th.pt-2.pr-3
-              label(for="timeline-filter-client") Client:
+              label(for="timeline-filter-client") {{ $t('timeline.client') }}
             td
               select#timeline-filter-client.form-control.form-control-sm(v-model="filter_client")
-                option(:value='null') All
+                option(:value='null') {{ $t('timeline.all') }}
                 option(v-for="client in clients", :value="client") {{ client }}
           tr
             th.pt-2.pr-3
-              label(for="timeline-filter-duration") Duration:
+              label(for="timeline-filter-duration") {{ $t('timeline.duration') }}
             td
               select#timeline-filter-duration.form-control.form-control-sm(v-model="filter_duration")
-                option(:value='null') All
+                option(:value='null') {{ $t('timeline.all') }}
                 option(:value='2') 2+ secs
                 option(:value='5') 5+ secs
                 option(:value='10') 10+ secs
@@ -46,7 +46,7 @@ div
                 option(:value='2 * 60 * 60') 2+ hrs
           tr
             th.pt-2.pr-3
-              label AFK:
+              label {{ $t('timeline.afk') }}
             td
               b-form-checkbox(v-model="filter_afk" size="sm" switch)
                 | Filter AFK

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -172,23 +172,23 @@ export default {
         desc.push(seconds_to_duration(this.filter_duration));
       }
       if (this.filter_afk) {
-        desc.push('AFK filtered');
+        desc.push(this.$t('timeline.filterAFK'));
       }
       if (this.filter_merge_similar) {
-        desc.push('merged by app');
+        desc.push(this.$t('timeline.filterMerged'));
       }
       if (this.filter_categories.length > 0) {
         desc.push(
-          this.filter_categories.length +
-            ' categor' +
-            (this.filter_categories.length === 1 ? 'y' : 'ies')
+          this.$tc('timeline.filterCategories', this.filter_categories.length, {
+            count: this.filter_categories.length,
+          })
         );
       }
 
       if (desc.length > 0) {
         return desc.join(', ');
       }
-      return 'none';
+      return this.$t('timeline.filterNone');
     },
   },
   watch: {

--- a/src/views/settings/LanguageSettings.vue
+++ b/src/views/settings/LanguageSettings.vue
@@ -1,27 +1,25 @@
 <template lang="pug">
 div.language-settings
   b-form-group(:label="$t('language.label')")
-    b-form-select(v-model="selectedLocale" :options="localeOptions" @change="onLocaleChange")
+    b-form-select(v-model="selectedLocale" :options="localeOptions")
 </template>
 
 <script lang="ts">
-import { i18n, setLocale, SUPPORTED_LOCALES } from '~/i18n';
+import { setLocale, SUPPORTED_LOCALES } from '~/i18n';
 
 export default {
   name: 'LanguageSettings',
-  data() {
-    return {
-      selectedLocale: i18n.locale,
-    };
-  },
   computed: {
+    selectedLocale: {
+      get() {
+        return this.$i18n.locale;
+      },
+      set(locale: string) {
+        setLocale(locale);
+      },
+    },
     localeOptions() {
       return SUPPORTED_LOCALES.map(l => ({ value: l.code, text: l.label }));
-    },
-  },
-  methods: {
-    onLocaleChange(locale: string) {
-      setLocale(locale);
     },
   },
 };

--- a/src/views/settings/LanguageSettings.vue
+++ b/src/views/settings/LanguageSettings.vue
@@ -1,0 +1,28 @@
+<template lang="pug">
+div.language-settings
+  b-form-group(:label="$t('language.label')")
+    b-form-select(v-model="selectedLocale" :options="localeOptions" @change="onLocaleChange")
+</template>
+
+<script lang="ts">
+import { i18n, setLocale, SUPPORTED_LOCALES } from '~/i18n';
+
+export default {
+  name: 'LanguageSettings',
+  data() {
+    return {
+      selectedLocale: i18n.locale,
+    };
+  },
+  computed: {
+    localeOptions() {
+      return SUPPORTED_LOCALES.map(l => ({ value: l.code, text: l.label }));
+    },
+  },
+  methods: {
+    onLocaleChange(locale: string) {
+      setLocale(locale);
+    },
+  },
+};
+</script>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  h3.mb-3 Settings
+  h3.mb-3 {{ $t('settings.title') }}
 
   div.settings-layout
     nav.settings-nav
@@ -33,6 +33,7 @@ import UncategorizedHintSettings from '~/views/settings/UncategorizedHintSetting
 import CategorizationSettings from '~/views/settings/CategorizationSettings.vue';
 import LandingPageSettings from '~/views/settings/LandingPageSettings.vue';
 import DeveloperSettings from '~/views/settings/DeveloperSettings.vue';
+import LanguageSettings from '~/views/settings/LanguageSettings.vue';
 import Theme from '~/views/settings/Theme.vue';
 import ColorSettings from '~/views/settings/ColorSettings.vue';
 import ActivePatternSettings from '~/views/settings/ActivePatternSettings.vue';
@@ -54,6 +55,7 @@ export default {
     UncategorizedHintSettings,
     CategorizationSettings,
     LandingPageSettings,
+    LanguageSettings,
     Theme,
     ColorSettings,
     DeveloperSettings,
@@ -85,8 +87,8 @@ export default {
     groups(): Group[] {
       const general: Group = {
         id: 'general',
-        label: 'General',
-        help: 'Defaults that shape how time periods, the timeline, and landing page behave.',
+        label: this.$t('settings.groups.general'),
+        help: this.$t('settings.groups.generalHelp'),
         components: [
           { name: 'DaystartSettings' },
           { name: 'TimelineDurationSettings' },
@@ -99,14 +101,14 @@ export default {
       };
       const appearance: Group = {
         id: 'appearance',
-        label: 'Appearance',
-        help: 'Theme and visualization colors.',
+        label: this.$t('settings.groups.appearance'),
+        help: this.$t('settings.groups.appearanceHelp'),
         components: [{ name: 'Theme' }, { name: 'ColorSettings' }],
       };
       const categorization: Group = {
         id: 'categorization',
-        label: 'Categorization',
-        help: 'Rules that classify events into categories, plus AFK/active-pattern overrides.',
+        label: this.$t('settings.groups.categorization'),
+        help: this.$t('settings.groups.categorizationHelp'),
         // CategorizationSettings (rules) is the primary content; the
         // ActivePatternSettings AFK override is an advanced edge-case
         // setting so it lives at the bottom of the group.
@@ -114,17 +116,23 @@ export default {
       };
       const privacy: Group = {
         id: 'privacy',
-        label: 'Privacy',
-        help: 'Filters that drop or redact sensitive event data before it is stored.',
+        label: this.$t('settings.groups.privacy'),
+        help: this.$t('settings.groups.privacyHelp'),
         components: [{ name: 'PrivacyFilterSettings' }],
       };
       const developer: Group = {
         id: 'developer',
-        label: 'Developer',
+        label: this.$t('settings.groups.developer'),
         components: [{ name: 'DeveloperSettings' }],
       };
+      const language: Group = {
+        id: 'language',
+        label: this.$t('settings.groups.language'),
+        help: this.$t('settings.groups.languageHelp'),
+        components: [{ name: 'LanguageSettings' }],
+      };
 
-      const groups: Group[] = [general, appearance, categorization, privacy, developer];
+      const groups: Group[] = [general, appearance, categorization, privacy, language, developer];
       return groups;
     },
   },

--- a/test/unit/i18n.test.js
+++ b/test/unit/i18n.test.js
@@ -1,0 +1,82 @@
+const originalLocalStorage = global.localStorage;
+
+function mockLocalStorage(methods) {
+  Object.defineProperty(global, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: jest.fn(() => null),
+      setItem: jest.fn(),
+      ...methods,
+    },
+  });
+}
+
+function loadI18n() {
+  jest.resetModules();
+  return require('../../src/i18n');
+}
+
+afterEach(() => {
+  Object.defineProperty(global, 'localStorage', {
+    configurable: true,
+    value: originalLocalStorage,
+  });
+  jest.restoreAllMocks();
+});
+
+test('defaults to English when stored locale cannot be read', () => {
+  mockLocalStorage({
+    getItem: jest.fn(() => {
+      throw new DOMException('Blocked storage', 'SecurityError');
+    }),
+  });
+
+  const { i18n } = loadI18n();
+
+  expect(i18n.locale).toBe('en');
+});
+
+test('ignores unsupported stored locales', () => {
+  mockLocalStorage({
+    getItem: jest.fn(() => 'not-a-locale'),
+  });
+
+  const { i18n } = loadI18n();
+
+  expect(i18n.locale).toBe('en');
+});
+
+test('persists supported locale changes', () => {
+  mockLocalStorage();
+
+  const { i18n, setLocale } = loadI18n();
+  setLocale('zh-CN');
+
+  expect(i18n.locale).toBe('zh-CN');
+  expect(localStorage.setItem).toHaveBeenCalledWith('aw-locale', 'zh-CN');
+});
+
+test('rejects unsupported locale changes', () => {
+  mockLocalStorage();
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  const { i18n, setLocale } = loadI18n();
+  setLocale('not-a-locale');
+
+  expect(i18n.locale).toBe('en');
+  expect(localStorage.setItem).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledWith('[i18n] Unsupported locale: not-a-locale');
+});
+
+test('changes locale even when storage cannot be written', () => {
+  mockLocalStorage({
+    setItem: jest.fn(() => {
+      throw new DOMException('Blocked storage', 'SecurityError');
+    }),
+  });
+
+  const { i18n, setLocale } = loadI18n();
+
+  expect(() => setLocale('zh-CN')).not.toThrow();
+  expect(i18n.locale).toBe('zh-CN');
+});


### PR DESCRIPTION
## Summary

Adds the i18n foundation to aw-webui and ships a Simplified Chinese (zh-CN) locale, addressing ActivityWatch/aw-webui#786.

**What's included:**

- **`vue-i18n@8`** installed (Vue 2 compatible)
- **`src/i18n.js`**: VueI18n instance, `setLocale()` helper, `SUPPORTED_LOCALES` list
- **`src/locales/en.json`** and **`src/locales/zh-CN.json`**: translations for nav, timeline, buckets, settings, and home
- **`src/main.js`**: i18n registered in the Vue root
- **`Header.vue`**: all nav labels migrated to `$t()` (Activity, Timeline, Stopwatch, Tools dropdown items, Raw Data, Settings, error states)
- **`Timeline.vue`**: page title + filter labels (Host, Client, Duration, AFK, All)
- **`Buckets.vue`**: page title, "last updated", "no events recorded yet", "this device" badge
- **`Home.vue`**: page title
- **`Settings.vue`**: page title + all group labels/help text via `$t()`
- **`LanguageSettings.vue`**: new Settings > Language panel with a dropdown that persists the selection to `localStorage` (key: `aw-locale`)

**Behavior:**
- Falls back to English for untranslated keys (Vue i18n fallback)
- Language preference persists across page reloads via `localStorage`
- English remains the default when no preference is stored

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Switch to zh-CN via Settings > Language — nav, timeline filters, and bucket list render in Chinese
- [ ] Switch back to English — UI reverts to English
- [ ] Page reload preserves the selected locale
- [ ] No broken English strings (all migrated keys covered in `en.json`)