### PR TITLE
fix(buckets): show phone icon for Android devices in Raw Data view

### DIFF
--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -13,7 +13,8 @@ div
     div.d-flex.justify-content-between.align-items-start.mb-2
       div.d-flex.align-items-center
         icon.mr-2.text-muted(v-if="device.hostname === 'unknown'" name="question" scale="1.2")
-        icon.mr-2.text-secondary(v-else, name="desktop" scale="1.2")
+        icon.mr-2.text-secondary(v-else-if="bucketsStore.available(device.hostname).android" name="mobile" scale="1.2")
+        icon.mr-2.text-secondary(v-else name="desktop" scale="1.2")
         div
           span.font-weight-bold {{ device.hostname }}
           b-badge.ml-2(v-if="serverStore.info.hostname == device.hostname" variant="info") {{ $t('buckets.thisDevice') }}


### PR DESCRIPTION
## Problem

The `mobile` icon was imported in `Buckets.vue` but never used. All devices
in the Raw Data view showed a desktop icon, even Android phones.

## Fix

Add a `v-else-if` that uses `bucketsStore.available(device.hostname).android`
(same runtime detection introduced in Activity.vue by #903) to render the
`mobile` icon for Android devices, with `desktop` as the fallback.

The hostname column was already removed in #903 (grouped-by-device context
made it redundant). This PR covers the remaining Raw Data view gap.

## Behaviour

| Situation | Before | After |
|-----------|--------|-------|
| Android device in Raw Data view | Desktop icon | Phone icon ✓ |
| Desktop device in Raw Data view | Desktop icon ✓ | Desktop icon ✓ |
| Unknown device | Question icon ✓ | Question icon ✓ |

Requested by ErikBjare in ActivityWatch/aw-android#176.