### PR TITLE
fix(settings): unify aw-notify config schema

### DIFF
--- a/src/util/aw-notify.ts
+++ b/src/util/aw-notify.ts
@@ -88,7 +88,7 @@ export function parseAwNotifyConfig(value: unknown): AwNotifyConfig | null {
 
   // PR #923 briefly stored Android's original array schema. Read it so users can
   // migrate without losing settings, then always save the canonical desktop shape.
-  if (Array.isArray(value) && value.length > 0 && value.every(isLegacyAlert)) {
+  if (Array.isArray(value) && value.every(isLegacyAlert)) {
     return {
       alerts: value.map(candidate => ({
         category: candidate.category ?? 'All',

--- a/src/util/aw-notify.ts
+++ b/src/util/aw-notify.ts
@@ -1,7 +1,103 @@
+export interface AwNotifyAlert {
+  category: string;
+  label: string | null;
+  thresholds_minutes: number[];
+  positive: boolean;
+}
+
+export interface AwNotifyConfig {
+  alerts: AwNotifyAlert[];
+  hourly_checkins?: boolean;
+  new_day_greetings?: boolean;
+  server_monitoring?: boolean;
+  productivity_score?: boolean;
+  http_port?: number;
+}
+
+interface LegacyAwNotifyAlert {
+  category: string | null;
+  label: string;
+  thresholdMinutes: number[];
+  positive: boolean;
+}
+
 export function parseThresholds(input: string): number[] | null {
   const values = input.split(',').map(s => s.trim());
   if (values.some(part => !/^[1-9]\d*$/.test(part))) {
     return null;
   }
   return values.map(Number);
+}
+
+function isPositiveWholeMinutes(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(minutes => Number.isInteger(minutes) && minutes > 0)
+  );
+}
+
+function hasOptionalBoolean(value: Record<string, unknown>, key: string): boolean {
+  return value[key] === undefined || typeof value[key] === 'boolean';
+}
+
+function isAwNotifyAlert(value: unknown): value is AwNotifyAlert {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.category === 'string' &&
+    (typeof candidate.label === 'string' || candidate.label === null) &&
+    isPositiveWholeMinutes(candidate.thresholds_minutes) &&
+    typeof candidate.positive === 'boolean'
+  );
+}
+
+function isLegacyAlert(value: unknown): value is LegacyAwNotifyAlert {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    (typeof candidate.category === 'string' || candidate.category === null) &&
+    typeof candidate.label === 'string' &&
+    isPositiveWholeMinutes(candidate.thresholdMinutes) &&
+    typeof candidate.positive === 'boolean'
+  );
+}
+
+export function parseAwNotifyConfig(value: unknown): AwNotifyConfig | null {
+  if (typeof value === 'object' && value !== null) {
+    const config = value as Record<string, unknown>;
+    if (
+      Array.isArray(config.alerts) &&
+      config.alerts.every(isAwNotifyAlert) &&
+      hasOptionalBoolean(config, 'hourly_checkins') &&
+      hasOptionalBoolean(config, 'new_day_greetings') &&
+      hasOptionalBoolean(config, 'server_monitoring') &&
+      hasOptionalBoolean(config, 'productivity_score') &&
+      (config.http_port === undefined ||
+        (Number.isInteger(config.http_port) &&
+          (config.http_port as number) >= 0 &&
+          (config.http_port as number) <= 65535))
+    ) {
+      return config as unknown as AwNotifyConfig;
+    }
+  }
+
+  // PR #923 briefly stored Android's original array schema. Read it so users can
+  // migrate without losing settings, then always save the canonical desktop shape.
+  if (Array.isArray(value) && value.length > 0 && value.every(isLegacyAlert)) {
+    return {
+      alerts: value.map(candidate => ({
+        category: candidate.category ?? 'All',
+        label: candidate.label || null,
+        thresholds_minutes: candidate.thresholdMinutes,
+        positive: candidate.positive,
+      })),
+    };
+  }
+
+  return null;
 }

--- a/src/views/settings/AwNotifySettings.vue
+++ b/src/views/settings/AwNotifySettings.vue
@@ -2,8 +2,8 @@
 div
   div.d-flex.justify-content-between.align-items-center.mb-3
     div
-      h5.mb-1 Mobile Notifications
-      small.text-muted Configure aw-notify alert thresholds for the Android app
+      h5.mb-1 Activity Notifications
+      small.text-muted Configure aw-notify alerts for Android and desktop
     b-btn(@click="save" size="sm" variant="primary" :disabled="saving || loading")
       | {{ saving ? 'Saving…' : 'Save' }}
 
@@ -15,9 +15,8 @@ div
 
   div(v-else)
     p.text-muted.small.mb-3
-      | Alerts are checked periodically by the Android app. Each alert fires a notification
-      | when the accumulated time crosses a threshold.
-      | Uses the #[code /api/0/settings/aw-notify] server setting.
+      | Alerts are checked periodically by aw-notify. Each alert fires a notification when
+      | the accumulated time crosses a threshold. The same config works in Android and aw-tauri.
 
     div(v-if="alerts.length === 0")
       p.text-muted.font-italic No alerts configured.
@@ -31,10 +30,10 @@ div
             b-input(
               v-model="alert.category"
               size="sm"
-              placeholder="Leave empty to track all time"
+              placeholder="All"
             )
             small.form-text.text-muted
-              | Match the category name in your AW categorization rules, or leave empty for total time.
+              | Match the category name in your AW categorization rules, or use All for total time.
           b-form-group(
             label="Thresholds"
             label-cols-sm="3"
@@ -64,42 +63,40 @@ import 'vue-awesome/icons/plus';
 import 'vue-awesome/icons/trash';
 
 import { getClient } from '~/util/awclient';
-import { parseThresholds } from '~/util/aw-notify';
+import {
+  AwNotifyAlert,
+  AwNotifyConfig,
+  parseAwNotifyConfig,
+  parseThresholds,
+} from '~/util/aw-notify';
 
 const SETTINGS_KEY = 'aw-notify';
 
 interface AlertRow {
   label: string;
-  category: string | null; // null = aggregate "All"
+  category: string;
   thresholdStr: string;
   positive: boolean;
 }
 
-interface AlertDTO {
-  label: string;
-  category: string | null;
-  thresholdMinutes: number[];
-  positive: boolean;
-}
-
-function dtoToRow(dto: AlertDTO): AlertRow {
+function dtoToRow(dto: AwNotifyAlert): AlertRow {
   return {
-    label: dto.label,
-    category: dto.category ?? '',
-    thresholdStr: dto.thresholdMinutes.join(', '),
+    label: dto.label ?? '',
+    category: dto.category,
+    thresholdStr: dto.thresholds_minutes.join(', '),
     positive: dto.positive,
   };
 }
 
-function rowToDto(row: AlertRow): AlertDTO {
+function rowToDto(row: AlertRow): AwNotifyAlert {
   const thresholds = parseThresholds(row.thresholdStr);
   if (!thresholds) {
     throw new Error('Thresholds must be comma-separated positive whole minutes.');
   }
   return {
-    label: row.label,
-    category: row.category && row.category.trim() !== '' ? row.category.trim() : null,
-    thresholdMinutes: thresholds,
+    label: row.label.trim() || null,
+    category: row.category.trim() || 'All',
+    thresholds_minutes: thresholds,
     positive: row.positive,
   };
 }
@@ -109,6 +106,7 @@ export default {
   data() {
     return {
       alerts: [] as AlertRow[],
+      config: {} as AwNotifyConfig,
       loading: false,
       saving: false,
       error: '',
@@ -129,10 +127,15 @@ export default {
       try {
         const client = getClient();
         const resp = await client.req.get(`/0/settings/${SETTINGS_KEY}`);
-        const data: AlertDTO[] = resp.data;
-        this.alerts = Array.isArray(data) ? data.map(dtoToRow) : this.defaultAlerts();
+        const config = parseAwNotifyConfig(resp.data);
+        if (!config) {
+          throw new Error('The saved aw-notify setting has an unsupported format.');
+        }
+        this.config = config;
+        this.alerts = config.alerts.map(dtoToRow);
       } catch (e: any) {
         if (e?.response?.status === 404) {
+          this.config = {} as AwNotifyConfig;
           this.alerts = this.defaultAlerts();
         } else {
           this.error = `Failed to load settings: ${e?.message ?? e}`;
@@ -151,7 +154,7 @@ export default {
       this.saving = true;
       try {
         const client = getClient();
-        const payload: AlertDTO[] = this.alerts.map(rowToDto);
+        const payload: AwNotifyConfig = { ...this.config, alerts: this.alerts.map(rowToDto) };
         await client.req.post(`/0/settings/${SETTINGS_KEY}`, payload, {
           headers: { 'Content-Type': 'application/json' },
         });
@@ -171,7 +174,7 @@ export default {
     addAlert() {
       this.alerts.push({
         label: '',
-        category: '',
+        category: 'All',
         thresholdStr: '60, 120',
         positive: false,
       });
@@ -181,8 +184,8 @@ export default {
     },
     defaultAlerts(): AlertRow[] {
       return [
-        { label: 'All', category: '', thresholdStr: '60, 120, 240', positive: false },
-        { label: 'Work', category: 'Work', thresholdStr: '15, 30, 60', positive: true },
+        { label: 'All', category: 'All', thresholdStr: '60, 240, 480', positive: false },
+        { label: '💼 Work', category: 'Work', thresholdStr: '60, 120, 240', positive: true },
       ];
     },
   },

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -125,7 +125,7 @@ export default {
       const notifications: Group = {
         id: 'notifications',
         label: 'Notifications',
-        help: 'Configure alert thresholds for the aw-notify Android integration.',
+        help: 'Configure shared aw-notify alert thresholds for Android and desktop.',
         components: [{ name: 'AwNotifySettings' }],
       };
 

--- a/test/unit/aw-notify.test.js
+++ b/test/unit/aw-notify.test.js
@@ -47,9 +47,12 @@ describe('parseAwNotifyConfig', () => {
     });
   });
 
+  test('migrates an empty original Android array', () => {
+    expect(parseAwNotifyConfig([])).toEqual({ alerts: [] });
+  });
+
   test.each([
     null,
-    [],
     { alerts: 'bad' },
     { alerts: [{ ...canonicalAlert, category: null }] },
     { alerts: [{ ...canonicalAlert, thresholds_minutes: [] }] },

--- a/test/unit/aw-notify.test.js
+++ b/test/unit/aw-notify.test.js
@@ -1,4 +1,4 @@
-import { parseThresholds } from '~/util/aw-notify';
+import { parseAwNotifyConfig, parseThresholds } from '~/util/aw-notify';
 
 describe('parseThresholds', () => {
   test('parses comma-separated positive whole minutes', () => {
@@ -11,4 +11,52 @@ describe('parseThresholds', () => {
       expect(parseThresholds(input)).toBeNull();
     }
   );
+});
+
+describe('parseAwNotifyConfig', () => {
+  const canonicalAlert = {
+    category: 'Work',
+    label: '💼 Work',
+    thresholds_minutes: [60, 120, 240],
+    positive: true,
+  };
+
+  test('accepts the full aw-notify-rs config shape', () => {
+    const config = {
+      alerts: [canonicalAlert],
+      hourly_checkins: true,
+      new_day_greetings: false,
+      server_monitoring: true,
+      productivity_score: true,
+      http_port: 0,
+    };
+    expect(parseAwNotifyConfig(config)).toEqual(config);
+  });
+
+  test('preserves an explicitly empty alert list', () => {
+    expect(parseAwNotifyConfig({ alerts: [] })).toEqual({ alerts: [] });
+  });
+
+  test('migrates the original Android array shape', () => {
+    expect(
+      parseAwNotifyConfig([
+        { category: null, label: 'All', thresholdMinutes: [60, 240], positive: false },
+      ])
+    ).toEqual({
+      alerts: [{ category: 'All', label: 'All', thresholds_minutes: [60, 240], positive: false }],
+    });
+  });
+
+  test.each([
+    null,
+    [],
+    { alerts: 'bad' },
+    { alerts: [{ ...canonicalAlert, category: null }] },
+    { alerts: [{ ...canonicalAlert, thresholds_minutes: [] }] },
+    { alerts: [{ ...canonicalAlert, thresholds_minutes: [0] }] },
+    { alerts: [canonicalAlert], hourly_checkins: 'yes' },
+    { alerts: [canonicalAlert], http_port: 70000 },
+  ])('rejects unsupported config %p', config => {
+    expect(parseAwNotifyConfig(config)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #923 and Erik's post-merge review: make the Notifications editor serialize the existing `aw-notify-rs` configuration format instead of Android's private array format.

- writes an object with `alerts` and snake_case `thresholds_minutes`
- uses `"All"` for aggregate time, matching desktop `AlertConfig`
- preserves desktop feature toggles and `http_port` when editing alerts
- reads and migrates the briefly shipped array/camelCase format from #923
- validates the canonical and legacy shapes before displaying them
- updates labels/defaults to describe both Android and desktop use

Desktop consumption of the server setting is tracked separately in ActivityWatch/aw-notify-rs#38. Android's parser must also accept this canonical shape before ActivityWatch/aw-android#201 can close.

## Test plan

- [x] `npm test -- --selectProjects jsdom --runTestsByPath test/unit/aw-notify.test.js --runInBand --coverage=false` (18 passed)
- [x] ESLint on all changed files with zero warnings
- [x] Prettier and pre-commit hooks
- [x] Legacy array config migrates without dropping alerts
- [x] Empty canonical `alerts` remains empty
- [x] Existing non-alert desktop fields survive save
