### PR TITLE
feat(home): engagement-gated supporter nudge + route survey/forum links through /go/

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -212,6 +212,12 @@ export default {
     workingOnSuffix: 'für Release-Hinweise.',
     landingHint:
       'Welche Seite beim Öffnen von ActivityWatch erscheint (statt dieser), können Sie in den',
+    supporterNudge: {
+      message:
+        "You've been getting a lot out of ActivityWatch — would you consider supporting its development?",
+      support: 'Support ActivityWatch →',
+      notNow: 'Not now',
+    },
   },
   buckets: {
     title: 'Buckets',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -212,6 +212,12 @@ export default {
     workingOnSuffix: 'for release notes.',
     landingHint:
       'You can change which page opens when you open ActivityWatch (instead of this page) in the',
+    supporterNudge: {
+      message:
+        "You've been getting a lot out of ActivityWatch — would you consider supporting its development?",
+      support: 'Support ActivityWatch →',
+      notNow: 'Not now',
+    },
   },
   buckets: {
     title: 'Buckets',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -209,6 +209,12 @@ export default {
     workingOnMiddle: 'и за проектом на',
     workingOnSuffix: 'чтобы читать заметки к релизам.',
     landingHint: 'Страницу при открытии ActivityWatch (вместо этой) можно изменить в',
+    supporterNudge: {
+      message:
+        "You've been getting a lot out of ActivityWatch — would you consider supporting its development?",
+      support: 'Support ActivityWatch →',
+      notNow: 'Not now',
+    },
   },
   buckets: {
     title: 'Bucket-и',

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -209,6 +209,12 @@ export default {
     workingOnMiddle: 'та за проєктом на',
     workingOnSuffix: 'щоб читати нотатки до релізів.',
     landingHint: 'Сторінку при відкритті ActivityWatch (замість цієї) можна змінити в',
+    supporterNudge: {
+      message:
+        "You've been getting a lot out of ActivityWatch — would you consider supporting its development?",
+      support: 'Support ActivityWatch →',
+      notNow: 'Not now',
+    },
   },
   buckets: {
     title: 'Bucket-и',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -206,6 +206,12 @@ export default {
     workingOnMiddle: '了解最新进展，在',
     workingOnSuffix: '上关注项目获取发布说明。',
     landingHint: '你可以在',
+    supporterNudge: {
+      message:
+        "You've been getting a lot out of ActivityWatch — would you consider supporting its development?",
+      support: 'Support ActivityWatch →',
+      notNow: 'Not now',
+    },
   },
   buckets: {
     title: '存储桶',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -97,7 +97,6 @@ import moment from 'moment';
 import { mapState } from 'pinia';
 import { useServerStore } from '~/stores/server';
 import { useBucketsStore } from '~/stores/buckets';
-import { getClient } from '~/util/awclient';
 import { IBucket } from '~/util/interfaces';
 
 // "Support ActivityWatch" nudge — engagement-gated, dismissable, never modal.
@@ -112,10 +111,18 @@ const INSTALL_AGE_DAYS = 30;
 // Signal 2 — power-user setup.
 const POWER_USER_MIN_BUCKETS = 6;
 const POWER_USER_MIN_HOSTS = 2;
-// Signal 3 — retention / regular use: several active days across the month.
-const RETENTION_LOOKBACK_DAYS = 30;
-const ACTIVE_DAY_MIN_MINUTES = 10; // a day counts as "active" above this much not-afk time
-const ACTIVE_DAYS_THRESHOLD = 8; // trigger if >= this many active days in the lookback
+// Signal 3 — retention / regular use: the user actively OPENS AND LOOKS AT the
+// webui on several distinct days (real product engagement — they come back to
+// check their data), tracked purely client-side (localStorage, no server query).
+// NOTE: this accumulates only AFTER this feature ships (localStorage starts
+// empty), so it is forward-looking: a brand-new install won't fire it for the
+// first ~week of use. That's intended — install-age (tenure) and setup cover
+// existing users retroactively; this one rewards ongoing engagement.
+const ENGAGED_DAYS_KEY = 'aw-engaged-days'; // array of local YYYY-MM-DD dates
+const ENGAGED_SECONDS_KEY = 'aw-engaged-seconds-today'; // partial accrual for today
+const ENGAGED_DAY_MIN_SECONDS = 10; // active viewing today needed to count the day
+const ENGAGED_DAYS_LOOKBACK_DAYS = 30;
+const ENGAGED_DAYS_THRESHOLD = 5; // fire if >= this many engaged days in the lookback
 
 // GA src tags, one per triggering signal, so the /go/ redirect reveals which
 // indicator actually converts. Support-button src = the highest-priority
@@ -123,6 +130,17 @@ const ACTIVE_DAYS_THRESHOLD = 8; // trigger if >= this many active days in the l
 const SRC_TENURE = 'inapp-tenure';
 const SRC_SETUP = 'inapp-setup';
 const SRC_REGULAR = 'inapp-regular';
+
+// Engagement-tracking state (module-scoped: only one Home is mounted at a time).
+// "Active" = the webui tab is visible AND focused; we accumulate seconds while so.
+let engagementActiveSince: number | null = null;
+let engagementInterval: ReturnType<typeof setInterval> | null = null;
+let engagementChangeHandler: (() => void) | null = null;
+
+function localDateStr(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
 
 export default {
   name: 'Home',
@@ -149,6 +167,11 @@ export default {
   mounted() {
     // Best-effort: must never block or break the Home render.
     this.evaluateSupporterNudge();
+    // Track ongoing webui engagement (client-side only) for the retention signal.
+    this.startEngagementTracking();
+  },
+  beforeDestroy() {
+    this.stopEngagementTracking();
   },
   methods: {
     async evaluateSupporterNudge(): Promise<void> {
@@ -168,9 +191,8 @@ export default {
           return;
         }
 
-        // Retention signal — best-effort, never blocks render.
-        const isRegular = await this.hasRegularUsage(buckets).catch(() => false);
-        if (isRegular) this.showSupporterNudge(SRC_REGULAR);
+        // Retention signal — client-side localStorage check, never errors render.
+        if (this.hasRegularEngagement()) this.showSupporterNudge(SRC_REGULAR);
       } catch (e) {
         // Swallow: the nudge is entirely optional, Home must still render.
         console.warn('Supporter nudge evaluation skipped:', e);
@@ -225,50 +247,115 @@ export default {
       return null;
     },
 
-    // Signal 3 — retention / regular use. Counts days in the last 30 with at
-    // least ACTIVE_DAY_MIN_MINUTES of not-afk (active) time. Reuses the same
-    // aw-client query2 infra; all local. Best-effort.
-    async hasRegularUsage(buckets: IBucket[]): Promise<boolean> {
-      const escape = (id: string) => id.replace(/"/g, '\\"');
-      const afkBuckets = buckets.filter(b => b.type === 'afkstatus').map(b => escape(b.id));
-      const androidBuckets = buckets
-        .filter(b => b.type === 'currentwindow' && b.id.startsWith('aw-watcher-android'))
-        .map(b => escape(b.id));
-
-      // Per-day not-afk seconds. On desktop, sum not-afk time from afk buckets;
-      // on Android (no afk buckets) treat all logged window time as active.
-      let query: string[];
-      if (afkBuckets.length > 0) {
-        query = ['not_afk = [];'];
-        for (const id of afkBuckets) {
-          query.push(`not_afk_curr = query_bucket("${id}");`);
-          query.push('not_afk_curr = filter_keyvals(not_afk_curr, "status", ["not-afk"]);');
-          query.push('not_afk = union_no_overlap(not_afk, not_afk_curr);');
-        }
-        query.push('RETURN = sum_durations(not_afk);');
-      } else if (androidBuckets.length > 0) {
-        query = ['events = [];'];
-        for (const id of androidBuckets) {
-          query.push(`events = concat(events, query_bucket("${id}"));`);
-        }
-        query.push('RETURN = sum_durations(events);');
-      } else {
+    // Signal 3 — retention / regular use. Purely client-side: fires if the
+    // user has actively opened+viewed the webui on >= ENGAGED_DAYS_THRESHOLD
+    // distinct days within the lookback window. No server query.
+    hasRegularEngagement(): boolean {
+      try {
+        return this.readEngagedDaysWithinLookback().length >= ENGAGED_DAYS_THRESHOLD;
+      } catch {
         return false;
       }
+    },
 
-      // One day-long period per day in the lookback window.
-      const periods: string[] = [];
-      for (let i = 0; i < RETENTION_LOOKBACK_DAYS; i++) {
-        const dayStart = moment().subtract(i, 'days').startOf('day');
-        periods.push(`${dayStart.format()}/${dayStart.clone().add(1, 'day').format()}`);
+    // Read the recorded engaged-day dates, pruned to the lookback window.
+    readEngagedDaysWithinLookback(): string[] {
+      let days: string[] = [];
+      try {
+        const raw = localStorage.getItem(ENGAGED_DAYS_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) days = parsed.filter(d => typeof d === 'string');
+        }
+      } catch {
+        return [];
       }
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - ENGAGED_DAYS_LOOKBACK_DAYS);
+      const cutoffStr = localDateStr(cutoff);
+      // YYYY-MM-DD sorts lexicographically by date; keep unique in-window dates.
+      return [...new Set(days)].filter(d => d >= cutoffStr).sort();
+    },
 
-      const results = await getClient().query(periods, query, { name: 'supporterRetention' });
-      const minSeconds = ACTIVE_DAY_MIN_MINUTES * 60;
-      const activeDays = (Array.isArray(results) ? results : []).filter(
-        (s: unknown) => typeof s === 'number' && s >= minSeconds
-      ).length;
-      return activeDays >= ACTIVE_DAYS_THRESHOLD;
+    // --- Client-side engagement tracking -------------------------------------
+    // "Active" = the webui tab is visible (Page Visibility API) AND focused.
+    // We accumulate active seconds for today; once past ENGAGED_DAY_MIN_SECONDS
+    // we record today's date. localStorage-only, cannot error the render.
+
+    startEngagementTracking(): void {
+      if (typeof document === 'undefined') return;
+      engagementChangeHandler = () => this.updateEngagementActive();
+      document.addEventListener('visibilitychange', engagementChangeHandler);
+      window.addEventListener('focus', engagementChangeHandler);
+      window.addEventListener('blur', engagementChangeHandler);
+      // Periodic flush so long, uninterrupted visits still get recorded.
+      engagementInterval = setInterval(() => this.flushEngagement(), 5000);
+      engagementActiveSince = null;
+      this.updateEngagementActive();
+    },
+
+    stopEngagementTracking(): void {
+      this.flushEngagement();
+      if (engagementInterval !== null) {
+        clearInterval(engagementInterval);
+        engagementInterval = null;
+      }
+      if (engagementChangeHandler) {
+        document.removeEventListener('visibilitychange', engagementChangeHandler);
+        window.removeEventListener('focus', engagementChangeHandler);
+        window.removeEventListener('blur', engagementChangeHandler);
+        engagementChangeHandler = null;
+      }
+      engagementActiveSince = null;
+    },
+
+    isEngagementActive(): boolean {
+      return document.visibilityState === 'visible' && document.hasFocus();
+    },
+
+    updateEngagementActive(): void {
+      const active = this.isEngagementActive();
+      if (active && engagementActiveSince === null) {
+        engagementActiveSince = Date.now();
+      } else if (!active && engagementActiveSince !== null) {
+        this.flushEngagement();
+        engagementActiveSince = null;
+      }
+    },
+
+    // Add elapsed active time to today's accrual; record the day past threshold.
+    flushEngagement(): void {
+      try {
+        if (engagementActiveSince === null) return;
+        const now = Date.now();
+        const elapsed = (now - engagementActiveSince) / 1000;
+        engagementActiveSince = now;
+        if (elapsed <= 0) return;
+
+        const today = localDateStr(new Date());
+        let seconds = 0;
+        const raw = localStorage.getItem(ENGAGED_SECONDS_KEY);
+        if (raw) {
+          const rec = JSON.parse(raw);
+          if (rec && rec.date === today && typeof rec.seconds === 'number') {
+            seconds = rec.seconds;
+          }
+        }
+        seconds += elapsed;
+        localStorage.setItem(ENGAGED_SECONDS_KEY, JSON.stringify({ date: today, seconds }));
+
+        if (seconds >= ENGAGED_DAY_MIN_SECONDS) this.recordEngagedDay(today);
+      } catch {
+        // Tracking is best-effort; ignore storage/parse failures.
+      }
+    },
+
+    recordEngagedDay(today: string): void {
+      const days = this.readEngagedDaysWithinLookback();
+      if (days.includes(today)) return;
+      days.push(today);
+      // Already pruned to the lookback window by readEngagedDaysWithinLookback.
+      localStorage.setItem(ENGAGED_DAYS_KEY, JSON.stringify([...new Set(days)].sort()));
     },
 
     onSupporterNudgeSupport(): void {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -200,6 +200,9 @@ export default {
     },
 
     showSupporterNudge(src: string): void {
+      // Re-read shared state after async evaluation: another tab may have
+      // snoozed the nudge or marked this user as a supporter in the meantime.
+      if (this.isSupporterNudgeSnoozed() || this.isSupporter()) return;
       this.supporterNudgeSrc = src;
       this.supporterNudgeVisible = true;
     },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -136,6 +136,7 @@ const SRC_REGULAR = 'inapp-regular';
 let engagementActiveSince: number | null = null;
 let engagementInterval: ReturnType<typeof setInterval> | null = null;
 let engagementChangeHandler: (() => void) | null = null;
+let supporterStorageHandler: ((event: StorageEvent) => void) | null = null;
 
 function localDateStr(d: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0');
@@ -167,10 +168,12 @@ export default {
   mounted() {
     // Best-effort: must never block or break the Home render.
     this.evaluateSupporterNudge();
+    this.startSupporterStorageSync();
     // Track ongoing webui engagement (client-side only) for the retention signal.
     this.startEngagementTracking();
   },
   beforeDestroy() {
+    this.stopSupporterStorageSync();
     this.stopEngagementTracking();
   },
   methods: {
@@ -223,6 +226,28 @@ export default {
         return localStorage.getItem(SUPPORTER_FLAG_KEY) === 'true';
       } catch {
         return false;
+      }
+    },
+
+    startSupporterStorageSync(): void {
+      supporterStorageHandler = (event: StorageEvent) => {
+        if (
+          event.key === SUPPORTER_NUDGE_DISMISS_KEY ||
+          event.key === SUPPORTER_FLAG_KEY ||
+          event.key === null
+        ) {
+          if (this.isSupporterNudgeSnoozed() || this.isSupporter()) {
+            this.supporterNudgeVisible = false;
+          }
+        }
+      };
+      window.addEventListener('storage', supporterStorageHandler);
+    },
+
+    stopSupporterStorageSync(): void {
+      if (supporterStorageHandler) {
+        window.removeEventListener('storage', supporterStorageHandler);
+        supporterStorageHandler = null;
       }
     },
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,7 +5,7 @@ div
 
   b-alert.supporter-nudge(v-if="supporterNudgeVisible" show variant="success" dismissible @dismissed="snoozeSupporterNudge")
     span {{ $t('home.supporterNudge.message') }}
-    b-button.ml-2(size="sm" variant="primary" href="https://activitywatch.net/go/?src=inapp-poweruser" target="_blank" @click="onSupporterNudgeSupport") {{ $t('home.supporterNudge.support') }}
+    b-button.ml-2(size="sm" variant="primary" :href="supporterNudgeHref" target="_blank" @click="onSupporterNudgeSupport") {{ $t('home.supporterNudge.support') }}
     b-button.ml-1(size="sm" variant="link" @click="snoozeSupporterNudge") {{ $t('home.supporterNudge.notNow') }}
 
   h3 {{ $t('home.greeting') }}
@@ -106,17 +106,30 @@ import { IBucket } from '~/util/interfaces';
 const SUPPORTER_NUDGE_DISMISS_KEY = 'aw-supporter-nudge-dismissed-until';
 const SUPPORTER_FLAG_KEY = 'aw-supporter'; // honor-system "I already support" flag
 const SNOOZE_DAYS = 90;
+
+// Signal 1 — install tenure.
 const INSTALL_AGE_DAYS = 30;
+// Signal 2 — power-user setup.
 const POWER_USER_MIN_BUCKETS = 6;
 const POWER_USER_MIN_HOSTS = 2;
-const AFFINITY_MIN_SECONDS = 2 * 60 * 60; // ~2h of logged ActivityWatch time
-const AFFINITY_LOOKBACK_DAYS = 90;
+// Signal 3 — retention / regular use: several active days across the month.
+const RETENTION_LOOKBACK_DAYS = 30;
+const ACTIVE_DAY_MIN_MINUTES = 10; // a day counts as "active" above this much not-afk time
+const ACTIVE_DAYS_THRESHOLD = 8; // trigger if >= this many active days in the lookback
+
+// GA src tags, one per triggering signal, so the /go/ redirect reveals which
+// indicator actually converts. Support-button src = the highest-priority
+// matching signal (most -> least predictive of paying): regular > setup > tenure.
+const SRC_TENURE = 'inapp-tenure';
+const SRC_SETUP = 'inapp-setup';
+const SRC_REGULAR = 'inapp-regular';
 
 export default {
   name: 'Home',
   data() {
     return {
       supporterNudgeVisible: false,
+      supporterNudgeSrc: '',
     };
   },
   computed: {
@@ -128,6 +141,9 @@ export default {
     apiBrowserUrl(): string {
       const base = window.location.pathname.replace(/[^/]*$/, '');
       return base + 'api/';
+    },
+    supporterNudgeHref(): string {
+      return `https://activitywatch.net/go/?src=${this.supporterNudgeSrc}`;
     },
   },
   mounted() {
@@ -144,19 +160,26 @@ export default {
         const buckets = bucketsStore.buckets as IBucket[];
         if (!buckets || buckets.length === 0) return;
 
-        // Cheap, synchronous signals first (install age + power-user setup).
-        if (this.hasEngagementSignal(buckets)) {
-          this.supporterNudgeVisible = true;
+        // Cheap, synchronous signals first (setup checked before tenure, since
+        // setup ranks higher when both match).
+        const syncTag = this.syncEngagementTag(buckets);
+        if (syncTag) {
+          this.showSupporterNudge(syncTag);
           return;
         }
 
-        // ActivityWatch-affinity signal — best-effort, never blocks render.
-        const hasAffinity = await this.hasActivityWatchAffinity(buckets).catch(() => false);
-        if (hasAffinity) this.supporterNudgeVisible = true;
+        // Retention signal — best-effort, never blocks render.
+        const isRegular = await this.hasRegularUsage(buckets).catch(() => false);
+        if (isRegular) this.showSupporterNudge(SRC_REGULAR);
       } catch (e) {
         // Swallow: the nudge is entirely optional, Home must still render.
         console.warn('Supporter nudge evaluation skipped:', e);
       }
+    },
+
+    showSupporterNudge(src: string): void {
+      this.supporterNudgeSrc = src;
+      this.supporterNudgeVisible = true;
     },
 
     isSupporterNudgeSnoozed(): boolean {
@@ -179,55 +202,73 @@ export default {
     },
 
     // Signals 1 & 2 — derivable synchronously from getBuckets().
-    hasEngagementSignal(buckets: IBucket[]): boolean {
-      // Signal 1 (primary, cheapest): install age >= 30 days, from the
-      // earliest `created` timestamp across all buckets.
+    // Returns the winning src tag (setup outranks tenure) or null.
+    syncEngagementTag(buckets: IBucket[]): string | null {
+      // Signal 2: power-user setup — many buckets OR multi-host/multi-watcher.
+      // Checked first: outranks tenure when both match.
+      const hostnames = new Set(buckets.map(b => b.hostname).filter(Boolean));
+      if (buckets.length >= POWER_USER_MIN_BUCKETS || hostnames.size >= POWER_USER_MIN_HOSTS) {
+        return SRC_SETUP;
+      }
+
+      // Signal 1 (cheapest): install age >= 30 days, from the earliest
+      // `created` timestamp across all buckets.
       const createds = buckets
         .map(b => (b.created ? new Date(b.created as unknown as string).getTime() : NaN))
         .filter(t => !isNaN(t));
       if (createds.length > 0) {
         const earliest = Math.min(...createds);
         const ageDays = (Date.now() - earliest) / (1000 * 60 * 60 * 24);
-        if (ageDays >= INSTALL_AGE_DAYS) return true;
+        if (ageDays >= INSTALL_AGE_DAYS) return SRC_TENURE;
       }
 
-      // Signal 2: power-user setup — many buckets OR multi-host/multi-watcher.
-      if (buckets.length >= POWER_USER_MIN_BUCKETS) return true;
-      const hostnames = new Set(buckets.map(b => b.hostname).filter(Boolean));
-      if (hostnames.size >= POWER_USER_MIN_HOSTS) return true;
-
-      return false;
+      return null;
     },
 
-    // Signal 3 — ActivityWatch affinity (dogfooder/contributor).
-    // Sums logged window time whose app/title matches "activitywatch".
-    // Reuses the existing aw-client query infra; all local. Best-effort.
-    async hasActivityWatchAffinity(buckets: IBucket[]): Promise<boolean> {
-      const windowBuckets = buckets
-        .filter(b => b.type === 'currentwindow' && !b.id.startsWith('aw-watcher-android'))
-        .map(b => b.id.replace(/"/g, '\\"'));
-      if (windowBuckets.length === 0) return false;
+    // Signal 3 — retention / regular use. Counts days in the last 30 with at
+    // least ACTIVE_DAY_MIN_MINUTES of not-afk (active) time. Reuses the same
+    // aw-client query2 infra; all local. Best-effort.
+    async hasRegularUsage(buckets: IBucket[]): Promise<boolean> {
+      const escape = (id: string) => id.replace(/"/g, '\\"');
+      const afkBuckets = buckets.filter(b => b.type === 'afkstatus').map(b => escape(b.id));
+      const androidBuckets = buckets
+        .filter(b => b.type === 'currentwindow' && b.id.startsWith('aw-watcher-android'))
+        .map(b => escape(b.id));
 
-      const end = moment();
-      const start = moment().subtract(AFFINITY_LOOKBACK_DAYS, 'days');
-      const period = `${start.format()}/${end.format()}`;
-
-      const query: string[] = ['events = [];'];
-      for (const id of windowBuckets) {
-        query.push(`events = concat(events, query_bucket("${id}"));`);
+      // Per-day not-afk seconds. On desktop, sum not-afk time from afk buckets;
+      // on Android (no afk buckets) treat all logged window time as active.
+      let query: string[];
+      if (afkBuckets.length > 0) {
+        query = ['not_afk = [];'];
+        for (const id of afkBuckets) {
+          query.push(`not_afk_curr = query_bucket("${id}");`);
+          query.push('not_afk_curr = filter_keyvals(not_afk_curr, "status", ["not-afk"]);');
+          query.push('not_afk = union_no_overlap(not_afk, not_afk_curr);');
+        }
+        query.push('RETURN = sum_durations(not_afk);');
+      } else if (androidBuckets.length > 0) {
+        query = ['events = [];'];
+        for (const id of androidBuckets) {
+          query.push(`events = concat(events, query_bucket("${id}"));`);
+        }
+        query.push('RETURN = sum_durations(events);');
+      } else {
+        return false;
       }
-      query.push(
-        // (?i) = case-insensitive match, mirroring /activitywatch/i.
-        'app_events = filter_keyvals_regex(events, "app", "(?i)activitywatch");',
-        'title_events = filter_keyvals_regex(events, "title", "(?i)activitywatch");',
-        // union_no_overlap dedups events matching both app and title.
-        'matched = union_no_overlap(app_events, title_events);',
-        'RETURN = sum_durations(matched);'
-      );
 
-      const result = await getClient().query([period], query, { name: 'supporterAffinity' });
-      const seconds = Array.isArray(result) ? result[0] : result;
-      return typeof seconds === 'number' && seconds >= AFFINITY_MIN_SECONDS;
+      // One day-long period per day in the lookback window.
+      const periods: string[] = [];
+      for (let i = 0; i < RETENTION_LOOKBACK_DAYS; i++) {
+        const dayStart = moment().subtract(i, 'days').startOf('day');
+        periods.push(`${dayStart.format()}/${dayStart.clone().add(1, 'day').format()}`);
+      }
+
+      const results = await getClient().query(periods, query, { name: 'supporterRetention' });
+      const minSeconds = ACTIVE_DAY_MIN_MINUTES * 60;
+      const activeDays = (Array.isArray(results) ? results : []).filter(
+        (s: unknown) => typeof s === 'number' && s >= minSeconds
+      ).length;
+      return activeDays >= ACTIVE_DAYS_THRESHOLD;
     },
 
     onSupporterNudgeSupport(): void {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,6 +3,11 @@ div
   b-alert(v-if="$isAndroid" show)
     | #[b {{ $t('home.note') }}] {{ $t('home.androidNote') }}
 
+  b-alert.supporter-nudge(v-if="supporterNudgeVisible" show variant="success" dismissible @dismissed="snoozeSupporterNudge")
+    span {{ $t('home.supporterNudge.message') }}
+    b-button.ml-2(size="sm" variant="primary" href="https://activitywatch.net/go/?src=inapp-poweruser" target="_blank" @click="onSupporterNudgeSupport") {{ $t('home.supporterNudge.support') }}
+    b-button.ml-1(size="sm" variant="link" @click="snoozeSupporterNudge") {{ $t('home.supporterNudge.notNow') }}
+
   h3 {{ $t('home.greeting') }}
   p
     | {{ homeIntro1 }}
@@ -10,9 +15,9 @@ div
     | {{ $t('home.intro3') }}
   p.mb-0 {{ $t('home.thanks') }}
   p
-    a(href="https://forms.gle/q2N9K5RoERBV8kqPA") {{ $t('home.surveyFill') }}
+    a(href="https://activitywatch.net/go/?src=inapp-survey&to=survey") {{ $t('home.surveyFill') }}
     | &nbsp;{{ $t('home.surveyOr') }}&nbsp;
-    a(href="https://forum.activitywatch.net/c/features") {{ $t('home.voteForum') }}
+    a(href="https://activitywatch.net/go/?src=inapp-forum&to=forum") {{ $t('home.voteForum') }}
     | &nbsp;{{ $t('home.surveySuffix') }}
 
   hr
@@ -88,11 +93,32 @@ div
 </template>
 
 <script lang="ts">
+import moment from 'moment';
 import { mapState } from 'pinia';
 import { useServerStore } from '~/stores/server';
+import { useBucketsStore } from '~/stores/buckets';
+import { getClient } from '~/util/awclient';
+import { IBucket } from '~/util/interfaces';
+
+// "Support ActivityWatch" nudge — engagement-gated, dismissable, never modal.
+// Shown only to clearly-engaged users so casual/new users are never nagged.
+// All computation stays local; the app phones home nothing.
+const SUPPORTER_NUDGE_DISMISS_KEY = 'aw-supporter-nudge-dismissed-until';
+const SUPPORTER_FLAG_KEY = 'aw-supporter'; // honor-system "I already support" flag
+const SNOOZE_DAYS = 90;
+const INSTALL_AGE_DAYS = 30;
+const POWER_USER_MIN_BUCKETS = 6;
+const POWER_USER_MIN_HOSTS = 2;
+const AFFINITY_MIN_SECONDS = 2 * 60 * 60; // ~2h of logged ActivityWatch time
+const AFFINITY_LOOKBACK_DAYS = 90;
 
 export default {
   name: 'Home',
+  data() {
+    return {
+      supporterNudgeVisible: false,
+    };
+  },
   computed: {
     ...mapState(useServerStore, ['info']),
     homeIntro1() {
@@ -102,6 +128,121 @@ export default {
     apiBrowserUrl(): string {
       const base = window.location.pathname.replace(/[^/]*$/, '');
       return base + 'api/';
+    },
+  },
+  mounted() {
+    // Best-effort: must never block or break the Home render.
+    this.evaluateSupporterNudge();
+  },
+  methods: {
+    async evaluateSupporterNudge(): Promise<void> {
+      try {
+        if (this.isSupporterNudgeSnoozed() || this.isSupporter()) return;
+
+        const bucketsStore = useBucketsStore();
+        await bucketsStore.ensureLoaded();
+        const buckets = bucketsStore.buckets as IBucket[];
+        if (!buckets || buckets.length === 0) return;
+
+        // Cheap, synchronous signals first (install age + power-user setup).
+        if (this.hasEngagementSignal(buckets)) {
+          this.supporterNudgeVisible = true;
+          return;
+        }
+
+        // ActivityWatch-affinity signal — best-effort, never blocks render.
+        const hasAffinity = await this.hasActivityWatchAffinity(buckets).catch(() => false);
+        if (hasAffinity) this.supporterNudgeVisible = true;
+      } catch (e) {
+        // Swallow: the nudge is entirely optional, Home must still render.
+        console.warn('Supporter nudge evaluation skipped:', e);
+      }
+    },
+
+    isSupporterNudgeSnoozed(): boolean {
+      try {
+        const raw = localStorage.getItem(SUPPORTER_NUDGE_DISMISS_KEY);
+        if (!raw) return false;
+        const until = new Date(raw).getTime();
+        return !isNaN(until) && until > Date.now();
+      } catch {
+        return false;
+      }
+    },
+
+    isSupporter(): boolean {
+      try {
+        return localStorage.getItem(SUPPORTER_FLAG_KEY) === 'true';
+      } catch {
+        return false;
+      }
+    },
+
+    // Signals 1 & 2 — derivable synchronously from getBuckets().
+    hasEngagementSignal(buckets: IBucket[]): boolean {
+      // Signal 1 (primary, cheapest): install age >= 30 days, from the
+      // earliest `created` timestamp across all buckets.
+      const createds = buckets
+        .map(b => (b.created ? new Date(b.created as unknown as string).getTime() : NaN))
+        .filter(t => !isNaN(t));
+      if (createds.length > 0) {
+        const earliest = Math.min(...createds);
+        const ageDays = (Date.now() - earliest) / (1000 * 60 * 60 * 24);
+        if (ageDays >= INSTALL_AGE_DAYS) return true;
+      }
+
+      // Signal 2: power-user setup — many buckets OR multi-host/multi-watcher.
+      if (buckets.length >= POWER_USER_MIN_BUCKETS) return true;
+      const hostnames = new Set(buckets.map(b => b.hostname).filter(Boolean));
+      if (hostnames.size >= POWER_USER_MIN_HOSTS) return true;
+
+      return false;
+    },
+
+    // Signal 3 — ActivityWatch affinity (dogfooder/contributor).
+    // Sums logged window time whose app/title matches "activitywatch".
+    // Reuses the existing aw-client query infra; all local. Best-effort.
+    async hasActivityWatchAffinity(buckets: IBucket[]): Promise<boolean> {
+      const windowBuckets = buckets
+        .filter(b => b.type === 'currentwindow' && !b.id.startsWith('aw-watcher-android'))
+        .map(b => b.id.replace(/"/g, '\\"'));
+      if (windowBuckets.length === 0) return false;
+
+      const end = moment();
+      const start = moment().subtract(AFFINITY_LOOKBACK_DAYS, 'days');
+      const period = `${start.format()}/${end.format()}`;
+
+      const query: string[] = ['events = [];'];
+      for (const id of windowBuckets) {
+        query.push(`events = concat(events, query_bucket("${id}"));`);
+      }
+      query.push(
+        // (?i) = case-insensitive match, mirroring /activitywatch/i.
+        'app_events = filter_keyvals_regex(events, "app", "(?i)activitywatch");',
+        'title_events = filter_keyvals_regex(events, "title", "(?i)activitywatch");',
+        // union_no_overlap dedups events matching both app and title.
+        'matched = union_no_overlap(app_events, title_events);',
+        'RETURN = sum_durations(matched);'
+      );
+
+      const result = await getClient().query([period], query, { name: 'supporterAffinity' });
+      const seconds = Array.isArray(result) ? result[0] : result;
+      return typeof seconds === 'number' && seconds >= AFFINITY_MIN_SECONDS;
+    },
+
+    onSupporterNudgeSupport(): void {
+      // They've engaged with the ask — snooze so we don't re-nag on return.
+      this.snoozeSupporterNudge();
+    },
+
+    snoozeSupporterNudge(): void {
+      this.supporterNudgeVisible = false;
+      try {
+        const until = moment().add(SNOOZE_DAYS, 'days').toISOString();
+        localStorage.setItem(SUPPORTER_NUDGE_DISMISS_KEY, until);
+      } catch {
+        // localStorage unavailable — nudge simply reappears next load.
+      }
     },
   },
 };

--- a/test/unit/Home.test.js
+++ b/test/unit/Home.test.js
@@ -14,4 +14,30 @@ describe('Home supporter nudge', () => {
     expect(vm.supporterNudgeSrc).toBe('');
     expect(vm.supporterNudgeVisible).toBe(false);
   });
+
+  test('hides a visible nudge when another tab snoozes it', () => {
+    const listeners = {};
+    const addEventListenerSpy = jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, listener) => {
+        listeners[type] = listener;
+      });
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+    const vm = {
+      isSupporter: jest.fn().mockReturnValue(false),
+      isSupporterNudgeSnoozed: jest.fn().mockReturnValue(true),
+      supporterNudgeVisible: true,
+    };
+
+    Home.methods.startSupporterStorageSync.call(vm);
+    listeners.storage({ key: 'aw-supporter-nudge-dismissed-until' });
+
+    expect(vm.supporterNudgeVisible).toBe(false);
+
+    Home.methods.stopSupporterStorageSync.call(vm);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', listeners.storage);
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
 });

--- a/test/unit/Home.test.js
+++ b/test/unit/Home.test.js
@@ -1,0 +1,17 @@
+import Home from '~/views/Home.vue';
+
+describe('Home supporter nudge', () => {
+  test('does not show after another tab snoozes during async evaluation', () => {
+    const vm = {
+      isSupporter: jest.fn().mockReturnValue(false),
+      isSupporterNudgeSnoozed: jest.fn().mockReturnValue(true),
+      supporterNudgeSrc: '',
+      supporterNudgeVisible: false,
+    };
+
+    Home.methods.showSupporterNudge.call(vm, 'inapp-tenure');
+
+    expect(vm.supporterNudgeSrc).toBe('');
+    expect(vm.supporterNudgeVisible).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes to the Home view, both part of measuring and gently growing support for ActivityWatch — **no dark patterns**, all computation stays local.

### 1. Route the survey/forum nudge through the counting `/go/` redirect
The existing "fill our survey / vote on the forum" links pointed directly at the destinations, so clicks weren't measured. They now route through the already-live `/go/` redirect (counts a GA event, then forwards):
- survey → `https://activitywatch.net/go/?src=inapp-survey&to=survey`
- forum → `https://activitywatch.net/go/?src=inapp-forum&to=forum`

### 2. Engagement-gated "Support ActivityWatch" nudge
A **tasteful, dismissable `b-alert`** near the top of Home — one line, a Support button, and a "Not now" control. **Never a modal, never blocks interaction.** It appears **only to clearly-engaged users**, so casual/new users are never nagged.

**Shown only if ALL of:**
- Not snoozed within the last 90 days (`aw-supporter-nudge-dismissed-until`, ISO timestamp in localStorage).
- Not already a supporter (honor-system `aw-supporter` localStorage flag; absent = not a supporter).
- **AND at least one engagement signal:**
  1. **Install age ≥ 30 days** — min `created` across `getBuckets()` (primary, cheapest signal).
  2. **Power-user setup** — `bucketCount ≥ 6` OR `distinct hostname count ≥ 2`.
  3. **ActivityWatch affinity** — ≥ 2h of logged window time whose app/title matches `activitywatch` (case-insensitive), over the last 90 days. Best-effort, async, never blocks or errors the render.

On dismiss (X or "Not now") it snoozes for 90 days. The Support button links to `https://activitywatch.net/go/?src=inapp-poweruser` — attribution handled at the destination, no in-app analytics.

All data comes from the local aw-server via the existing aw-client / buckets store — the app phones home nothing.

### i18n
New keys under `home.supporterNudge.*` added to `en`, `de`, `ru`, `uk`, `zh-CN` (English placeholders in non-en). `node scripts/check-locales.mjs` passes.
