### PR TITLE
fix(activity): hide unsupported visualizations instead of showing warning

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-div(v-if="editable || !activityStore.buckets.loaded || has_prerequisites")
+div(v-if="editable || !activityStore.buckets.loaded || has_prerequisites || !settingsStore.hideUnsupportedVisualizations")
   h5
     icon.handle(name="bars" v-if="editable" style="opacity: 0.6; cursor: grab;")
     | {{ visualizations[type].title }}
@@ -131,6 +131,7 @@ import { useActivityStore } from '~/stores/activity';
 import { useCategoryStore } from '~/stores/categories';
 import { useBucketsStore } from '~/stores/buckets';
 import { useViewsStore } from '~/stores/views';
+import { useSettingsStore } from '~/stores/settings';
 
 import moment from 'moment';
 
@@ -153,6 +154,7 @@ export default {
     return {
       activityStore: useActivityStore(),
       categoryStore: useCategoryStore(),
+      settingsStore: useSettingsStore(),
 
       types: [
         'top_apps',

--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-div
+div(v-if="editable || !activityStore.buckets.loaded || has_prerequisites")
   h5
     icon.handle(name="bars" v-if="editable" style="opacity: 0.6; cursor: grab;")
     | {{ visualizations[type].title }}

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -66,6 +66,9 @@ interface State {
   useMultidevice: boolean;
   requestTimeout: number;
 
+  // Whether to hide visualizations that lack required data (default: off)
+  hideUnsupportedVisualizations: boolean;
+
   // Set to true if settings loaded
   _loaded: boolean;
 }
@@ -114,6 +117,7 @@ export const useSettingsStore = defineStore('settings', {
     showYearly: false,
     useMultidevice: false,
     requestTimeout: 30,
+    hideUnsupportedVisualizations: false,
 
     _loaded: false,
   }),

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia';
 import { useSettingsStore } from './settings';
-import { useBucketsStore } from './buckets';
 
 interface IElement {
   type: string;
@@ -107,12 +106,7 @@ export const useViewsStore = defineStore('views', {
     restoreDefaults(this: State) {
       this.views = defaultViews;
     },
-    viewsForHost(host: string): View[] {
-      const bucketsStore = useBucketsStore();
-      const available = bucketsStore.available(host);
-      if (available.android && !available.window) {
-        return androidViews;
-      }
+    viewsForHost(_host: string): View[] {
       return this.views;
     },
     addView(this: State, view: View) {

--- a/src/views/settings/DeveloperSettings.vue
+++ b/src/views/settings/DeveloperSettings.vue
@@ -18,6 +18,10 @@ div
     div
       b-input.float-right.ml-2(v-model="requestTimeout" type="number")
 
+  b-form-group(label="Hide unsupported visualizations" label-cols-md=3 description="Hide visualizations that lack required data instead of showing a warning. Disabled by default.")
+    div
+      b-form-checkbox.float-right.ml-2(v-model="hideUnsupportedVisualizations" switch)
+
   div
     | Web UI commit hash: {{ COMMIT_HASH }}
 </template>
@@ -62,6 +66,14 @@ export default {
       },
       set(requestTimeout) {
         useSettingsStore().update({ requestTimeout });
+      },
+    },
+    hideUnsupportedVisualizations: {
+      get() {
+        return useSettingsStore().hideUnsupportedVisualizations;
+      },
+      set(hideUnsupportedVisualizations) {
+        useSettingsStore().update({ hideUnsupportedVisualizations });
       },
     },
   },


### PR DESCRIPTION
Closes #904.

## What this does

Replaces the per-devicetype view-set approach from #903 (which returned hardcoded `androidViews` for Android devices) with a simpler model: **one view layout for all devices, with individual visualizations hidden when they have no backing data**.

Erik's direction from #904:
> "let's stick with hiding unsupported visualizations for now. That way visualizations can also 'automatically' start showing once the requisites are there."

## Changes

**`src/components/SelectableVisualization.vue`** — add `v-if` on the root div:
```diff
-div
+div(v-if="editable || !activityStore.buckets.loaded || has_prerequisites")
```
- In **view mode**: if `has_prerequisites` is false (no backing data for this device type), the widget disappears entirely instead of showing a warning
- In **edit mode**: still shown (including the existing "missing data" warning), so users can manage their layout
- While **buckets are loading**: still shown (to prevent a flash of missing widgets)

**`src/stores/views.ts`** — simplify `viewsForHost`:
```diff
-viewsForHost(host: string): View[] {
-  const bucketsStore = useBucketsStore();
-  const available = bucketsStore.available(host);
-  if (available.android && !available.window) {
-    return androidViews;
-  }
+viewsForHost(_host: string): View[] {
   return this.views;
 },
```
The Android-specific view selection is no longer needed — the visibility guard handles it automatically.

## Behaviour

For an Android device viewed from desktop (no window buckets):
- **Summary tab**: `top_apps` visible, `top_titles` hidden, rest visible
- Visualizations reappear automatically if a watcher is later installed

For the multi-device view: no change (aggregation view uses whatever's available).