### PR TITLE
fix: match Helium with chrome web watcher bucket

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -263,7 +263,8 @@ function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
 // The full set of historical app names these patterns replace is documented in the unit tests.
 // See: test/unit/queries.test.node.ts, https://github.com/ActivityWatch/aw-webui/issues/749
 export const browser_appname_regex: Record<string, string> = {
-  chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium)',
+  // Helium can use the Chrome Web Store extension, which emits aw-watcher-web-chrome buckets.
+  chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium|helium)',
   firefox: '(?i)(firefox|librewolf|waterfox|nightly)',
   opera: '(?i)(opera)',
   brave: '(?i)(brave)',

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -245,11 +245,21 @@ const browser_appnames: Record<string, string[]> = {
 };
 
 // Returns a list of (browserName, bucketId) pairs for found browser buckets
+function browserBucketMatches(bucketId: string, browserName: string): boolean {
+  return _.includes(bucketId, browserName);
+}
+
+function browserBucketExists(browserbuckets: string[], browserName: string): boolean {
+  return _.some(browserbuckets, bucket_id => browserBucketMatches(bucket_id, browserName));
+}
+
 function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
   const browsername_to_bucketid: [string, string | undefined][] = _.map(
     Object.keys(browser_appnames),
     browserName => {
-      const bucketId = _.find(browserbuckets, bucket_id => _.includes(bucket_id, browserName));
+      const bucketId = _.find(browserbuckets, bucket_id =>
+        browserBucketMatches(bucket_id, browserName)
+      );
       return [browserName, bucketId];
     }
   );
@@ -262,9 +272,11 @@ function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
 // Used with filter_keyvals_regex in addition to the exact names in browser_appnames.
 // The full set of historical app names these patterns replace is documented in the unit tests.
 // See: test/unit/queries.test.node.ts, https://github.com/ActivityWatch/aw-webui/issues/749
+const chrome_appname_regex = '(?i)^(google[-_ ]?chrome|chrome|chromium)';
+const chrome_appname_regex_with_helium = '(?i)^(google[-_ ]?chrome|chrome|chromium|helium)';
+
 export const browser_appname_regex: Record<string, string> = {
-  // Helium can use the Chrome Web Store extension, which emits aw-watcher-web-chrome buckets.
-  chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium|helium)',
+  chrome: chrome_appname_regex,
   firefox: '(?i)(firefox|librewolf|waterfox|nightly)',
   opera: '(?i)(opera)',
   brave: '(?i)(brave)',
@@ -278,6 +290,15 @@ export const browser_appname_regex: Record<string, string> = {
   helium: '(?i)(helium)',
 };
 
+function browserAppnameRegex(browserName: string, browserbuckets: string[]): string | undefined {
+  // Helium can use the Chrome Web Store extension, which emits aw-watcher-web-chrome buckets.
+  // Only match Helium there when no dedicated Helium bucket exists, to avoid double-counting.
+  if (browserName === 'chrome' && !browserBucketExists(browserbuckets, 'helium')) {
+    return chrome_appname_regex_with_helium;
+  }
+  return browser_appname_regex[browserName];
+}
+
 // Returns a list of active browser events (where the browser was the active window) from all browser buckets
 function browserEvents(params: DesktopQueryParams): string {
   let code = `
@@ -290,7 +311,7 @@ function browserEvents(params: DesktopQueryParams): string {
        window_${browserName} = filter_keyvals(events, "app", ${browser_appnames_str});`;
 
     // Add regex-based matching to cover case/spacing/versioning variants (e.g., Firefox.exe, firefox-esr-esr140)
-    const pattern = browser_appname_regex[browserName];
+    const pattern = browserAppnameRegex(browserName, params.bid_browsers);
     if (pattern) {
       code += `
        window_${browserName}_re = filter_keyvals_regex(events, "app", ${JSON.stringify(pattern)});

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -11,7 +11,7 @@
  *   Chrome:   'Google Chrome', 'Google-chrome', 'Chrome.exe', 'chrome.exe',
  *             'google-chrome-stable', 'Chromium', 'Chromium-browser', 'chromium-browser',
  *             'Chromium-browser-chromium', 'Chromium.exe', 'chromium.exe',
- *             'Google-chrome-beta', 'Google-chrome-unstable', 'Helium'
+ *             'Google-chrome-beta', 'Google-chrome-unstable'
  *             (Flatpak app IDs retained as exact: 'com.google.Chrome', 'com.google.ChromeDev',
  *              'org.chromium.Chromium')
  *
@@ -53,13 +53,25 @@
  *             (Flatpak app ID retained: 'one.ablaze.floorp')
  */
 
-import { browser_appname_regex } from '~/queries';
+import { browser_appname_regex, fullDesktopQuery } from '~/queries';
 
 // Convert ActivityWatch (?i) patterns to JS RegExp with i flag for testing.
 // AW server uses Python-style (?i) inline flag; JS uses RegExp 'i' flag instead.
 function toRegex(pattern: string): RegExp {
   const stripped = pattern.replace(/^\(\?i\)/, '');
   return new RegExp(stripped, 'i');
+}
+
+function browserQueryForBuckets(bid_browsers: string[]): string {
+  return fullDesktopQuery({
+    bid_window: 'aw-watcher-window_testhost',
+    bid_afk: 'aw-watcher-afk_testhost',
+    bid_browsers,
+    filter_afk: true,
+    categories: [],
+    filter_categories: [],
+    include_audible: false,
+  }).join('\n');
 }
 
 describe('browser_appname_regex', () => {
@@ -81,7 +93,6 @@ describe('browser_appname_regex', () => {
       'chromium.exe',
       'Google-chrome-beta',
       'Google-chrome-unstable',
-      'Helium',
     ];
     for (const name of knownNames) {
       expect(re.test(name)).toBe(true);
@@ -94,6 +105,29 @@ describe('browser_appname_regex', () => {
     expect(re.test('com.google.Chrome')).toBe(false);
     expect(re.test('Slack')).toBe(false);
     expect(re.test('Electron')).toBe(false);
+  });
+
+  test('chrome web watcher bucket matches Helium when there is no Helium bucket', () => {
+    const query = browserQueryForBuckets(['aw-watcher-web-chrome_testhost']);
+    expect(query).toContain(
+      'window_chrome_re = filter_keyvals_regex(events, "app", "(?i)^(google[-_ ]?chrome|chrome|chromium|helium)")'
+    );
+  });
+
+  test('chrome web watcher bucket does not match Helium when a Helium bucket exists', () => {
+    const query = browserQueryForBuckets([
+      'aw-watcher-web-chrome_testhost',
+      'aw-watcher-web-helium_testhost',
+    ]);
+    expect(query).toContain(
+      'window_chrome_re = filter_keyvals_regex(events, "app", "(?i)^(google[-_ ]?chrome|chrome|chromium)")'
+    );
+    expect(query).toContain(
+      'window_helium_re = filter_keyvals_regex(events, "app", "(?i)(helium)")'
+    );
+    expect(query).not.toContain(
+      'window_chrome_re = filter_keyvals_regex(events, "app", "(?i)^(google[-_ ]?chrome|chrome|chromium|helium)")'
+    );
   });
 
   test('firefox pattern matches all known Firefox/LibreWolf/Waterfox app names', () => {

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -11,7 +11,7 @@
  *   Chrome:   'Google Chrome', 'Google-chrome', 'Chrome.exe', 'chrome.exe',
  *             'google-chrome-stable', 'Chromium', 'Chromium-browser', 'chromium-browser',
  *             'Chromium-browser-chromium', 'Chromium.exe', 'chromium.exe',
- *             'Google-chrome-beta', 'Google-chrome-unstable'
+ *             'Google-chrome-beta', 'Google-chrome-unstable', 'Helium'
  *             (Flatpak app IDs retained as exact: 'com.google.Chrome', 'com.google.ChromeDev',
  *              'org.chromium.Chromium')
  *
@@ -81,6 +81,7 @@ describe('browser_appname_regex', () => {
       'chromium.exe',
       'Google-chrome-beta',
       'Google-chrome-unstable',
+      'Helium',
     ];
     for (const name of knownNames) {
       expect(re.test(name)).toBe(true);


### PR DESCRIPTION
## Summary

- Match `Helium` for Chrome web watcher buckets when no dedicated Helium bucket exists.
- Avoid matching `Helium` through the Chrome bucket when an `aw-watcher-web-helium_*` bucket is also present.
- Add regression tests for both bucket configurations.

## Why

Helium can install and run the Chrome Web Store ActivityWatch extension, which reports URL events into an `aw-watcher-web-chrome_*` bucket. In that setup, the active window app name is `Helium`, so the Chrome bucket filter would otherwise drop those browser events even though the data exists.

The PR now also guards the edge case where both a Chrome-extension bucket and a dedicated Helium bucket are present, so the same Helium browsing activity is not claimed by both browser paths.

## Test

```sh
npm test -- --selectProjects node --runTestsByPath test/unit/queries.test.node.ts
npx prettier --check src/queries.ts test/unit/queries.test.node.ts
```
