### PR TITLE
Add subscribe CTA to the Home Support section

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -191,6 +191,9 @@ export default {
     spreadFollow: 'Folgen Sie uns und teilen Sie auf',
     spreadStar: 'Geben Sie uns einen Stern auf',
     supportTitle: 'Unterstützen Sie uns!',
+    subscribeIntro:
+      'The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime.',
+    subscribeCta: 'Support ActivityWatch →',
     support1: 'Gefällt Ihnen ActivityWatch? Helfen Sie uns, Ihnen zu helfen — spenden Sie über:',
     support2: 'Mehr Infos auf der',
     donationPage: 'Spendenseite der Website',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -190,6 +190,9 @@ export default {
     spreadFollow: 'Follow us and spread the word on',
     spreadStar: 'Star us on',
     supportTitle: 'Support us!',
+    subscribeIntro:
+      'The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime.',
+    subscribeCta: 'Support ActivityWatch →',
     support1:
       'Do you like ActivityWatch? Has it helped you? Help us help you by donating! You can donate to us via:',
     support2: 'For more info, please visit the',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -189,6 +189,9 @@ export default {
     spreadFollow: 'Следите и делитесь в',
     spreadStar: 'Поставьте звезду на',
     supportTitle: 'Поддержите нас!',
+    subscribeIntro:
+      'The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime.',
+    subscribeCta: 'Support ActivityWatch →',
     support1: 'Нравится ActivityWatch? Помогите нам помочь вам — пожертвование через:',
     support2: 'Подробнее — на',
     donationPage: 'странице пожертвований на сайте',

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -189,6 +189,9 @@ export default {
     spreadFollow: 'Слідкуйте та поширюйте в',
     spreadStar: 'Поставте зірку на',
     supportTitle: 'Підтримайте нас!',
+    subscribeIntro:
+      'The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime.',
+    subscribeCta: 'Support ActivityWatch →',
     support1: 'Подобається ActivityWatch? Допоможіть нам допомогти вам — пожертва через:',
     support2: 'Детальніше — на',
     donationPage: 'сторінці пожертв на сайті',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -185,6 +185,9 @@ export default {
     spreadFollow: '关注我们并传播：',
     spreadStar: '给我们加星：',
     supportTitle: '支持我们！',
+    subscribeIntro:
+      'The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime.',
+    subscribeCta: 'Support ActivityWatch →',
     support1:
       '你喜欢 ActivityWatch 吗？它帮到你了吗？通过捐赠帮助我们继续帮助你！你可以通过以下方式捐赠：',
     support2: '更多信息请访问',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -41,6 +41,9 @@ div
     div.col-md-6
       h4 {{ $t('home.supportTitle') }}
       p
+        | {{ $t('home.subscribeIntro') }}
+        |  #[a(href="https://activitywatch.net/subscribe?src=inapp-home") {{ $t('home.subscribeCta') }}]
+      p
         | {{ $t('home.support1') }}
       ul
         li #[a(href="https://www.patreon.com/erikbjare") Patreon]

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -42,7 +42,7 @@ div
       h4 {{ $t('home.supportTitle') }}
       p
         | {{ $t('home.subscribeIntro') }}
-        |  #[a(href="https://activitywatch.net/subscribe?src=inapp-home") {{ $t('home.subscribeCta') }}]
+        |  #[a(href="https://activitywatch.net/go/?src=inapp-home") {{ $t('home.subscribeCta') }}]
       p
         | {{ $t('home.support1') }}
       ul


### PR DESCRIPTION
Draft for iteration — the in-app half of the ActivityWatch Pro subscription funnel (pairs with activitywatch.github.io#64, which adds the `/subscribe` page).

## What this does
Adds one tasteful line at the top of the existing **Support us!** section on the Home view:

> The best way to keep ActivityWatch maintained is a subscription — from $5/month, every feature stays free, cancel anytime. **[Support ActivityWatch →](https://activitywatch.net/subscribe?src=inapp-home)**

- Points at the new `activitywatch.net/subscribe` page with a **`?src=inapp-home`** tag so we can attribute clicks **at the destination** — the app itself phones home nothing and gets no analytics (privacy ethos preserved).
- **Patronage framing**: subscribing funds the project; every feature stays free and ungated.
- New i18n keys `home.subscribeIntro` / `home.subscribeCta` added to **all** locales (en, de, uk, ru, zh-CN); non-en use the English string as a placeholder for translators. `check:locales` passes.

## Notes for iteration
- Deliberately minimal + non-intrusive (a line in the existing support block, not a modal/banner). Easy to expand later to a dismissable banner or a report-view footer if you want more surfaces.
- The `?src=` tag assumes the counting-redirect instrumentation from the profitability plan; until that's live the link still works, it just isn't counted.
- Copy/placement are a starting point — iterate freely.

Context: existing in-app nudges have zero click instrumentation, so this destination-tagged approach is how we start actually measuring conversion.