### PR TITLE
feat(ai-summary): add client-side AI activity summary page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/logo.png">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!-- Verify with https://csp-evaluator.withgoogle.com/ -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' <%= htmlWebpackPlugin.options.templateParameters.cspDefaultSrc %> https://api.github.com/repos/ActivityWatch/activitywatch/releases/latest; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; object-src 'none'; script-src 'self' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' <%= htmlWebpackPlugin.options.templateParameters.cspDefaultSrc %> https://api.github.com/repos/ActivityWatch/activitywatch/releases/latest; connect-src 'self' <%= htmlWebpackPlugin.options.templateParameters.cspDefaultSrc %> https://api.github.com/repos/ActivityWatch/activitywatch/releases/latest https://api.openai.com https://api.anthropic.com; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; object-src 'none'; script-src 'self' 'unsafe-eval'">
   </head>
   <body>
     <noscript>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -60,6 +60,9 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
           b-dropdown-item(to="/work-report")
             icon(name="briefcase")
             | {{ $t('nav.workReport') }}
+          b-dropdown-item(to="/ai-summary")
+            icon(name="robot")
+            | {{ $t('nav.aiSummary') }}
           b-dropdown-item(to="/trends" v-if="devmode")
             icon(name="chart-line")
             | {{ $t('nav.trends') }}
@@ -108,6 +111,7 @@ import 'vue-awesome/icons/chart-line';
 import 'vue-awesome/icons/chart-pie';
 import 'vue-awesome/icons/flag-checkered';
 import 'vue-awesome/icons/stopwatch';
+import 'vue-awesome/icons/robot';
 import 'vue-awesome/icons/cog';
 import 'vue-awesome/icons/tools';
 import 'vue-awesome/icons/history';

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -60,7 +60,7 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
           b-dropdown-item(to="/work-report")
             icon(name="briefcase")
             | {{ $t('nav.workReport') }}
-          b-dropdown-item(to="/activity-analysis" v-if="devmode")
+          b-dropdown-item(to="/analysis/activity" v-if="devmode")
             icon(name="robot")
             | {{ $t('nav.aiSummary') }}
           b-dropdown-item(to="/trends" v-if="devmode")

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -60,7 +60,7 @@ div(:class="{'fixed-top-padding': fixedTopMenu}")
           b-dropdown-item(to="/work-report")
             icon(name="briefcase")
             | {{ $t('nav.workReport') }}
-          b-dropdown-item(to="/ai-summary")
+          b-dropdown-item(to="/activity-analysis" v-if="devmode")
             icon(name="robot")
             | {{ $t('nav.aiSummary') }}
           b-dropdown-item(to="/trends" v-if="devmode")

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export default {
     tools: 'Tools',
     search: 'Search',
     workReport: 'Work Report',
+    aiSummary: 'AI Summary',
     trends: 'Trends',
     report: 'Report',
     alerts: 'Alerts',

--- a/src/route.js
+++ b/src/route.js
@@ -19,6 +19,7 @@ const Settings = () => import('./views/settings/Settings.vue');
 // pulling a second copy into a separate chunk.
 const Stopwatch = () => import('./views/Stopwatch.vue');
 const WorkReport = () => import('./views/WorkReport.vue');
+const AISummaryView = () => import('./views/AISummaryView.vue');
 const Alerts = () => import('./views/Alerts.vue');
 const Search = () => import('./views/Search.vue');
 const Report = () => import('./views/Report.vue');
@@ -82,6 +83,7 @@ const router = new VueRouter({
     },
     { path: '/stopwatch', component: Stopwatch },
     { path: '/work-report', component: WorkReport },
+    { path: '/ai-summary', component: AISummaryView },
     { path: '/search', component: Search },
     { path: '/graph', component: Graph },
     { path: '/dev', component: Dev },

--- a/src/route.js
+++ b/src/route.js
@@ -83,7 +83,7 @@ const router = new VueRouter({
     },
     { path: '/stopwatch', component: Stopwatch },
     { path: '/work-report', component: WorkReport },
-    { path: '/activity-analysis', component: AISummaryView },
+    { path: '/analysis/activity', component: AISummaryView },
     { path: '/search', component: Search },
     { path: '/graph', component: Graph },
     { path: '/dev', component: Dev },

--- a/src/route.js
+++ b/src/route.js
@@ -83,7 +83,7 @@ const router = new VueRouter({
     },
     { path: '/stopwatch', component: Stopwatch },
     { path: '/work-report', component: WorkReport },
-    { path: '/ai-summary', component: AISummaryView },
+    { path: '/activity-analysis', component: AISummaryView },
     { path: '/search', component: Search },
     { path: '/graph', component: Graph },
     { path: '/dev', component: Dev },

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -41,13 +41,12 @@ export function buildSummaryText(data: ActivitySummaryData): string {
   return lines.join('\n');
 }
 
-export type LLMProvider = 'openai' | 'anthropic' | 'custom';
+export type LLMProvider = 'openai' | 'anthropic';
 
 export interface LLMConfig {
   provider: LLMProvider;
   apiKey: string;
   model: string;
-  baseUrl?: string; // used when provider === 'custom'
 }
 
 const LS_KEY = 'aw-ai-summary-llm-config';
@@ -70,13 +69,8 @@ export function saveLLMConfig(config: Partial<LLMConfig>): void {
 export async function callLLM(config: LLMConfig, userMessage: string): Promise<string> {
   if (!config.apiKey) throw new Error('API key is required');
 
-  if (config.provider === 'openai' || config.provider === 'custom') {
-    const baseUrl =
-      config.provider === 'custom'
-        ? (config.baseUrl || '').replace(/\/$/, '')
-        : 'https://api.openai.com';
-    const url = `${baseUrl}/v1/chat/completions`;
-    const res = await fetch(url, {
+  if (config.provider === 'openai') {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -1,0 +1,120 @@
+export interface AppUsage {
+  app: string;
+  duration: number; // seconds
+}
+
+export interface ActivitySummaryData {
+  topApps: AppUsage[];
+  totalDuration: number; // seconds
+  periodDays: number;
+}
+
+export function aggregateEvents(events: any[]): AppUsage[] {
+  const byApp: Record<string, number> = {};
+  for (const event of events) {
+    const app = event.data?.app || event.data?.title || 'unknown';
+    byApp[app] = (byApp[app] || 0) + (event.duration || 0);
+  }
+  return Object.entries(byApp)
+    .map(([app, duration]) => ({ app, duration }))
+    .sort((a, b) => b.duration - a.duration);
+}
+
+export function formatDurationHuman(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function buildSummaryText(data: ActivitySummaryData): string {
+  const lines: string[] = [
+    `Activity summary — past ${data.periodDays} day(s):`,
+    `Total tracked time: ${formatDurationHuman(data.totalDuration)}`,
+    '',
+    'Top applications by time:',
+  ];
+  for (const item of data.topApps.slice(0, 20)) {
+    lines.push(`  ${item.app}: ${formatDurationHuman(item.duration)}`);
+  }
+  return lines.join('\n');
+}
+
+export type LLMProvider = 'openai' | 'anthropic' | 'custom';
+
+export interface LLMConfig {
+  provider: LLMProvider;
+  apiKey: string;
+  model: string;
+  baseUrl?: string; // used when provider === 'custom'
+}
+
+const LS_KEY = 'aw-ai-summary-llm-config';
+
+export function loadLLMConfig(): Partial<LLMConfig> {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveLLMConfig(config: Partial<LLMConfig>): void {
+  localStorage.setItem(LS_KEY, JSON.stringify(config));
+}
+
+export async function callLLM(config: LLMConfig, prompt: string): Promise<string> {
+  if (!config.apiKey) throw new Error('API key is required');
+
+  if (config.provider === 'openai' || config.provider === 'custom') {
+    const baseUrl =
+      config.provider === 'custom'
+        ? (config.baseUrl || '').replace(/\/$/, '')
+        : 'https://api.openai.com';
+    const url = `${baseUrl}/v1/chat/completions`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: config.model || 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 1024,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`LLM request failed (${res.status}): ${text.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content ?? '';
+  }
+
+  if (config.provider === 'anthropic') {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': config.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: config.model || 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`LLM request failed (${res.status}): ${text.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    return data.content?.[0]?.text ?? '';
+  }
+
+  throw new Error(`Unknown provider: ${config.provider}`);
+}

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -54,7 +54,11 @@ const LS_KEY = 'aw-ai-summary-llm-config';
 export function loadLLMConfig(): Partial<LLMConfig> {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) : {};
+    const config: Partial<LLMConfig> = raw ? JSON.parse(raw) : {};
+    if (config.provider !== 'openai' && config.provider !== 'anthropic') {
+      delete config.provider;
+    }
+    return config;
   } catch {
     return {};
   }

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -65,7 +65,7 @@ export function saveLLMConfig(config: Partial<LLMConfig>): void {
   localStorage.setItem(LS_KEY, JSON.stringify(config));
 }
 
-export async function callLLM(config: LLMConfig, prompt: string): Promise<string> {
+export async function callLLM(config: LLMConfig, userMessage: string): Promise<string> {
   if (!config.apiKey) throw new Error('API key is required');
 
   if (config.provider === 'openai' || config.provider === 'custom') {
@@ -82,7 +82,7 @@ export async function callLLM(config: LLMConfig, prompt: string): Promise<string
       },
       body: JSON.stringify({
         model: config.model || 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: userMessage }],
         max_tokens: 1024,
       }),
     });
@@ -105,7 +105,7 @@ export async function callLLM(config: LLMConfig, prompt: string): Promise<string
       body: JSON.stringify({
         model: config.model || 'claude-haiku-4-5-20251001',
         max_tokens: 1024,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: userMessage }],
       }),
     });
     if (!res.ok) {

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -51,26 +51,20 @@ export interface LLMConfig {
 }
 
 const LS_KEY = 'aw-ai-summary-llm-config';
-const SS_KEY = 'aw-ai-summary-llm-apikey';
 
 export function loadLLMConfig(): Partial<LLMConfig> {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    const config: Partial<LLMConfig> = raw ? JSON.parse(raw) : {};
-    const apiKey = sessionStorage.getItem(SS_KEY);
-    if (apiKey) config.apiKey = apiKey;
-    return config;
+    return raw ? JSON.parse(raw) : {};
   } catch {
     return {};
   }
 }
 
 export function saveLLMConfig(config: Partial<LLMConfig>): void {
-  const { apiKey, ...rest } = config;
-  localStorage.setItem(LS_KEY, JSON.stringify(rest));
-  if (apiKey !== undefined) {
-    sessionStorage.setItem(SS_KEY, apiKey);
-  }
+  const persistedConfig = { ...config };
+  delete persistedConfig.apiKey;
+  localStorage.setItem(LS_KEY, JSON.stringify(persistedConfig));
 }
 
 export async function callLLM(config: LLMConfig, userMessage: string): Promise<string> {

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -51,18 +51,26 @@ export interface LLMConfig {
 }
 
 const LS_KEY = 'aw-ai-summary-llm-config';
+const SS_KEY = 'aw-ai-summary-llm-apikey';
 
 export function loadLLMConfig(): Partial<LLMConfig> {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) : {};
+    const config: Partial<LLMConfig> = raw ? JSON.parse(raw) : {};
+    const apiKey = sessionStorage.getItem(SS_KEY);
+    if (apiKey) config.apiKey = apiKey;
+    return config;
   } catch {
     return {};
   }
 }
 
 export function saveLLMConfig(config: Partial<LLMConfig>): void {
-  localStorage.setItem(LS_KEY, JSON.stringify(config));
+  const { apiKey, ...rest } = config;
+  localStorage.setItem(LS_KEY, JSON.stringify(rest));
+  if (apiKey !== undefined) {
+    sessionStorage.setItem(SS_KEY, apiKey);
+  }
 }
 
 export async function callLLM(config: LLMConfig, userMessage: string): Promise<string> {

--- a/src/util/aiSummary.ts
+++ b/src/util/aiSummary.ts
@@ -57,6 +57,7 @@ export function loadLLMConfig(): Partial<LLMConfig> {
     const config: Partial<LLMConfig> = raw ? JSON.parse(raw) : {};
     if (config.provider !== 'openai' && config.provider !== 'anthropic') {
       delete config.provider;
+      delete config.model;
     }
     return config;
   } catch {

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -3,9 +3,8 @@ div
   h3.mb-3 AI Activity Summary
 
   b-alert(variant="info" show)
-    | Your API key is stored only in your browser's&nbsp;
-    code localStorage
-    |  and is sent directly to the LLM provider. ActivityWatch does not receive it.
+    | Your API key is kept only in memory and sent directly to the LLM provider.
+    |  ActivityWatch does not receive it.
 
   div.row.mb-3
     div.col-md-4
@@ -75,6 +74,7 @@ div
 
 <script lang="ts">
 import { useBucketsStore } from '~/stores/buckets';
+import { getClient } from '~/util/awclient';
 import {
   aggregateEvents,
   buildSummaryText,
@@ -228,16 +228,7 @@ export default {
       const end = new Date();
       const start = new Date(end.getTime() - this.periodDays * 24 * 60 * 60 * 1000);
 
-      // Use REST directly for simplicity — aw-client's getEvents signature
-      const resp = await fetch(
-        `/api/0/buckets/${
-          windowBucket.id
-        }/events?start=${start.toISOString()}&end=${end.toISOString()}&limit=10000`
-      );
-      if (!resp.ok) {
-        throw new Error(`Failed to fetch events: ${resp.status}`);
-      }
-      return resp.json();
+      return getClient().getEvents(windowBucket.id, { start, end, limit: -1 });
     },
     async copyResponse() {
       try {

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -74,7 +74,6 @@ div
 </template>
 
 <script lang="ts">
-import { getClient } from '~/util/awclient';
 import { useBucketsStore } from '~/stores/buckets';
 import {
   aggregateEvents,
@@ -218,7 +217,6 @@ export default {
       }
     },
     async fetchEvents(): Promise<any[]> {
-      const client = getClient();
       const buckets = this.bucketsStore.buckets || [];
       const windowBucket = buckets.find(
         b => b.type === 'currentwindow' && b.hostname === this.selectedHost

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -5,6 +5,8 @@ div
   b-alert(variant="info" show)
     | Your API key is kept only in this page's memory and sent directly to the LLM provider.
     |  It is cleared when the page reloads and ActivityWatch does not receive it.
+    |  For deeper analysis with agents, see the
+    |  #[a(href="https://docs.activitywatch.net/en/latest/examples/querying-data.html") ActivityWatch querying guide].
 
   div.row.mb-3
     div.col-md-4

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -1,0 +1,257 @@
+<template lang="pug">
+div
+  h3.mb-3 AI Activity Summary
+
+  b-alert(variant="info" show)
+    | Your API key is stored only in your browser's&nbsp;
+    code localStorage
+    |  and is sent directly to the LLM provider. ActivityWatch does not receive it.
+
+  div.row.mb-3
+    div.col-md-4
+      b-form-group(label="Host" label-class="font-weight-bold")
+        b-form-select(v-model="selectedHost" :options="hostOptions")
+
+    div.col-md-4
+      b-form-group(label="Date Range" label-class="font-weight-bold")
+        b-form-select(v-model="dateRange" :options="dateRangeOptions")
+
+    div.col-md-4
+      b-form-group(label="LLM Provider" label-class="font-weight-bold")
+        b-form-select(v-model="provider" :options="providerOptions" @change="onProviderChange")
+
+  div.row.mb-3
+    div.col-md-6
+      b-form-group(label="API Key" label-class="font-weight-bold")
+        b-form-input(
+          v-model="apiKey"
+          type="password"
+          placeholder="sk-..."
+          autocomplete="off"
+          @blur="persistConfig"
+        )
+
+    div.col-md-3
+      b-form-group(label="Model" label-class="font-weight-bold")
+        b-form-input(v-model="model" placeholder="e.g. gpt-4o-mini" @blur="persistConfig")
+
+    div.col-md-3(v-if="provider === 'custom'")
+      b-form-group(label="Base URL" label-class="font-weight-bold")
+        b-form-input(v-model="customBaseUrl" placeholder="https://my-proxy.example.com" @blur="persistConfig")
+
+  div.mb-3
+    b-form-group(label="Prompt" label-class="font-weight-bold")
+      b-form-textarea(v-model="userPrompt" rows="3" max-rows="8")
+
+  div.mb-4
+    b-button(@click="generate" variant="primary" :disabled="loading || !apiKey || !selectedHost")
+      b-spinner.mr-2(v-if="loading" small)
+      | {{ loading ? 'Generating…' : 'Generate Summary' }}
+    b-button.ml-2(
+      v-if="aggregatedText"
+      variant="outline-secondary"
+      @click="dataVisible = !dataVisible"
+    ) {{ dataVisible ? 'Hide raw data' : 'Show raw data' }}
+
+  b-alert(v-if="error" variant="danger" show dismissible @dismissed="error = ''")
+    | {{ error }}
+
+  div(v-if="dataVisible && aggregatedText")
+    b-card.mb-3
+      template(slot="header")
+        strong Raw activity data sent to LLM
+      pre.mb-0(style="white-space: pre-wrap; font-size: 0.85em") {{ aggregatedText }}
+
+  div(v-if="llmResponse")
+    b-card
+      template(slot="header")
+        div.d-flex.justify-content-between.align-items-center
+          strong AI Summary
+          b-button(size="sm" variant="outline-secondary" @click="copyResponse")
+            icon(name="copy")
+            |  {{ copied ? 'Copied!' : 'Copy' }}
+      div(style="white-space: pre-wrap") {{ llmResponse }}
+</template>
+
+<script lang="ts">
+import { getClient } from '~/util/awclient';
+import { useBucketsStore } from '~/stores/buckets';
+import {
+  aggregateEvents,
+  buildSummaryText,
+  loadLLMConfig,
+  saveLLMConfig,
+  callLLM,
+  type LLMProvider,
+} from '~/util/aiSummary';
+import 'vue-awesome/icons/copy';
+
+const DEFAULT_PROMPT =
+  'Based on the following activity data, provide a concise summary of how I spent my time. ' +
+  'Highlight the main activities, identify focus areas, and suggest any observations about productivity patterns.';
+
+export default {
+  name: 'AISummaryView',
+  data() {
+    const saved = loadLLMConfig();
+    return {
+      bucketsStore: useBucketsStore(),
+
+      selectedHost: '',
+      dateRange: 'last7d',
+      provider: (saved.provider || 'openai') as LLMProvider,
+      apiKey: saved.apiKey || '',
+      model: saved.model || '',
+      customBaseUrl: saved.baseUrl || '',
+      userPrompt: DEFAULT_PROMPT,
+
+      loading: false,
+      error: '',
+      aggregatedText: '',
+      llmResponse: '',
+      dataVisible: false,
+      copied: false,
+    };
+  },
+  computed: {
+    hostOptions(): { value: string; text: string }[] {
+      const buckets = this.bucketsStore.buckets || [];
+      const hosts = new Set<string>();
+      for (const b of buckets) {
+        if (b.type === 'currentwindow') {
+          hosts.add(b.hostname);
+        }
+      }
+      return Array.from(hosts).map(h => ({ value: h, text: h }));
+    },
+    dateRangeOptions() {
+      return [
+        { value: 'last7d', text: 'Last 7 days' },
+        { value: 'last30d', text: 'Last 30 days' },
+        { value: 'last90d', text: 'Last 90 days' },
+      ];
+    },
+    providerOptions() {
+      return [
+        { value: 'openai', text: 'OpenAI' },
+        { value: 'anthropic', text: 'Anthropic' },
+        { value: 'custom', text: 'Custom (OpenAI-compatible)' },
+      ];
+    },
+    periodDays(): number {
+      return this.dateRange === 'last7d' ? 7 : this.dateRange === 'last30d' ? 30 : 90;
+    },
+    defaultModel(): string {
+      if (this.provider === 'anthropic') return 'claude-haiku-4-5-20251001';
+      return 'gpt-4o-mini';
+    },
+  },
+  async mounted() {
+    await this.bucketsStore.ensureLoaded();
+    if (this.hostOptions.length > 0 && !this.selectedHost) {
+      this.selectedHost = this.hostOptions[0].value;
+    }
+    if (!this.model) {
+      this.model = this.defaultModel;
+    }
+  },
+  methods: {
+    onProviderChange() {
+      if (
+        !this.model ||
+        this.model === 'gpt-4o-mini' ||
+        this.model === 'claude-haiku-4-5-20251001'
+      ) {
+        this.model = this.defaultModel;
+      }
+      this.persistConfig();
+    },
+    persistConfig() {
+      saveLLMConfig({
+        provider: this.provider,
+        apiKey: this.apiKey,
+        model: this.model,
+        baseUrl: this.customBaseUrl,
+      });
+    },
+    async generate() {
+      this.error = '';
+      this.llmResponse = '';
+      this.aggregatedText = '';
+
+      if (!this.selectedHost) {
+        this.error = 'No host with a window-watcher bucket found.';
+        return;
+      }
+      if (!this.apiKey.trim()) {
+        this.error = 'Please enter your LLM API key.';
+        return;
+      }
+
+      this.loading = true;
+      try {
+        const events = await this.fetchEvents();
+        const topApps = aggregateEvents(events);
+        const totalDuration = topApps.reduce((s, a) => s + a.duration, 0);
+        const summaryData = { topApps, totalDuration, periodDays: this.periodDays };
+        const summaryText = buildSummaryText(summaryData);
+
+        this.aggregatedText = summaryText;
+
+        const fullPrompt = `${this.userPrompt}\n\n${summaryText}`;
+        const effectiveModel = this.model.trim() || this.defaultModel;
+
+        const response = await callLLM(
+          {
+            provider: this.provider,
+            apiKey: this.apiKey.trim(),
+            model: effectiveModel,
+            baseUrl: this.customBaseUrl,
+          },
+          fullPrompt
+        );
+        this.llmResponse = response;
+      } catch (err: any) {
+        this.error = err?.message || String(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+    async fetchEvents(): Promise<any[]> {
+      const client = getClient();
+      const buckets = this.bucketsStore.buckets || [];
+      const windowBucket = buckets.find(
+        b => b.type === 'currentwindow' && b.hostname === this.selectedHost
+      );
+      if (!windowBucket) {
+        throw new Error(`No window-watcher bucket found for host: ${this.selectedHost}`);
+      }
+
+      const end = new Date();
+      const start = new Date(end.getTime() - this.periodDays * 24 * 60 * 60 * 1000);
+
+      // Use REST directly for simplicity — aw-client's getEvents signature
+      const resp = await fetch(
+        `/api/0/buckets/${
+          windowBucket.id
+        }/events?start=${start.toISOString()}&end=${end.toISOString()}&limit=10000`
+      );
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch events: ${resp.status}`);
+      }
+      return resp.json();
+    },
+    async copyResponse() {
+      try {
+        await navigator.clipboard.writeText(this.llmResponse);
+        this.copied = true;
+        setTimeout(() => {
+          this.copied = false;
+        }, 2000);
+      } catch {
+        this.error = 'Could not copy to clipboard';
+      }
+    },
+  },
+};
+</script>

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -30,13 +30,9 @@ div
           @blur="persistConfig"
         )
 
-    div.col-md-3
+    div.col-md-6
       b-form-group(label="Model" label-class="font-weight-bold")
         b-form-input(v-model="model" placeholder="e.g. gpt-4o-mini" @blur="persistConfig")
-
-    div.col-md-3(v-if="provider === 'custom'")
-      b-form-group(label="Base URL" label-class="font-weight-bold")
-        b-form-input(v-model="customBaseUrl" placeholder="https://my-proxy.example.com" @blur="persistConfig")
 
   div.mb-3
     b-form-group(label="Prompt" label-class="font-weight-bold")
@@ -101,7 +97,6 @@ export default {
       provider: (saved.provider || 'openai') as LLMProvider,
       apiKey: saved.apiKey || '',
       model: saved.model || '',
-      customBaseUrl: saved.baseUrl || '',
       userPrompt: DEFAULT_PROMPT,
 
       loading: false,
@@ -134,7 +129,6 @@ export default {
       return [
         { value: 'openai', text: 'OpenAI' },
         { value: 'anthropic', text: 'Anthropic' },
-        { value: 'custom', text: 'Custom (OpenAI-compatible)' },
       ];
     },
     periodDays(): number {
@@ -170,7 +164,6 @@ export default {
         provider: this.provider,
         apiKey: this.apiKey,
         model: this.model,
-        baseUrl: this.customBaseUrl,
       });
     },
     async generate() {
@@ -205,7 +198,6 @@ export default {
             provider: this.provider,
             apiKey: this.apiKey.trim(),
             model: effectiveModel,
-            baseUrl: this.customBaseUrl,
           },
           fullPrompt
         );

--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -3,8 +3,8 @@ div
   h3.mb-3 AI Activity Summary
 
   b-alert(variant="info" show)
-    | Your API key is kept only in memory and sent directly to the LLM provider.
-    |  ActivityWatch does not receive it.
+    | Your API key is kept only in this page's memory and sent directly to the LLM provider.
+    |  It is cleared when the page reloads and ActivityWatch does not receive it.
 
   div.row.mb-3
     div.col-md-4

--- a/test/unit/aiSummary.test.node.ts
+++ b/test/unit/aiSummary.test.node.ts
@@ -90,7 +90,7 @@ describe('LLM config storage', () => {
       JSON.stringify({ provider: 'custom', model: 'local-model' })
     );
 
-    expect(loadLLMConfig()).toEqual({ model: 'local-model' });
+    expect(loadLLMConfig()).toEqual({});
   });
 });
 

--- a/test/unit/aiSummary.test.node.ts
+++ b/test/unit/aiSummary.test.node.ts
@@ -1,6 +1,7 @@
 import {
   aggregateEvents,
   buildSummaryText,
+  callLLM,
   formatDurationHuman,
   loadLLMConfig,
   saveLLMConfig,
@@ -81,6 +82,51 @@ describe('LLM config storage', () => {
 
     expect(loadLLMConfig()).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
     expect(localStorage.getItem('aw-ai-summary-llm-config')).not.toContain('secret');
+  });
+});
+
+describe('callLLM', () => {
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      configurable: true,
+    });
+  });
+  beforeEach(() => fetchMock.mockReset());
+
+  test('sends OpenAI requests to the CSP-allowed endpoint', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'Summary' } }] }),
+    });
+
+    await expect(
+      callLLM({ provider: 'openai', apiKey: 'secret', model: 'gpt-4o-mini' }, 'Activity')
+    ).resolves.toBe('Summary');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  test('sends Anthropic requests to the CSP-allowed endpoint', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [{ text: 'Summary' }] }),
+    });
+
+    await expect(
+      callLLM(
+        { provider: 'anthropic', apiKey: 'secret', model: 'claude-haiku-4-5-20251001' },
+        'Activity'
+      )
+    ).resolves.toBe('Summary');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.any(Object)
+    );
   });
 });
 

--- a/test/unit/aiSummary.test.node.ts
+++ b/test/unit/aiSummary.test.node.ts
@@ -1,0 +1,91 @@
+import { aggregateEvents, buildSummaryText, formatDurationHuman } from '~/util/aiSummary';
+
+describe('aggregateEvents', () => {
+  test('returns empty array for no events', () => {
+    expect(aggregateEvents([])).toEqual([]);
+  });
+
+  test('aggregates duration by app', () => {
+    const events = [
+      { data: { app: 'Firefox' }, duration: 300 },
+      { data: { app: 'Firefox' }, duration: 120 },
+      { data: { app: 'Terminal' }, duration: 60 },
+    ];
+    const result = aggregateEvents(events);
+    expect(result[0]).toEqual({ app: 'Firefox', duration: 420 });
+    expect(result[1]).toEqual({ app: 'Terminal', duration: 60 });
+  });
+
+  test('sorts by duration descending', () => {
+    const events = [
+      { data: { app: 'Slack' }, duration: 10 },
+      { data: { app: 'VS Code' }, duration: 1000 },
+      { data: { app: 'Chrome' }, duration: 500 },
+    ];
+    const result = aggregateEvents(events);
+    expect(result.map(r => r.app)).toEqual(['VS Code', 'Chrome', 'Slack']);
+  });
+
+  test('falls back to title when app is missing', () => {
+    const events = [{ data: { title: 'My Window' }, duration: 90 }];
+    const result = aggregateEvents(events);
+    expect(result[0].app).toBe('My Window');
+  });
+
+  test('falls back to unknown when data is empty', () => {
+    const events = [{ data: {}, duration: 30 }];
+    const result = aggregateEvents(events);
+    expect(result[0].app).toBe('unknown');
+  });
+});
+
+describe('formatDurationHuman', () => {
+  test('formats seconds under 60', () => {
+    expect(formatDurationHuman(45)).toBe('45s');
+  });
+
+  test('formats minutes under 3600', () => {
+    expect(formatDurationHuman(90)).toBe('2m');
+    expect(formatDurationHuman(3540)).toBe('59m');
+  });
+
+  test('formats hours with minutes', () => {
+    expect(formatDurationHuman(3660)).toBe('1h 1m');
+    expect(formatDurationHuman(7200)).toBe('2h');
+  });
+});
+
+describe('buildSummaryText', () => {
+  test('includes period and total duration', () => {
+    const data = {
+      topApps: [{ app: 'Firefox', duration: 3600 }],
+      totalDuration: 3600,
+      periodDays: 7,
+    };
+    const text = buildSummaryText(data);
+    expect(text).toContain('past 7 day(s)');
+    expect(text).toContain('Total tracked time: 1h');
+  });
+
+  test('includes top apps', () => {
+    const data = {
+      topApps: [
+        { app: 'VS Code', duration: 7200 },
+        { app: 'Chrome', duration: 1800 },
+      ],
+      totalDuration: 9000,
+      periodDays: 1,
+    };
+    const text = buildSummaryText(data);
+    expect(text).toContain('VS Code');
+    expect(text).toContain('Chrome');
+  });
+
+  test('caps at 20 apps', () => {
+    const apps = Array.from({ length: 25 }, (_, i) => ({ app: `App${i}`, duration: 100 - i }));
+    const data = { topApps: apps, totalDuration: 2500, periodDays: 7 };
+    const text = buildSummaryText(data);
+    expect(text).toContain('App0');
+    expect(text).not.toContain('App20');
+  });
+});

--- a/test/unit/aiSummary.test.node.ts
+++ b/test/unit/aiSummary.test.node.ts
@@ -83,6 +83,15 @@ describe('LLM config storage', () => {
     expect(loadLLMConfig()).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
     expect(localStorage.getItem('aw-ai-summary-llm-config')).not.toContain('secret');
   });
+
+  test('discards a stale unsupported provider', () => {
+    localStorage.setItem(
+      'aw-ai-summary-llm-config',
+      JSON.stringify({ provider: 'custom', model: 'local-model' })
+    );
+
+    expect(loadLLMConfig()).toEqual({ model: 'local-model' });
+  });
 });
 
 describe('callLLM', () => {

--- a/test/unit/aiSummary.test.node.ts
+++ b/test/unit/aiSummary.test.node.ts
@@ -1,4 +1,10 @@
-import { aggregateEvents, buildSummaryText, formatDurationHuman } from '~/util/aiSummary';
+import {
+  aggregateEvents,
+  buildSummaryText,
+  formatDurationHuman,
+  loadLLMConfig,
+  saveLLMConfig,
+} from '~/util/aiSummary';
 
 describe('aggregateEvents', () => {
   test('returns empty array for no events', () => {
@@ -52,6 +58,29 @@ describe('formatDurationHuman', () => {
   test('formats hours with minutes', () => {
     expect(formatDurationHuman(3660)).toBe('1h 1m');
     expect(formatDurationHuman(7200)).toBe('2h');
+  });
+});
+
+describe('LLM config storage', () => {
+  const values = new Map<string, string>();
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+        clear: () => values.clear(),
+      },
+      configurable: true,
+    });
+  });
+  beforeEach(() => values.clear());
+
+  test('persists provider settings without the API key', () => {
+    saveLLMConfig({ provider: 'openai', model: 'gpt-4o-mini', apiKey: 'secret' });
+
+    expect(loadLLMConfig()).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+    expect(localStorage.getItem('aw-ai-summary-llm-config')).not.toContain('secret');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an **experimental**, dev-mode-only `/analysis/activity` page for trying a client-side LLM summary of ActivityWatch window data.

- Fetches local window events through the configured ActivityWatch client
- Aggregates events by application before any provider request
- Supports fixed OpenAI and Anthropic endpoints
- Keeps the API key in page memory only; it is cleared on reload and never sent to aw-server
- Persists only non-secret provider/model preferences
- Shows the exact compact activity text sent to the provider
- Includes date-range selection, custom prompt, response display, and copy action
- Hides the Tools entry unless dev mode is enabled
- Links to the ActivityWatch querying guide for deeper agent-based analysis

## Experimental/privacy scope

This is a prototype, not the recommended end-user path for ActivityWatch + AI. Clicking **Generate** sends the displayed application names and durations to the selected third-party provider. The UI says so before the request, and the feature is hidden from the default navigation.

The broader product direction—local or subscription-backed agent workflows plus proper documentation built around ActivityWatch exporting/analysis and the canonical query—is tracked in ActivityWatch/activitywatch#1388. Richer, privacy-bounded single-pass context is tracked in ActivityWatch/aw-webui#925. Neither belongs in this prototype PR.

## Test plan

- [x] CI unit tests, lint, builds, and CodeQL pass
- [x] Tools entry is visible in dev mode and hidden otherwise
- [x] Route uses the intent-based `/analysis/activity` namespace
- [x] API key is not persisted
- [x] Unsupported stale provider settings are discarded
- [x] Provider requests use only CSP-allowed fixed endpoints
- [x] Raw aggregated text can be inspected before/after generation
- [x] Page links to the current querying documentation

Prototype toward #883; does not close the broader issue.
