### PR TITLE
fix(queries): don't split on semicolons inside string literals

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -2,12 +2,38 @@ import _ from 'lodash';
 
 // TODO: Sanitize string input of buckets
 
-function querystr_to_array(querystr: string): string[] {
-  return querystr
-    .split(';')
-    .map(s => s.trim())
-    .filter(s => s)
-    .map(s => s + ';');
+export function querystr_to_array(querystr: string): string[] {
+  // Split on ';' but only when not inside a double-quoted string literal.
+  // A naive .split(';') breaks category rules whose regex contains semicolons,
+  // e.g. `"regex": "foo;bar"` would be shredded before reaching the server.
+  const statements: string[] = [];
+  let current = '';
+  let inString = false;
+  let escape = false;
+
+  for (const char of querystr) {
+    if (escape) {
+      current += char;
+      escape = false;
+    } else if (char === '\\' && inString) {
+      current += char;
+      escape = true;
+    } else if (char === '"') {
+      inString = !inString;
+      current += char;
+    } else if (char === ';' && !inString) {
+      const trimmed = current.trim();
+      if (trimmed) statements.push(trimmed + ';');
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) statements.push(trimmed + ';');
+
+  return statements;
 }
 
 function escape_doublequote(s: string) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -9,15 +9,15 @@ export function querystr_to_array(querystr: string): string[] {
   const statements: string[] = [];
   let current = '';
   let inString = false;
-  let escape = false;
+  let inEscape = false;
 
   for (const char of querystr) {
-    if (escape) {
+    if (inEscape) {
       current += char;
-      escape = false;
+      inEscape = false;
     } else if (char === '\\' && inString) {
       current += char;
-      escape = true;
+      inEscape = true;
     } else if (char === '"') {
       inString = !inString;
       current += char;

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -60,7 +60,7 @@ div
 <script lang="ts">
 import _ from 'lodash';
 import moment from 'moment';
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 
 import 'vue-awesome/icons/plus';
 import 'vue-awesome/icons/check';
@@ -163,7 +163,7 @@ export default {
       });
       query += '; RETURN = events;';
 
-      const query_array = query.split(';').map(s => s.trim() + ';');
+      const query_array = querystr_to_array(query);
 
       // Get start of today
       const start = moment().subtract(1, 'days').startOf('day');

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -67,7 +67,7 @@ import 'vue-awesome/icons/spinner';
 import 'vue-awesome/icons/angle-double-down';
 import 'vue-awesome/icons/angle-double-up';
 
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 
 import { useCategoryStore } from '~/stores/categories';
 
@@ -119,7 +119,7 @@ export default {
       });
       query += '; RETURN = events;';
 
-      const query_array = query.split(';').map(s => s.trim() + ';');
+      const query_array = querystr_to_array(query);
       const start = moment(this.queryOptions.start).format();
       const end = moment(this.queryOptions.stop).format();
       const timeperiods = [start + '/' + end];

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -62,6 +62,7 @@ div
 import 'vue-awesome/icons/trash';
 import moment from 'moment';
 import _ from 'lodash';
+import { querystr_to_array } from '~/queries';
 import { useCategoryStore } from '~/stores/categories';
 import { useSettingsStore } from '~/stores/settings';
 import {
@@ -264,7 +265,7 @@ RETURN = sort_by_duration(merged_events);
       }
 
       // the aw-client expects an array of commands with whitespace cleaned up
-      query = query.split(';').map(s => s.trim() + ';');
+      query = querystr_to_array(query as string);
       const timeperiods = [moment(this.startdate).format() + '/' + moment(this.enddate).format()];
 
       try {

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -85,7 +85,7 @@ import 'vue-awesome/icons/spinner';
 import 'vue-awesome/icons/angle-double-down';
 import 'vue-awesome/icons/angle-double-up';
 
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 import { buildBarchartDataset } from '~/util/datasets';
 
 import { useActivityStore } from '~/stores/activity';
@@ -141,7 +141,7 @@ export default {
       });
       query += '; RETURN = events;';
 
-      const query_array = query.split(';').map(s => s.trim() + ';');
+      const query_array = querystr_to_array(query);
       const start = moment(this.queryOptions.start).format();
       const end = moment(this.queryOptions.stop).format();
       const timeperiods = [start + '/' + end];

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -44,7 +44,7 @@ div
 <script lang="ts">
 import _ from 'lodash';
 import moment from 'moment';
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 
 import 'vue-awesome/icons/search';
 import 'vue-awesome/icons/spinner';
@@ -80,7 +80,7 @@ export default {
       });
       query += '; RETURN = events;';
 
-      const query_array = query.split(';').map(s => s.trim() + ';');
+      const query_array = querystr_to_array(query);
       const timeperiods = [
         moment(this.queryOptions.start).format() + '/' + moment(this.queryOptions.stop).format(),
       ];

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -115,7 +115,7 @@ import { mapState } from 'pinia';
 import { useSettingsStore } from '~/stores/settings';
 import { useBucketsStore } from '~/stores/buckets';
 import { getClient } from '~/util/awclient';
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 import { useCategoryStore } from '~/stores/categories';
 import { matchString } from '~/util/classes';
 import { getCategorizationStringFromEvent } from '~/util/color';
@@ -390,11 +390,7 @@ export default {
           filter_categories: null,
         }) + '\nRETURN = events;';
 
-      const queryArray = queryCode
-        .split(';')
-        .map(s => s.trim())
-        .filter(s => s)
-        .map(s => s + ';');
+      const queryArray = querystr_to_array(queryCode);
 
       const start = this.daterange[0].format();
       const end = this.daterange[1].format();

--- a/src/views/Trends.vue
+++ b/src/views/Trends.vue
@@ -91,7 +91,7 @@ div
 import moment from 'moment';
 import { get_today_with_offset, format_date_short, format_date_with_weekday } from '~/util/time';
 import { buildBarchartDataset } from '~/util/datasets';
-import { canonicalEvents } from '~/queries';
+import { canonicalEvents, querystr_to_array } from '~/queries';
 import { getClient } from '~/util/awclient';
 import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
@@ -375,11 +375,7 @@ export default {
         cat_events = sort_by_duration(merge_events_by_keys(events, ["$category"]));
         RETURN = {"cat_events": cat_events};
       `;
-      return code
-        .split(';')
-        .map(s => s.trim())
-        .filter(s => s)
-        .map(s => s + ';');
+      return querystr_to_array(code);
     },
   },
 };

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -53,7 +53,7 @@
  *             (Flatpak app ID retained: 'one.ablaze.floorp')
  */
 
-import { browser_appname_regex } from '~/queries';
+import { browser_appname_regex, querystr_to_array } from '~/queries';
 
 // Convert ActivityWatch (?i) patterns to JS RegExp with i flag for testing.
 // AW server uses Python-style (?i) inline flag; JS uses RegExp 'i' flag instead.
@@ -229,5 +229,40 @@ describe('browser_appname_regex', () => {
     for (const name of knownNames) {
       expect(re.test(name)).toBe(true);
     }
+  });
+});
+
+describe('querystr_to_array', () => {
+  test('splits simple multi-statement query correctly', () => {
+    const query = 'events = query_bucket("aw-watcher-window_host"); RETURN = {"events": events};';
+    const result = querystr_to_array(query);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe('events = query_bucket("aw-watcher-window_host");');
+    expect(result[1]).toBe('RETURN = {"events": events};');
+  });
+
+  test('does not split on semicolons inside string literals (category regex case)', () => {
+    // A category rule with a semicolon in the regex — the naive .split(';') would shred this.
+    const query =
+      'events = categorize(events, [["Work", {"type": "regex", "regex": "foo;bar"}]]);';
+    const result = querystr_to_array(query);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(
+      'events = categorize(events, [["Work", {"type": "regex", "regex": "foo;bar"}]]);'
+    );
+  });
+
+  test('handles escaped double-quotes inside string literals', () => {
+    const query = 'x = "say \\"hello;world\\""; RETURN = x;';
+    const result = querystr_to_array(query);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe('x = "say \\"hello;world\\"";');
+    expect(result[1]).toBe('RETURN = x;');
+  });
+
+  test('filters out empty statements from whitespace-only segments', () => {
+    const query = '\n  events = query_bucket("bucket");\n  RETURN = events;\n';
+    const result = querystr_to_array(query);
+    expect(result).toHaveLength(2);
   });
 });

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -243,8 +243,7 @@ describe('querystr_to_array', () => {
 
   test('does not split on semicolons inside string literals (category regex case)', () => {
     // A category rule with a semicolon in the regex — the naive .split(';') would shred this.
-    const query =
-      'events = categorize(events, [["Work", {"type": "regex", "regex": "foo;bar"}]]);';
+    const query = 'events = categorize(events, [["Work", {"type": "regex", "regex": "foo;bar"}]]);';
     const result = querystr_to_array(query);
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(


### PR DESCRIPTION
## Root cause

`querystr_to_array()` naively splits on all `;` characters. Category rules get embedded as JSON string literals inside the query — for example a rule with regex `foo;bar` becomes:

```
events = categorize(events, [["Work", {"type": "regex", "regex": "foo;bar"}]]);
```

A plain `.split(';')` shreds this into two broken fragments before the query reaches aw-server, causing a parse error. **Both aw-server-python and aw-server-rust handle `;` inside quoted string literals correctly** — the bug is entirely in the client-side splitter.

This explains the forum report in #724 and why the UI warning (PR #724) was only a workaround.

## Fix

### `src/queries.ts`
The new `querystr_to_array` tracks double-quoted string context (with backslash-escape support) and only treats `;` as a statement separator when it appears _outside_ a string literal.

Also exports `querystr_to_array` for direct unit testing and adds 4 tests:
- basic multi-statement split
- semicolon inside string literal (the regression case)
- escaped double-quote inside string
- whitespace/empty statement filtering

### View files (7 updated)
All view-level query splitting paths now use `querystr_to_array` instead of a naive `.split(';')`:
- `views/Alerts.vue`, `views/Search.vue`, `views/Graph.vue`, `views/Report.vue`, `views/QueryExplorer.vue` — replace `.split(';').map(s => s.trim() + ';')`
- `views/Timeline.vue`, `views/Trends.vue` — replace the longer split/trim/filter/map chain

## Investigation notes (from #724 comment thread)

Checked aw-server-rust's lexer (`aw-query/src/lexer.rs`): the string-literal rule `"([^\"]|(\\\"))*"` is matched before the bare `;` → `Token::Semi` rule, so semicolons inside quoted strings are correctly captured as part of `Token::String`. The server is not the problem.

Fixes #724.