### PR TITLE
fix(categories): filter null/empty segments before saving class name

### DIFF
--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -145,20 +145,20 @@ export default {
       }
 
       // Save the category
-      // Guard against null/undefined segments (e.g. when parent is "None" and
-      // subname was never touched, or when a corrupted class was loaded).
+      // Guard against null/undefined/empty segments (e.g. when parent is "None"
+      // and subname was never touched, or when a corrupted class was loaded).
       // Without this, [].concat(null) or [null].concat(x) writes `null` into
       // classes[].name, which the query engine then tries to resolve as the
       // variable `null` and throws QueryInterpretException, breaking all
       // charts that call categorize(). See #1355.
-      const parent = Array.isArray(this.editing.parent) ? this.editing.parent : [];
-      const nameSegments = parent
-        .concat(this.editing.name)
-        .filter(s => s !== null && s !== undefined && s !== '');
-      if (nameSegments.length === 0) {
-        // Nothing valid to save (no parent, no name) — abort silently.
+      const isValid = s => s !== null && s !== undefined && s !== '';
+      const parent = Array.isArray(this.editing.parent) ? this.editing.parent.filter(isValid) : [];
+      // The leaf name must be valid on its own — do NOT let a blank name
+      // silently collapse a child into its parent's path.
+      if (!isValid(this.editing.name)) {
         return;
       }
+      const nameSegments = parent.concat(this.editing.name);
       const new_class = {
         id: this.editing.id,
         name: nameSegments,

--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -145,9 +145,23 @@ export default {
       }
 
       // Save the category
+      // Guard against null/undefined segments (e.g. when parent is "None" and
+      // subname was never touched, or when a corrupted class was loaded).
+      // Without this, [].concat(null) or [null].concat(x) writes `null` into
+      // classes[].name, which the query engine then tries to resolve as the
+      // variable `null` and throws QueryInterpretException, breaking all
+      // charts that call categorize(). See #1355.
+      const parent = Array.isArray(this.editing.parent) ? this.editing.parent : [];
+      const nameSegments = parent
+        .concat(this.editing.name)
+        .filter(s => s !== null && s !== undefined && s !== '');
+      if (nameSegments.length === 0) {
+        // Nothing valid to save (no parent, no name) — abort silently.
+        return;
+      }
       const new_class = {
         id: this.editing.id,
-        name: this.editing.parent.concat(this.editing.name),
+        name: nameSegments,
         rule: this.editing.rule.type !== 'none' ? this.editing.rule : { type: 'none' },
         data: {
           color: this.editing.inherit_color === true ? undefined : this.editing.color,


### PR DESCRIPTION
跟进 ActivityWatch/activitywatch#1355 — 现在还没人在做。

## 问题

Category Editor 保存分类时,如果 parent 选 "None" 且 name 字段没被 touch,`[].concat(this.editing.name)` 会产生 `[null]`。原因是 `this.editing.name` 初始化自 `cat.subname`,对新建/已损坏的 class 可能是 null/undefined。

一旦 `null` 被写进 `classes[].name`,后续会被序列化进 `categorize()` query,query 解释器把它当变量名去查:

```
QueryInterpretException: Tried to reference variable 'null' which is not defined
```

所有用 `categorize()` 的 chart 全部挂掉。

## 修复

`handleSubmit()` 里加三道保护:
- parent 不是数组就当空数组
- 过滤掉最终 name 里的 null / undefined / 空串
- 全部过滤完为空则 abort(既没 parent 也没 name,没啥可存)

不动 store 和 query 层,改动最小。

## 测试

`npm test` — 25/25 test suites 全过(121 tests)。
`npm run lint` — 0 errors(3 个 pre-existing warnings 与本 PR 无关)。

## 备注

issue 里提到后端 `aw_query.q2_categorize` 也可以做防御性 filter,那个应该单独一个 PR 到 aw-server-python(算 defense in depth)。这里先修根源,阻止前端再写坏数据。

user #s13mjl 已在 issue 里给出手动 workaround(改 settings.json 删 null),那部分对已有损坏数据仍然需要。