### PR TITLE
fix(build): allow root git dependencies for npm >= 12 (fixes activitywatch#1356)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+; npm >= 12 defaults allow-git=none, which breaks the vue-d3-sunburst
+; git-hosted dependency in package.json. Allow git deps declared at the
+; project root (safer than "all", which also enables transitive git deps).
+; See https://github.com/ActivityWatch/activitywatch/issues/1356
+allow-git=root


### PR DESCRIPTION
Fixes ActivityWatch/activitywatch#1356.

npm 12 (released 2026-07-08) [flipped `allow-git` default from "all" to "none"](https://github.com/npm/cli/releases/tag/v12.0.0), so `npm ci` / `npm install` refuses to fetch the `vue-d3-sunburst` git dep and the build dies:

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "vue-d3-sunburst@git+ssh://git@github.com/ErikBjare/Vue.D3.sunburst.git#patch-1"
```

Fix: check in a repo `.npmrc` with `allow-git=root`. That re-enables git deps declared in this project's own `package.json` (i.e. the `vue-d3-sunburst` entry) while still blocking transitive git deps — strictly tighter than the pre-12 default of `all`.

No `.npmrc` existed before, and the setting doesn't affect older npm (they just ignore an unknown key). Verified locally with npm 12.0.1 on Node 22.

Longer-term the ideal fix is to drop the git dep (publish `vue-d3-sunburst` to npm, or vendor it), but that touches upstream fork policy — happy to look into that as a follow-up if you'd prefer.