### PR TITLE
fix(queries): match Arc and Dia in the chrome appname patterns

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -289,7 +289,12 @@ function browsersWithBuckets(browserbuckets: string[]): [string, string][] {
 // The full set of historical app names these patterns replace is documented in the unit tests.
 // See: test/unit/queries.test.node.ts, https://github.com/ActivityWatch/aw-webui/issues/749
 export const browser_appname_regex: Record<string, string> = {
-  chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium)',
+  // Chromium forks (Arc, Dia) run the chrome build of the extension, which announces itself
+  // as chrome unless the user overrides the browser name in the extension settings. So by
+  // default their events land in the chrome bucket and their app names have to be matched
+  // here (#927, ActivityWatch/activitywatch#1094). The standalone arc key below only covers
+  // setups where Arc was picked explicitly in the settings, which changes the bucket name.
+  chrome: '(?i)^(google[-_ ]?chrome|chrome|chromium|arc(\\.exe)?$|dia(\\.exe)?$)',
   firefox: '(?i)(firefox|librewolf|waterfox|nightly)',
   opera: '(?i)(opera)',
   brave: '(?i)(brave)',

--- a/test/unit/queries.test.node.ts
+++ b/test/unit/queries.test.node.ts
@@ -36,6 +36,8 @@
  *             (Flatpak app IDs retained: 'com.microsoft.Edge', 'com.microsoft.EdgeDev')
  *
  *   Arc:      'arc.exe', 'Arc.exe', 'Arc'
+ *             (also matched by the chrome pattern, since Arc reports to the chrome bucket
+ *              unless the browser name is overridden in the extension settings)
  *
  *   Vivaldi:  'Vivaldi-stable', 'Vivaldi-snapshot', 'vivaldi.exe', 'Vivaldi.exe', 'Vivaldi'
  *             (Flatpak app ID retained: 'com.vivaldi.Vivaldi')
@@ -81,6 +83,12 @@ describe('browser_appname_regex', () => {
       'chromium.exe',
       'Google-chrome-beta',
       'Google-chrome-unstable',
+      // Chromium forks that report through the chrome extension bucket (#927)
+      'Arc',
+      'arc.exe',
+      'Arc.exe',
+      'Dia',
+      'Dia.exe',
     ];
     for (const name of knownNames) {
       expect(re.test(name)).toBe(true);
@@ -93,6 +101,10 @@ describe('browser_appname_regex', () => {
     expect(re.test('com.google.Chrome')).toBe(false);
     expect(re.test('Slack')).toBe(false);
     expect(re.test('Electron')).toBe(false);
+    // The fork alternatives are anchored, so names merely starting with them don't match
+    expect(re.test('archive')).toBe(false);
+    expect(re.test('arcade')).toBe(false);
+    expect(re.test('Dialog')).toBe(false);
   });
 
   test('firefox pattern matches all known Firefox/LibreWolf/Waterfox app names', () => {


### PR DESCRIPTION
Fixes #927. Should also cover ActivityWatch/activitywatch#1094, which is the same failure mode with Arc.

As described in the issue: forks like Dia and Arc run the chrome build of the extension, so by default their web events land in `aw-watcher-web-chrome_<host>`, but aw-watcher-window reports them under their own app names ("Dia", "Arc"). Nothing in the chrome patterns matches those, so `filter_period_intersect` comes back empty and the Browser view shows no data.

One correction to what I wrote in the issue: I claimed a standalone key can never bind because no bucket id contains the fork's name. That's only true for the default setup. The extension settings actually have a browser dropdown (Arc is one of the options) that overrides the detected name, and picking it changes the bucket to `aw-watcher-web-arc_<host>`, which the existing `arc` key does bind to. So the standalone key stays for that case, and the chrome patterns pick up the default case.

So this PR:

- adds `arc` and `dia` alternatives to the chrome regex, each with its own terminal anchor so names like `archive` or `Dialog` don't match
- leaves the standalone `arc` entries alone, with a comment on the chrome entry explaining which case each one covers
- adds the fork names to the chrome pattern tests, plus negative cases for the anchoring

No `dia` key for now since the dropdown has no Dia option, so nothing ever produces a dia bucket. Easy to add alongside `arc` if the extension grows one.

I've been running this patched into the bundled webui inside the .app for a couple days and Top Domains/URLs/Titles populate fine in Dia now.