### PR TITLE
feat(settings): add aw-notify configuration panel

### DIFF
--- a/src/util/aw-notify.ts
+++ b/src/util/aw-notify.ts
@@ -1,0 +1,7 @@
+export function parseThresholds(input: string): number[] | null {
+  const values = input.split(',').map(s => s.trim());
+  if (values.some(part => !/^[1-9]\d*$/.test(part))) {
+    return null;
+  }
+  return values.map(Number);
+}

--- a/src/views/settings/AwNotifySettings.vue
+++ b/src/views/settings/AwNotifySettings.vue
@@ -35,13 +35,20 @@ div
             )
             small.form-text.text-muted
               | Match the category name in your AW categorization rules, or leave empty for total time.
-          b-form-group(label="Thresholds" label-cols-sm="3" label-size="sm")
+          b-form-group(
+            label="Thresholds"
+            label-cols-sm="3"
+            label-size="sm"
+            :invalid-feedback="thresholdError(alert.thresholdStr)"
+            :state="thresholdState(alert.thresholdStr)"
+          )
             b-input(
               v-model="alert.thresholdStr"
               size="sm"
               placeholder="e.g. 60, 120, 240"
+              :state="thresholdState(alert.thresholdStr)"
             )
-            small.form-text.text-muted Comma-separated minutes. A notification fires as each threshold is crossed.
+            small.form-text.text-muted Comma-separated positive whole minutes. A notification fires as each threshold is crossed.
           b-form-group(label="Type" label-cols-sm="3" label-size="sm")
             b-form-radio-group(v-model="alert.positive" :options="goalOptions" size="sm")
         b-btn.ml-2(@click="removeAlert(idx)" variant="outline-danger" size="sm" title="Remove alert")
@@ -57,6 +64,7 @@ import 'vue-awesome/icons/plus';
 import 'vue-awesome/icons/trash';
 
 import { getClient } from '~/util/awclient';
+import { parseThresholds } from '~/util/aw-notify';
 
 const SETTINGS_KEY = 'aw-notify';
 
@@ -84,10 +92,10 @@ function dtoToRow(dto: AlertDTO): AlertRow {
 }
 
 function rowToDto(row: AlertRow): AlertDTO {
-  const thresholds = row.thresholdStr
-    .split(',')
-    .map(s => parseInt(s.trim(), 10))
-    .filter(n => !isNaN(n) && n > 0);
+  const thresholds = parseThresholds(row.thresholdStr);
+  if (!thresholds) {
+    throw new Error('Thresholds must be comma-separated positive whole minutes.');
+  }
   return {
     label: row.label,
     category: row.category && row.category.trim() !== '' ? row.category.trim() : null,
@@ -122,11 +130,7 @@ export default {
         const client = getClient();
         const resp = await client.req.get(`/0/settings/${SETTINGS_KEY}`);
         const data: AlertDTO[] = resp.data;
-        if (Array.isArray(data) && data.length > 0) {
-          this.alerts = data.map(dtoToRow);
-        } else {
-          this.alerts = this.defaultAlerts();
-        }
+        this.alerts = Array.isArray(data) ? data.map(dtoToRow) : this.defaultAlerts();
       } catch (e: any) {
         if (e?.response?.status === 404) {
           this.alerts = this.defaultAlerts();
@@ -138,9 +142,13 @@ export default {
       }
     },
     async save() {
-      this.saving = true;
       this.error = '';
       this.success = false;
+      if (this.alerts.some(row => parseThresholds(row.thresholdStr) === null)) {
+        this.error = 'Thresholds must be comma-separated positive whole minutes.';
+        return;
+      }
+      this.saving = true;
       try {
         const client = getClient();
         const payload: AlertDTO[] = this.alerts.map(rowToDto);
@@ -153,6 +161,12 @@ export default {
       } finally {
         this.saving = false;
       }
+    },
+    thresholdError(value: string): string {
+      return parseThresholds(value) === null ? 'Use comma-separated positive whole minutes.' : '';
+    },
+    thresholdState(value: string): boolean | null {
+      return parseThresholds(value) === null ? false : null;
     },
     addAlert() {
       this.alerts.push({

--- a/src/views/settings/AwNotifySettings.vue
+++ b/src/views/settings/AwNotifySettings.vue
@@ -1,0 +1,176 @@
+<template lang="pug">
+div
+  div.d-flex.justify-content-between.align-items-center.mb-3
+    div
+      h5.mb-1 Mobile Notifications
+      small.text-muted Configure aw-notify alert thresholds for the Android app
+    b-btn(@click="save" size="sm" variant="primary" :disabled="saving || loading")
+      | {{ saving ? 'Saving…' : 'Save' }}
+
+  b-alert(v-if="error" show variant="danger") {{ error }}
+  b-alert(v-if="success" show variant="success" dismissible @dismissed="success = false") Settings saved.
+
+  div(v-if="loading")
+    b-spinner(small) Loading…
+
+  div(v-else)
+    p.text-muted.small.mb-3
+      | Alerts are checked periodically by the Android app. Each alert fires a notification
+      | when the accumulated time crosses a threshold.
+      | Uses the #[code /api/0/settings/aw-notify] server setting.
+
+    div(v-if="alerts.length === 0")
+      p.text-muted.font-italic No alerts configured.
+
+    b-card.mb-2(v-for="(alert, idx) in alerts" :key="idx")
+      div.d-flex.align-items-start
+        div.flex-grow-1
+          b-form-group(label="Label" label-cols-sm="3" label-size="sm")
+            b-input(v-model="alert.label" size="sm" placeholder="e.g. Work")
+          b-form-group(label="Category" label-cols-sm="3" label-size="sm")
+            b-input(
+              v-model="alert.category"
+              size="sm"
+              placeholder="Leave empty to track all time"
+            )
+            small.form-text.text-muted
+              | Match the category name in your AW categorization rules, or leave empty for total time.
+          b-form-group(label="Thresholds" label-cols-sm="3" label-size="sm")
+            b-input(
+              v-model="alert.thresholdStr"
+              size="sm"
+              placeholder="e.g. 60, 120, 240"
+            )
+            small.form-text.text-muted Comma-separated minutes. A notification fires as each threshold is crossed.
+          b-form-group(label="Type" label-cols-sm="3" label-size="sm")
+            b-form-radio-group(v-model="alert.positive" :options="goalOptions" size="sm")
+        b-btn.ml-2(@click="removeAlert(idx)" variant="outline-danger" size="sm" title="Remove alert")
+          icon(name="trash")
+
+    b-btn.mt-1(@click="addAlert" variant="outline-secondary" size="sm")
+      icon(name="plus")
+      |  Add alert
+</template>
+
+<script lang="ts">
+import 'vue-awesome/icons/plus';
+import 'vue-awesome/icons/trash';
+
+import { getClient } from '~/util/awclient';
+
+const SETTINGS_KEY = 'aw-notify';
+
+interface AlertRow {
+  label: string;
+  category: string | null; // null = aggregate "All"
+  thresholdStr: string;
+  positive: boolean;
+}
+
+interface AlertDTO {
+  label: string;
+  category: string | null;
+  thresholdMinutes: number[];
+  positive: boolean;
+}
+
+function dtoToRow(dto: AlertDTO): AlertRow {
+  return {
+    label: dto.label,
+    category: dto.category ?? '',
+    thresholdStr: dto.thresholdMinutes.join(', '),
+    positive: dto.positive,
+  };
+}
+
+function rowToDto(row: AlertRow): AlertDTO {
+  const thresholds = row.thresholdStr
+    .split(',')
+    .map(s => parseInt(s.trim(), 10))
+    .filter(n => !isNaN(n) && n > 0);
+  return {
+    label: row.label,
+    category: row.category && row.category.trim() !== '' ? row.category.trim() : null,
+    thresholdMinutes: thresholds,
+    positive: row.positive,
+  };
+}
+
+export default {
+  name: 'AwNotifySettings',
+  data() {
+    return {
+      alerts: [] as AlertRow[],
+      loading: false,
+      saving: false,
+      error: '',
+      success: false,
+      goalOptions: [
+        { text: 'Warning (exceeded limit)', value: false },
+        { text: 'Goal (reached target)', value: true },
+      ],
+    };
+  },
+  async mounted() {
+    await this.load();
+  },
+  methods: {
+    async load() {
+      this.loading = true;
+      this.error = '';
+      try {
+        const client = getClient();
+        const resp = await client.req.get(`/0/settings/${SETTINGS_KEY}`);
+        const data: AlertDTO[] = resp.data;
+        if (Array.isArray(data) && data.length > 0) {
+          this.alerts = data.map(dtoToRow);
+        } else {
+          this.alerts = this.defaultAlerts();
+        }
+      } catch (e: any) {
+        if (e?.response?.status === 404) {
+          this.alerts = this.defaultAlerts();
+        } else {
+          this.error = `Failed to load settings: ${e?.message ?? e}`;
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    async save() {
+      this.saving = true;
+      this.error = '';
+      this.success = false;
+      try {
+        const client = getClient();
+        const payload: AlertDTO[] = this.alerts.map(rowToDto);
+        await client.req.post(`/0/settings/${SETTINGS_KEY}`, payload, {
+          headers: { 'Content-Type': 'application/json' },
+        });
+        this.success = true;
+      } catch (e: any) {
+        this.error = `Failed to save settings: ${e?.message ?? e}`;
+      } finally {
+        this.saving = false;
+      }
+    },
+    addAlert() {
+      this.alerts.push({
+        label: '',
+        category: '',
+        thresholdStr: '60, 120',
+        positive: false,
+      });
+    },
+    removeAlert(idx: number) {
+      this.alerts.splice(idx, 1);
+    },
+    defaultAlerts(): AlertRow[] {
+      return [
+        { label: 'All', category: '', thresholdStr: '60, 120, 240', positive: false },
+        { label: 'Work', category: 'Work', thresholdStr: '15, 30, 60', positive: true },
+      ];
+    },
+  },
+};
+</script>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -38,6 +38,7 @@ import Theme from '~/views/settings/Theme.vue';
 import ColorSettings from '~/views/settings/ColorSettings.vue';
 import ActivePatternSettings from '~/views/settings/ActivePatternSettings.vue';
 import PrivacyFilterSettings from '~/views/settings/PrivacyFilterSettings.vue';
+import AwNotifySettings from '~/views/settings/AwNotifySettings.vue';
 
 interface Group {
   id: string;
@@ -61,6 +62,7 @@ export default {
     DeveloperSettings,
     ActivePatternSettings,
     PrivacyFilterSettings,
+    AwNotifySettings,
   },
   beforeRouteLeave(to, from, next) {
     const categoryStore = useCategoryStore();
@@ -120,7 +122,14 @@ export default {
         components: [{ name: 'DeveloperSettings' }],
       };
 
-      return [general, appearance, categorization, privacy, developer];
+      const notifications: Group = {
+        id: 'notifications',
+        label: 'Notifications',
+        help: 'Configure alert thresholds for the aw-notify Android integration.',
+        components: [{ name: 'AwNotifySettings' }],
+      };
+
+      return [general, appearance, categorization, notifications, privacy, developer];
     },
   },
   async created() {

--- a/test/unit/aw-notify.test.js
+++ b/test/unit/aw-notify.test.js
@@ -1,0 +1,14 @@
+import { parseThresholds } from '~/util/aw-notify';
+
+describe('parseThresholds', () => {
+  test('parses comma-separated positive whole minutes', () => {
+    expect(parseThresholds('15, 30, 60')).toEqual([15, 30, 60]);
+  });
+
+  test.each(['', '60.5', '60, abc', '60, -5', '60, 0', '60,'])(
+    'rejects invalid threshold input %p',
+    input => {
+      expect(parseThresholds(input)).toBeNull();
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Adds a **Notifications** settings group with an `AwNotifySettings` component that reads and writes `/api/0/settings/aw-notify` — the same key the Android aw-notify `NotifyWorker` reads at startup (ActivityWatch/aw-android#202).

- New settings component: `src/views/settings/AwNotifySettings.vue`
- New "Notifications" tab in Settings.vue wired to the component
- Reads existing config on mount with graceful 404 fallback to defaults
- Lets users configure alert label, category filter, minute thresholds, and goal/warning type
- Matches the JSON schema from ActivityWatch/aw-android#202:
  ```json
  [
    {"category": null, "label": "All", "thresholdMinutes": [60, 120, 240], "positive": false},
    {"category": "Work", "label": "Work", "thresholdMinutes": [15, 30, 60], "positive": true}
  ]
  ```

## Context

This is Goal 2 from ActivityWatch/aw-android#201: a shared webui config surface so users manage notification thresholds in one place regardless of client, once the config lives in the settings API (done via ActivityWatch/aw-android#202).

Default alerts mirror the trimmed set from ActivityWatch/aw-android#206.

## Test plan

- [ ] Navigate to Settings → Notifications — panel loads
- [ ] On a server with no `aw-notify` setting, defaults (All 60/120/240 min, Work 15/30/60 min) appear
- [ ] Edit thresholds and click Save — `/api/0/settings/aw-notify` is updated
- [ ] Reload page — saved config persists
- [ ] Add and remove alert rows
- [ ] Verify Android app reads updated thresholds from `/api/0/settings/aw-notify`