### PR TITLE
fix(views): guard server info before dereferencing in templates

### DIFF
--- a/src/views/Buckets.vue
+++ b/src/views/Buckets.vue
@@ -17,7 +17,7 @@ div
         icon.mr-2.text-secondary(v-else name="desktop" scale="1.2")
         div
           span.font-weight-bold {{ device.hostname }}
-          b-badge.ml-2(v-if="serverStore.info.hostname == device.hostname" variant="info") {{ $t('buckets.thisDevice') }}
+          b-badge.ml-2(v-if="serverStore.info && serverStore.info.hostname == device.hostname" variant="info") {{ $t('buckets.thisDevice') }}
           div.small.text-muted(v-if="device.hostname !== device.device_id")
             | ID: {{ device.id }}
           div.small(v-if="deviceHasEvents(device)")

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -71,7 +71,7 @@ div
         li #[a(href="https://discord.gg/vDskV9q") {{ $t('home.discord') }}]
         li #[a(href="https://www.reddit.com/r/activitywatch/") {{ $t('home.reddit') }}]
         li #[a(href="https://github.com/ActivityWatch/activitywatch") GitHub]
-        li(v-if="!info.version.includes('rust')") #[a(:href="apiBrowserUrl") {{ $t('home.apiBrowser') }}]
+        li(v-if="info && !info.version.includes('rust')") #[a(:href="apiBrowserUrl") {{ $t('home.apiBrowser') }}]
 
     div.col-md-6
       h4 {{ $t('home.workingOnTitle') }}

--- a/test/unit/serverInfoGuard.test.js
+++ b/test/unit/serverInfoGuard.test.js
@@ -1,0 +1,72 @@
+// Regression guard for the "TypeError: null is not an object (evaluating
+// 't.info.version')" crash: useServerStore starts with `info: null` and only
+// populates it from App.vue's `mounted` hook, which runs *after* the first
+// child render. Any template that dereferences `info` without a null check
+// therefore throws on cold load — and permanently when the server is
+// unreachable, since getInfo() swallows the error and leaves `info` null.
+import fs from 'fs';
+import path from 'path';
+
+const SRC = path.resolve(__dirname, '../../src');
+
+// Templates are pug; extract the <template lang="pug"> block so we only inspect
+// render-time expressions, not script-side code (which has its own guards).
+function template(relPath) {
+  const source = fs.readFileSync(path.join(SRC, relPath), 'utf8');
+  const match = source.match(/<template[^>]*>([\s\S]*?)<\/template>/);
+  if (!match) throw new Error(`no <template> block in ${relPath}`);
+  return match[1];
+}
+
+const DEREFS_INFO = /\binfo\.(version|hostname|device_id|testing)\b/;
+// `v-if="info"`, `v-if="info && ..."`, and `info?.` all establish a guard.
+const GUARDS_INFO = /v-if="[^"]*\binfo"|\binfo\s*&&|\binfo\?\./;
+
+// Pug nests by indentation, so a guard on an ancestor line covers its children
+// (Footer.vue wraps its `info.hostname` / `info.version` in `span(v-if="info")`).
+// Walk the indentation stack and treat a line as safe if it, or any ancestor,
+// guards `info`.
+function unguardedInfoDerefs(pug) {
+  const offenders = [];
+  const stack = []; // [{ indent, guarded }]
+
+  for (const line of pug.split('\n')) {
+    if (!line.trim()) continue;
+    const indent = line.length - line.trimStart().length;
+
+    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+
+    const inheritedGuard = stack.some(frame => frame.guarded);
+    const guarded = inheritedGuard || GUARDS_INFO.test(line);
+
+    if (DEREFS_INFO.test(line) && !guarded) offenders.push(line.trim());
+
+    stack.push({ indent, guarded });
+  }
+  return offenders;
+}
+
+describe('server store info is never dereferenced unguarded in templates', () => {
+  test.each([['views/Home.vue'], ['views/Buckets.vue'], ['components/Footer.vue']])(
+    '%s guards info before dereferencing',
+    relPath => {
+      expect(unguardedInfoDerefs(template(relPath))).toEqual([]);
+    }
+  );
+
+  test('detects the original crashing expression', () => {
+    expect(unguardedInfoDerefs(`li(v-if="!info.version.includes('rust')") link`)).toHaveLength(1);
+  });
+
+  test('accepts an ancestor guard, as Footer.vue relies on', () => {
+    const pug = ['span(v-if="info")', '  small', '    | {{info.version}}'].join('\n');
+    expect(unguardedInfoDerefs(pug)).toEqual([]);
+  });
+
+  test('does not let a closed guard block cover a later sibling', () => {
+    const pug = ['span(v-if="info")', '  | {{info.version}}', 'span', '  | {{info.hostname}}'].join(
+      '\n'
+    );
+    expect(unguardedInfoDerefs(pug)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

`useServerStore` starts with `info: null` and is only populated from `App.vue`'s
`mounted` hook — which runs *after* the first child render. Two templates
dereferenced `info` unguarded, so a cold load of either view throws:

```
TypeError: null is not an object (evaluating 't.info.version')
```

It renders as a red error banner over an otherwise perfectly working install.

Worse, when the server is unreachable the crash is **permanent**, not a
first-paint race: `getInfo()` catches the connection error and leaves `info`
null forever, so the banner never clears.

## Sites

| File | Expression | Status |
|---|---|---|
| `src/views/Home.vue:74` | `!info.version.includes('rust')` | fixed |
| `src/views/Buckets.vue:20` | `serverStore.info.hostname == device.hostname` | fixed |
| `src/components/Footer.vue:12,15` | `info.hostname` / `info.version` | already safe — ancestor `v-if="info"` |
| `src/stores/buckets.ts:44,187` | `serverStore.info && ...` | already safe |

## Regression test

`test/unit/serverInfoGuard.test.js` walks the pug template tree by indentation
and rejects any `info.*` dereference not covered by a guard on itself or an
ancestor. The indentation-awareness matters: a naive per-line check would
false-positive on Footer.vue, whose guard sits on the wrapping `span`. Covered
both ways — an ancestor guard passes, a sibling *after* a closed guard block
does not.

Verified against the pre-fix files from `master`: the detector flags both
offending lines and reports Footer clean, then reports all three clean after the
fix.

## Verification

- `npx jest --selectProjects jsdom` — 14 suites, 69 tests pass
- `make lint` clean on the changed files

## Origin

Found while triaging a participant's test report on the ActivityWatch Research
Edition build (`v0.14.0b3-research`). The install was working correctly and the
privacy filter was doing its job, but the banner made it look broken.