### PR TITLE
feat(categories): let builds ship a preset category set active by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,15 @@ categorization settings page imports/exports):
 ]
 ```
 
-Preset sets are activated by default on installs that have no stored
-categorization of their own. Users who already configured categories keep
-theirs — the presets only show up as additional sets they can switch to in
-Settings → Categorization. A set the user has edited and saved always wins over
-the preset definition with the same id.
+The first preset set is activated by default on installs that have no stored
+categorization of their own; any further sets are offered as alternatives the
+user can switch to or combine. Users who already configured categories keep
+theirs — the presets only show up as additional sets in Settings →
+Categorization. A set the user has edited and saved always wins over the preset
+definition with the same id.
+
+Rules are validated for both the JavaScript and the server-side (Python) regex
+engines, since category rules are also evaluated in queries.
 
 Embedders that can set a global before the app boots (Tauri, Android WebView,
 custom launchers) may instead assign the same payload to

--- a/README.md
+++ b/README.md
@@ -87,6 +87,47 @@ Then, in another terminal (with your venv activated) run:
 python3 -m http.server --bind 127.0.0.1 27180 --directory ../aw-server/static
 ```
 
+### Shipping preset categories in a build
+
+Distributions that need their own categorization scheme (a research build, a
+company-wide deployment, ...) can ship one or more *preset category sets* with
+the bundle, instead of patching the built-in defaults:
+
+```bash
+AW_PRESET_CATEGORY_SETS="$(cat mypreset.json)" npm run build
+```
+
+where `mypreset.json` holds a list of category sets (the same shape the
+categorization settings page imports/exports):
+
+```json
+[
+  {
+    "id": "mypreset",
+    "categories": [
+      {
+        "name": ["Work"],
+        "rule": { "type": "regex", "regex": "^Work$" },
+        "data": { "color": "#0F0" }
+      }
+    ]
+  }
+]
+```
+
+Preset sets are activated by default on installs that have no stored
+categorization of their own. Users who already configured categories keep
+theirs — the presets only show up as additional sets they can switch to in
+Settings → Categorization. A set the user has edited and saved always wins over
+the preset definition with the same id.
+
+Embedders that can set a global before the app boots (Tauri, Android WebView,
+custom launchers) may instead assign the same payload to
+`window.__AW_PRESET_CATEGORY_SETS__`, which avoids rebuilding the bundle.
+
+Malformed presets are logged and ignored rather than breaking the UI.
+See `src/util/presetCategories.ts`.
+
 ## Tests
 
 Tests can be run with:

--- a/README.md
+++ b/README.md
@@ -115,19 +115,23 @@ categorization settings page imports/exports):
 ]
 ```
 
-The first preset set is activated by default on installs that have no stored
-categorization of their own; any further sets are offered as alternatives the
-user can switch to or combine. Users who already configured categories keep
-theirs — the presets only show up as additional sets in Settings →
-Categorization. A set the user has edited and saved always wins over the preset
-definition with the same id.
-
-Rules are validated for both the JavaScript and the server-side (Python) regex
-engines, since category rules are also evaluated in queries.
+When a build ships presets, the **first** preset in the list is active by
+default on installs with no stored categorization. Remaining presets are
+available in Settings → Categorization for the user to enable. Users who
+already configured categories keep theirs — presets only show up as additional
+sets. A set the user has edited and saved always wins over the preset definition
+with the same id.
 
 Embedders that can set a global before the app boots (Tauri, Android WebView,
 custom launchers) may instead assign the same payload to
 `window.__AW_PRESET_CATEGORY_SETS__`, which avoids rebuilding the bundle.
+
+**Regex compatibility note**: preset regexes are validated against JavaScript
+syntax, but they are also passed to the Python-backed categorization engine for
+server-side queries. Use patterns compatible with both engines: basic groups,
+quantifiers, character classes, and anchors are safe. Avoid JS-only
+constructs such as named-capture-group syntax (`(?<name>...)`) — use the
+Python form (`(?P<name>...)`) or omit named groups entirely.
 
 Malformed presets are logged and ignored rather than breaking the UI.
 See `src/util/presetCategories.ts`.

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -5,3 +5,6 @@
 declare const PRODUCTION: boolean;
 declare const AW_SERVER_URL: string;
 declare const COMMIT_HASH: string;
+// JSON-encoded preset category sets shipped by this build (empty string if none).
+// See src/util/presetCategories.ts
+declare const AW_PRESET_CATEGORY_SETS: string;

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -366,13 +366,17 @@ export const useCategoryStore = defineStore('categories', {
       this.classes_unsaved_changes = true;
     },
     /**
-     * Reset the effective classes to the install defaults.
+     * Reset the effective classes to the defaults of the active set.
      *
-     * On builds that ship preset category sets, "defaults" means the presets —
-     * otherwise "Restore defaults" would silently drop the shipped scheme.
+     * When the active set is one shipped by the build, "defaults" means that
+     * preset — otherwise "Restore defaults" would silently drop the shipped
+     * scheme. For a user-owned set it means the built-in categories: the
+     * subsequent save syncs these classes into the active set, so restoring
+     * anything else here would overwrite that set with another set's contents.
      */
     restoreDefaultClasses(this: State) {
-      this.classes = assignIds(createMissingParents(getDefaultClasses()));
+      const activeId = this.active_set_ids.length > 0 ? this.active_set_ids[0] : undefined;
+      this.classes = assignIds(createMissingParents(getDefaultClasses(activeId)));
       this.classes_unsaved_changes = true;
     },
     clearAll(this: State) {

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -4,7 +4,7 @@ import {
   saveCategories,
   loadCategories,
   cleanCategory,
-  defaultCategories,
+  getDefaultClasses,
   build_category_hierarchy,
   createMissingParents,
   mergeCategorySets,
@@ -365,8 +365,14 @@ export const useCategoryStore = defineStore('categories', {
       }
       this.classes_unsaved_changes = true;
     },
+    /**
+     * Reset the effective classes to the install defaults.
+     *
+     * On builds that ship preset category sets, "defaults" means the presets —
+     * otherwise "Restore defaults" would silently drop the shipped scheme.
+     */
     restoreDefaultClasses(this: State) {
-      this.classes = assignIds(createMissingParents(defaultCategories));
+      this.classes = assignIds(createMissingParents(getDefaultClasses()));
       this.classes_unsaved_changes = true;
     },
     clearAll(this: State) {

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import moment, { Moment } from 'moment';
 import { getClient } from '~/util/awclient';
-import { Category, CategorySet, defaultCategories, cleanCategory } from '~/util/classes';
+import { Category, CategorySet, getDefaultClasses, cleanCategory } from '~/util/classes';
 import { SavedQuery } from '~/util/savedQueries';
 import { View, defaultViews } from '~/stores/views';
 import type { PrivacyFilterRule } from '~/util/privacyFilters';
@@ -71,6 +71,11 @@ interface State {
 
   // Set to true if settings loaded
   _loaded: boolean;
+  // Keys that were actually present in storage (server or localStorage) on load.
+  // Lets us tell "user has never configured this" apart from "user configured it
+  // to the same value as the default" — needed to decide whether build-shipped
+  // preset categories may be activated. See `loadCategories()` in ~/util/classes.
+  _storedKeys: string[];
 }
 
 export const useSettingsStore = defineStore('settings', {
@@ -105,7 +110,7 @@ export const useSettingsStore = defineStore('settings', {
 
     always_active_pattern: '',
     privacy_filters: [],
-    classes: defaultCategories,
+    classes: getDefaultClasses(),
     category_sets: [],
     active_set_ids: ['default'],
     views: defaultViews,
@@ -120,11 +125,16 @@ export const useSettingsStore = defineStore('settings', {
     hideUnsupportedVisualizations: false,
 
     _loaded: false,
+    _storedKeys: [],
   }),
 
   getters: {
     loaded(state: State) {
       return state._loaded;
+    },
+    /** Whether the user has a stored categorization of their own (as opposed to defaults). */
+    hasStoredCategories(state: State) {
+      return state._storedKeys.includes('classes') || state._storedKeys.includes('category_sets');
     },
   },
 
@@ -205,7 +215,7 @@ export const useSettingsStore = defineStore('settings', {
           console.error('failed to parse', key, raw, e);
         }
       }
-      this.$patch({ ...storage, _loaded: true });
+      this.$patch({ ...storage, _loaded: true, _storedKeys: Object.keys(storage) });
 
       const localeFromServer = 'locale' in server_settings;
       const localeFromLocalStorage = localStorage.getItem('locale') != null;

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -133,11 +133,15 @@ export const defaultCategories: Category[] = [
  *
  * Normally the built-in `defaultCategories`, but builds/deployments that ship
  * preset category sets (see `~/util/presetCategories`) start from those instead.
+ *
+ * Only the *first* preset is used, matching what `loadCategories()` activates on
+ * a fresh install. Merging every preset here would make "Restore defaults" fold
+ * the categories of inactive presets into the one active set on the next save.
  */
 export function getDefaultClasses(): Category[] {
   const presets = getPresetCategorySets();
   if (presets.length > 0) {
-    return mergeCategorySets(presets);
+    return presets[0].categories;
   }
   return _.cloneDeep(defaultCategories);
 }

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -285,9 +285,15 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
     activeIds =
       storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
   } else if (presets.length > 0 && !settingsStore.hasStoredCategories) {
-    // First run on a build that ships presets: activate them, in declared order.
+    // First run on a build that ships presets: activate the first one.
+    //
+    // Deliberately only one: while several sets are active the store cannot
+    // sync edits back into them (see syncToPrimarySet), so activating multiple
+    // sets by default would put users in a state where editing and saving
+    // silently drops their changes. Additional presets stay available for the
+    // user to switch to or combine explicitly.
     sets = [];
-    activeIds = presets.map(s => s.id);
+    activeIds = [presets[0].id];
   } else {
     // Migration path: no sets defined yet — wrap the existing flat classes into a "default" set
     const legacyClasses = settingsStore.classes || defaultCategories;

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -285,13 +285,16 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
     activeIds =
       storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
   } else if (presets.length > 0 && !settingsStore.hasStoredCategories) {
-    // First run on a build that ships presets: activate the first one.
+    // First run on a build that ships presets: activate the first preset only.
     //
-    // Deliberately only one: while several sets are active the store cannot
-    // sync edits back into them (see syncToPrimarySet), so activating multiple
-    // sets by default would put users in a state where editing and saving
-    // silently drops their changes. Additional presets stay available for the
-    // user to switch to or combine explicitly.
+    // We deliberately limit the initial selection to one set: syncToPrimarySet()
+    // in the category store cannot split state.classes back into individual sets
+    // when multiple sets are active, so it skips the sync entirely. Activating
+    // more than one preset on first run would therefore cause any category edit
+    // the user makes to be lost on the next reload.
+    //
+    // The remaining presets are still appended below and are available in the UI
+    // for the user to activate manually.
     sets = [];
     activeIds = [presets[0].id];
   } else {

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -129,21 +129,28 @@ export const defaultCategories: Category[] = [
 ];
 
 /**
- * The categories an install starts out with.
+ * The categories a set starts out with — what "restore defaults" restores.
  *
  * Normally the built-in `defaultCategories`, but builds/deployments that ship
  * preset category sets (see `~/util/presetCategories`) start from those instead.
  *
- * Only the *first* preset is used, matching what `loadCategories()` activates on
- * a fresh install. Merging every preset here would make "Restore defaults" fold
- * the categories of inactive presets into the one active set on the next save.
+ * `setId` is the set the categories are destined for, so that restoring never
+ * writes one set's categories into another:
+ *  - a preset set restores its own categories,
+ *  - a user-owned set restores the built-in defaults,
+ *  - omitting it (install default) uses the first preset, which is the one
+ *    `loadCategories()` activates on a fresh install.
  */
-export function getDefaultClasses(): Category[] {
+export function getDefaultClasses(setId?: string): Category[] {
   const presets = getPresetCategorySets();
-  if (presets.length > 0) {
+  if (presets.length === 0) {
+    return _.cloneDeep(defaultCategories);
+  }
+  if (setId === undefined) {
     return presets[0].categories;
   }
-  return _.cloneDeep(defaultCategories);
+  const preset = presets.find(p => p.id === setId);
+  return preset ? preset.categories : _.cloneDeep(defaultCategories);
 }
 
 export function annotate(c: Category) {

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -1,10 +1,14 @@
 import _ from 'lodash';
 import { IEvent } from './interfaces';
 import { useSettingsStore } from '~/stores/settings';
+import { getPresetCategorySets } from '~/util/presetCategories';
 
 const level_sep = '>';
 const CLASSIFY_KEYS = ['app', 'title'];
 const UNCATEGORIZED = ['Uncategorized'];
+
+/** ID of the implicit set holding a user's own (non-preset) categories. */
+export const DEFAULT_SET_ID = 'default';
 
 export interface Rule {
   type: 'regex' | 'none';
@@ -123,6 +127,20 @@ export const defaultCategories: Category[] = [
   { name: ['Comms', 'Email'], rule: { type: 'regex', regex: 'Gmail|Thunderbird|mutt|alpine' } },
   { name: ['Uncategorized'], rule: { type: null }, data: { color: COLOR_UNCAT } },
 ];
+
+/**
+ * The categories an install starts out with.
+ *
+ * Normally the built-in `defaultCategories`, but builds/deployments that ship
+ * preset category sets (see `~/util/presetCategories`) start from those instead.
+ */
+export function getDefaultClasses(): Category[] {
+  const presets = getPresetCategorySets();
+  if (presets.length > 0) {
+    return mergeCategorySets(presets);
+  }
+  return _.cloneDeep(defaultCategories);
+}
 
 export function annotate(c: Category) {
   const ch = c.name;
@@ -247,22 +265,54 @@ export function saveCategories(sets: CategorySet[], activeIds: string[]) {
 /**
  * Load category sets and active set IDs from the settings store.
  * Falls back to the legacy flat `classes` setting if no sets are defined yet.
+ *
+ * Preset sets shipped by the build/deployment (see `~/util/presetCategories`)
+ * are always appended as *available* sets, but are only active by default when
+ * the user has no stored categorization of their own. A stored set with the
+ * same id always wins over the preset definition, so user edits stick.
  */
 export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
   const settingsStore = useSettingsStore();
-  const sets: CategorySet[] = settingsStore.category_sets;
-  const activeIds: string[] = settingsStore.active_set_ids;
+  const storedSets: CategorySet[] = settingsStore.category_sets;
+  const storedActiveIds: string[] = settingsStore.active_set_ids;
+  const presets = getPresetCategorySets();
 
-  if (sets && sets.length > 0) {
-    return { sets, activeIds: activeIds && activeIds.length > 0 ? activeIds : [sets[0].id] };
+  let sets: CategorySet[];
+  let activeIds: string[];
+
+  if (storedSets && storedSets.length > 0) {
+    sets = [...storedSets];
+    activeIds =
+      storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
+  } else if (presets.length > 0 && !settingsStore.hasStoredCategories) {
+    // First run on a build that ships presets: activate them, in declared order.
+    sets = [];
+    activeIds = presets.map(s => s.id);
+  } else {
+    // Migration path: no sets defined yet — wrap the existing flat classes into a "default" set
+    const legacyClasses = settingsStore.classes || defaultCategories;
+    sets = [{ id: DEFAULT_SET_ID, categories: legacyClasses }];
+    activeIds = [DEFAULT_SET_ID];
   }
 
-  // Migration path: no sets defined yet — wrap the existing flat classes into a "default" set
-  const legacyClasses = settingsStore.classes || defaultCategories;
-  return {
-    sets: [{ id: 'default', categories: legacyClasses }],
-    activeIds: ['default'],
-  };
+  // Presets are always offered as sets the user can switch to/combine,
+  // unless a set with the same id is already stored (that one is authoritative).
+  for (const preset of presets) {
+    if (!sets.some(s => s.id === preset.id)) {
+      sets.push(preset);
+    }
+  }
+
+  // Never return a dangling or empty selection
+  if (sets.length === 0) {
+    sets = [{ id: DEFAULT_SET_ID, categories: defaultCategories }];
+  }
+  activeIds = activeIds.filter(id => sets.some(s => s.id === id));
+  if (activeIds.length === 0) {
+    activeIds = [sets[0].id];
+  }
+
+  return { sets, activeIds };
 }
 
 function pickDeepest(categories: Category[]) {

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -29,13 +29,15 @@
  *                       "data": {"color": "#0F0"}}]}]
  *
  * Behaviour of the resulting sets is defined in `loadCategories()` in
- * `~/util/classes`: preset sets are always *available*, but only activated by
- * default when the user has no stored categorization of their own.
+ * `~/util/classes`: preset sets are always *available*, but only the first one
+ * is activated by default, and only when the user has no stored categorization
+ * of their own.
  *
  * Malformed input is dropped with a warning rather than thrown — a broken
  * preset must never prevent the UI from starting.
  */
 import type { Category, CategorySet, Rule } from '~/util/classes';
+import { validateRegex } from '~/util/validate';
 
 /** Name of the global an embedder can set to inject presets at runtime. */
 export const PRESET_GLOBAL_NAME = '__AW_PRESET_CATEGORY_SETS__';
@@ -62,11 +64,12 @@ function parseRule(raw: unknown, context: string): Rule | null {
     console.warn(`[presets] ${context}: regex rule without a pattern, skipping`);
     return null;
   }
-  try {
-    // Validate here so a bad pattern can't break categorization at match time
-    RegExp(raw.regex);
-  } catch (e) {
-    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`, e);
+  // Validate here so a bad pattern can't break categorization at match time.
+  // validateRegex() also rejects patterns that only work in JavaScript: rules
+  // are sent to the server-side query engine via `classes_for_query`, so a
+  // JS-only pattern would break every categorized query.
+  if (!validateRegex(raw.regex)) {
+    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`);
     return null;
   }
   const rule: Rule = { type: 'regex', regex: raw.regex };

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -36,6 +36,7 @@
  * preset must never prevent the UI from starting.
  */
 import type { Category, CategorySet, Rule } from '~/util/classes';
+import { validateRegex } from '~/util/validate';
 
 /** Name of the global an embedder can set to inject presets at runtime. */
 export const PRESET_GLOBAL_NAME = '__AW_PRESET_CATEGORY_SETS__';
@@ -62,18 +63,11 @@ function parseRule(raw: unknown, context: string): Rule | null {
     console.warn(`[presets] ${context}: regex rule without a pattern, skipping`);
     return null;
   }
-  try {
-    // Validate against JavaScript regex syntax so a bad pattern cannot break
-    // categorization at match time. Note: this does NOT guarantee that the
-    // pattern is valid for the Python `re` module used by aw-server for
-    // server-side categorization queries (classes_for_query). JS-specific
-    // constructs such as named-capture-group syntax (?<name>...) are accepted
-    // here but will fail on the backend. Keep preset regexes simple and stick
-    // to syntax that is valid in both engines (basic groups, quantifiers,
-    // character classes, anchors).
-    RegExp(raw.regex);
-  } catch (e) {
-    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`, e);
+  // validateRegex() also rejects patterns that only work in JavaScript: rules
+  // are sent to the server-side query engine via `classes_for_query`, so a
+  // JS-only pattern would break every categorized query.
+  if (!validateRegex(raw.regex)) {
+    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`);
     return null;
   }
   const rule: Rule = { type: 'regex', regex: raw.regex };

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -29,15 +29,13 @@
  *                       "data": {"color": "#0F0"}}]}]
  *
  * Behaviour of the resulting sets is defined in `loadCategories()` in
- * `~/util/classes`: preset sets are always *available*, but only the first one
- * is activated by default, and only when the user has no stored categorization
- * of their own.
+ * `~/util/classes`: preset sets are always *available*, but only activated by
+ * default when the user has no stored categorization of their own.
  *
  * Malformed input is dropped with a warning rather than thrown — a broken
  * preset must never prevent the UI from starting.
  */
 import type { Category, CategorySet, Rule } from '~/util/classes';
-import { validateRegex } from '~/util/validate';
 
 /** Name of the global an embedder can set to inject presets at runtime. */
 export const PRESET_GLOBAL_NAME = '__AW_PRESET_CATEGORY_SETS__';
@@ -64,12 +62,18 @@ function parseRule(raw: unknown, context: string): Rule | null {
     console.warn(`[presets] ${context}: regex rule without a pattern, skipping`);
     return null;
   }
-  // Validate here so a bad pattern can't break categorization at match time.
-  // validateRegex() also rejects patterns that only work in JavaScript: rules
-  // are sent to the server-side query engine via `classes_for_query`, so a
-  // JS-only pattern would break every categorized query.
-  if (!validateRegex(raw.regex)) {
-    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`);
+  try {
+    // Validate against JavaScript regex syntax so a bad pattern cannot break
+    // categorization at match time. Note: this does NOT guarantee that the
+    // pattern is valid for the Python `re` module used by aw-server for
+    // server-side categorization queries (classes_for_query). JS-specific
+    // constructs such as named-capture-group syntax (?<name>...) are accepted
+    // here but will fail on the backend. Keep preset regexes simple and stick
+    // to syntax that is valid in both engines (basic groups, quantifiers,
+    // character classes, anchors).
+    RegExp(raw.regex);
+  } catch (e) {
+    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`, e);
     return null;
   }
   const rule: Rule = { type: 'regex', regex: raw.regex };

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -1,0 +1,196 @@
+/**
+ * Preset category sets.
+ *
+ * Lets a build or deployment ship a category set that is active by default on a
+ * fresh install, without modifying the built-in `defaultCategories`.
+ *
+ * This exists for distributions that ship their own categorization scheme (a
+ * study build, a company-wide deployment, a locale-specific default set, ...).
+ * The preset is defined entirely outside of aw-webui — nothing scheme-specific
+ * belongs in this file.
+ *
+ * Two sources are supported, checked in this order:
+ *
+ *  1. `globalThis.__AW_PRESET_CATEGORY_SETS__` — set by an embedder (Tauri,
+ *     Android WebView, a custom launcher) before the app boots. Useful for
+ *     deployments that ship presets without rebuilding the bundle.
+ *  2. `AW_PRESET_CATEGORY_SETS` — a compile-time constant, defined by webpack
+ *     (`vue.config.js`) and Vite (`vite.config.js`) from the environment
+ *     variable of the same name. This is the build-variant path:
+ *
+ *         AW_PRESET_CATEGORY_SETS="$(cat mypreset.json)" npm run build
+ *
+ * Both take the same payload: a JSON string (or an already-parsed value) holding
+ * either a single CategorySet or an array of them:
+ *
+ *     [{"id": "mypreset",
+ *       "categories": [{"name": ["Work"],
+ *                       "rule": {"type": "regex", "regex": "^Work$"},
+ *                       "data": {"color": "#0F0"}}]}]
+ *
+ * Behaviour of the resulting sets is defined in `loadCategories()` in
+ * `~/util/classes`: preset sets are always *available*, but only activated by
+ * default when the user has no stored categorization of their own.
+ *
+ * Malformed input is dropped with a warning rather than thrown — a broken
+ * preset must never prevent the UI from starting.
+ */
+import type { Category, CategorySet, Rule } from '~/util/classes';
+
+/** Name of the global an embedder can set to inject presets at runtime. */
+export const PRESET_GLOBAL_NAME = '__AW_PRESET_CATEGORY_SETS__';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseRule(raw: unknown, context: string): Rule | null {
+  if (!isPlainObject(raw)) {
+    console.warn(`[presets] ${context}: category is missing a rule, skipping`);
+    return null;
+  }
+  // `null` was a valid "no rule" type in older exports
+  const type = raw.type === null || raw.type === undefined ? 'none' : raw.type;
+  if (type === 'none') {
+    return { type: 'none' };
+  }
+  if (type !== 'regex') {
+    console.warn(`[presets] ${context}: unknown rule type ${JSON.stringify(type)}, skipping`);
+    return null;
+  }
+  if (typeof raw.regex !== 'string' || raw.regex.length === 0) {
+    console.warn(`[presets] ${context}: regex rule without a pattern, skipping`);
+    return null;
+  }
+  try {
+    // Validate here so a bad pattern can't break categorization at match time
+    RegExp(raw.regex);
+  } catch (e) {
+    console.warn(`[presets] ${context}: invalid regex ${JSON.stringify(raw.regex)}, skipping`, e);
+    return null;
+  }
+  const rule: Rule = { type: 'regex', regex: raw.regex };
+  if (raw.ignore_case === true) rule.ignore_case = true;
+  return rule;
+}
+
+function parseCategory(raw: unknown, context: string): Category | null {
+  if (!isPlainObject(raw)) {
+    console.warn(`[presets] ${context}: category is not an object, skipping`);
+    return null;
+  }
+  const name = raw.name;
+  if (
+    !Array.isArray(name) ||
+    name.length === 0 ||
+    !name.every(n => typeof n === 'string' && n.length > 0)
+  ) {
+    console.warn(`[presets] ${context}: category name must be a non-empty list of strings`);
+    return null;
+  }
+  const rule = parseRule(raw.rule, `${context} category ${name.join('>')}`);
+  if (rule === null) return null;
+
+  const category: Category = { name: name as string[], rule };
+  if (isPlainObject(raw.data)) category.data = { ...raw.data };
+  return category;
+}
+
+function parseSet(raw: unknown, index: number): CategorySet | null {
+  if (!isPlainObject(raw)) {
+    console.warn(`[presets] set #${index} is not an object, skipping`);
+    return null;
+  }
+  if (typeof raw.id !== 'string' || raw.id.length === 0) {
+    console.warn(`[presets] set #${index} is missing a non-empty string id, skipping`);
+    return null;
+  }
+  if (!Array.isArray(raw.categories)) {
+    console.warn(`[presets] set "${raw.id}" has no categories list, skipping`);
+    return null;
+  }
+  const categories = raw.categories
+    .map(c => parseCategory(c, `set "${raw.id}"`))
+    .filter((c): c is Category => c !== null);
+  if (categories.length === 0) {
+    console.warn(`[presets] set "${raw.id}" has no valid categories, skipping`);
+    return null;
+  }
+  return { id: raw.id, categories };
+}
+
+/**
+ * Parse and validate a preset payload.
+ *
+ * Accepts a JSON string, a single CategorySet, or a list of CategorySets.
+ * Invalid entries are dropped (with a warning); never throws.
+ */
+export function parsePresetCategorySets(raw: unknown): CategorySet[] {
+  if (raw === undefined || raw === null) return [];
+
+  let value: unknown = raw;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return [];
+    try {
+      value = JSON.parse(trimmed);
+    } catch (e) {
+      console.error('[presets] failed to parse preset category sets as JSON, ignoring', e);
+      return [];
+    }
+  }
+
+  const rawSets = Array.isArray(value) ? value : [value];
+  const sets: CategorySet[] = [];
+  const seen = new Set<string>();
+  rawSets.forEach((rawSet, i) => {
+    const set = parseSet(rawSet, i);
+    if (set === null) return;
+    if (seen.has(set.id)) {
+      console.warn(`[presets] duplicate set id "${set.id}", keeping the first one`);
+      return;
+    }
+    seen.add(set.id);
+    sets.push(set);
+  });
+  return sets;
+}
+
+function readRuntimeGlobal(): unknown {
+  if (typeof globalThis === 'undefined') return undefined;
+  return (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME];
+}
+
+function readBuildConstant(): unknown {
+  // Guarded with typeof: the constant is only defined in builds that set it
+  return typeof AW_PRESET_CATEGORY_SETS !== 'undefined' ? AW_PRESET_CATEGORY_SETS : undefined;
+}
+
+let cached: CategorySet[] | null = null;
+
+/**
+ * The preset category sets this build/deployment ships, if any.
+ *
+ * Returns an empty list for stock builds, in which case all preset-related
+ * behaviour is inert.
+ */
+export function getPresetCategorySets(): CategorySet[] {
+  if (cached === null) {
+    const runtime = readRuntimeGlobal();
+    const source = runtime !== undefined && runtime !== null ? runtime : readBuildConstant();
+    cached = parsePresetCategorySets(source);
+    if (cached.length > 0) {
+      console.info('[presets] loaded preset category sets:', cached.map(s => s.id).join(', '));
+    }
+  }
+  // Deep enough copy to keep callers from mutating the cache
+  return cached.map(s => ({
+    id: s.id,
+    categories: s.categories.map(c => ({ ...c, name: [...c.name], rule: { ...c.rule } })),
+  }));
+}
+
+/** Drop the memoized presets. Intended for tests. */
+export function clearPresetCategorySetsCache(): void {
+  cached = null;
+}

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -364,7 +364,43 @@ function hasPythonInvalidLookbehind(re: string): boolean {
       // Python's re module does not support nested lookbehind inside a lookbehind.
       // The width-check below treats inner (?<=...) as zero-width, so it would
       // incorrectly pass e.g. (?<=(?<=a)b). Reject any nested lookbehind early.
-      if (/\(\?<[=!]/.test(body)) return true;
+      // Scan character-class-aware to avoid false positives when (?<= appears
+      // as literal text inside [...], e.g. (?<=[a(?<=z]b) is a valid fixed-width
+      // lookbehind whose body [a(?<=z]b has no actual nested assertion.
+      {
+        let bi = 0,
+          bClass = false,
+          bEsc = false,
+          hasNested = false;
+        while (bi < body.length) {
+          if (bEsc) {
+            bEsc = false;
+            bi++;
+            continue;
+          }
+          if (body[bi] === '\\') {
+            bEsc = true;
+            bi++;
+            continue;
+          }
+          if (body[bi] === '[' && !bClass) {
+            bClass = true;
+            bi++;
+            continue;
+          }
+          if (body[bi] === ']' && bClass) {
+            bClass = false;
+            bi++;
+            continue;
+          }
+          if (!bClass && (body.startsWith('(?<=', bi) || body.startsWith('(?<!', bi))) {
+            hasNested = true;
+            break;
+          }
+          bi++;
+        }
+        if (hasNested) return true;
+      }
       if (lookbehindIsVariableWidth(body)) return true;
       i = j;
       continue;

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -83,6 +83,135 @@ function hasPythonInvalidEscape(re: string): boolean {
   );
 }
 
+function lookbehindIsVariableWidth(s: string): boolean {
+  // Returns true if the lookbehind pattern content matches strings of variable length.
+  // Python's re requires fixed-width lookbehind; variable-width causes re.error.
+  let i = 0;
+  let inClass = false;
+  let escaped = false;
+  while (i < s.length) {
+    if (escaped) {
+      escaped = false;
+      i++;
+      continue;
+    }
+    if (s[i] === '\\') {
+      escaped = true;
+      i++;
+      continue;
+    }
+    if (s[i] === '[' && !inClass) {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (s[i] === ']' && inClass) {
+      inClass = false;
+      i++;
+      continue;
+    }
+    if (inClass) {
+      i++;
+      continue;
+    }
+    if (s[i] === '+' || s[i] === '*') return true;
+    if (s[i] === '?') {
+      // '?' immediately after '(' is a group modifier ((?:...) etc.), not a quantifier
+      if (i === 0 || s[i - 1] !== '(') return true;
+    }
+    if (s[i] === '{') {
+      const close = s.indexOf('}', i + 1);
+      if (close !== -1) {
+        const inner = s.slice(i + 1, close);
+        if (inner.includes(',')) {
+          const [lo, hi] = inner.split(',', 2);
+          if (hi === '' || lo !== hi) return true; // {m,} or {m,n} with m≠n
+        }
+        i = close + 1;
+        if (i < s.length && s[i] === '?') i++; // skip lazy modifier on fixed quantifier
+        continue;
+      }
+    }
+    i++;
+  }
+  return false;
+}
+
+function hasPythonInvalidLookbehind(re: string): boolean {
+  // Python's re module only supports fixed-width lookbehind.
+  // Variable-width lookbehind (e.g. (?<=\d+)foo) is valid JS but raises
+  // re.error in Python at compile time, breaking server-side categorization.
+  let i = 0;
+  let inClass = false;
+  let escaped = false;
+  while (i < re.length) {
+    if (escaped) {
+      escaped = false;
+      i++;
+      continue;
+    }
+    if (re[i] === '\\') {
+      escaped = true;
+      i++;
+      continue;
+    }
+    if (re[i] === '[' && !inClass) {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (re[i] === ']' && inClass) {
+      inClass = false;
+      i++;
+      continue;
+    }
+    if (inClass) {
+      i++;
+      continue;
+    }
+    if (re.startsWith('(?<=', i) || re.startsWith('(?<!', i)) {
+      const start = i + 4;
+      let depth = 1;
+      let j = start;
+      let ic = false;
+      let esc = false;
+      while (j < re.length && depth > 0) {
+        if (esc) {
+          esc = false;
+          j++;
+          continue;
+        }
+        if (re[j] === '\\') {
+          esc = true;
+          j++;
+          continue;
+        }
+        if (re[j] === '[' && !ic) {
+          ic = true;
+          j++;
+          continue;
+        }
+        if (re[j] === ']' && ic) {
+          ic = false;
+          j++;
+          continue;
+        }
+        if (!ic) {
+          if (re[j] === '(') depth++;
+          else if (re[j] === ')') depth--;
+        }
+        j++;
+      }
+      const content = re.slice(start, j - 1);
+      if (lookbehindIsVariableWidth(content)) return true;
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return false;
+}
+
 export function validateRegex(re: string) {
   // validates if pattern is a valid regex in both JavaScript and Python
   // returns true if regex is valid
@@ -93,9 +222,7 @@ export function validateRegex(re: string) {
     return false;
   }
   // Reject JS-only syntax that Python's re module doesn't support.
-  // JS named groups (?<name>...) are valid JS but invalid Python (Python uses (?P<name>...)).
-  // Lookbehind (?<=...) and (?<!...) are valid in both, so we allow those.
-  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re)) {
+  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re) || hasPythonInvalidLookbehind(re)) {
     return false;
   }
   return true;

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -83,135 +83,6 @@ function hasPythonInvalidEscape(re: string): boolean {
   );
 }
 
-function lookbehindIsVariableWidth(s: string): boolean {
-  // Returns true if the lookbehind pattern content matches strings of variable length.
-  // Python's re requires fixed-width lookbehind; variable-width causes re.error.
-  let i = 0;
-  let inClass = false;
-  let escaped = false;
-  while (i < s.length) {
-    if (escaped) {
-      escaped = false;
-      i++;
-      continue;
-    }
-    if (s[i] === '\\') {
-      escaped = true;
-      i++;
-      continue;
-    }
-    if (s[i] === '[' && !inClass) {
-      inClass = true;
-      i++;
-      continue;
-    }
-    if (s[i] === ']' && inClass) {
-      inClass = false;
-      i++;
-      continue;
-    }
-    if (inClass) {
-      i++;
-      continue;
-    }
-    if (s[i] === '+' || s[i] === '*') return true;
-    if (s[i] === '?') {
-      // '?' immediately after '(' is a group modifier ((?:...) etc.), not a quantifier
-      if (i === 0 || s[i - 1] !== '(') return true;
-    }
-    if (s[i] === '{') {
-      const close = s.indexOf('}', i + 1);
-      if (close !== -1) {
-        const inner = s.slice(i + 1, close);
-        if (inner.includes(',')) {
-          const [lo, hi] = inner.split(',', 2);
-          if (hi === '' || lo !== hi) return true; // {m,} or {m,n} with m≠n
-        }
-        i = close + 1;
-        if (i < s.length && s[i] === '?') i++; // skip lazy modifier on fixed quantifier
-        continue;
-      }
-    }
-    i++;
-  }
-  return false;
-}
-
-function hasPythonInvalidLookbehind(re: string): boolean {
-  // Python's re module only supports fixed-width lookbehind.
-  // Variable-width lookbehind (e.g. (?<=\d+)foo) is valid JS but raises
-  // re.error in Python at compile time, breaking server-side categorization.
-  let i = 0;
-  let inClass = false;
-  let escaped = false;
-  while (i < re.length) {
-    if (escaped) {
-      escaped = false;
-      i++;
-      continue;
-    }
-    if (re[i] === '\\') {
-      escaped = true;
-      i++;
-      continue;
-    }
-    if (re[i] === '[' && !inClass) {
-      inClass = true;
-      i++;
-      continue;
-    }
-    if (re[i] === ']' && inClass) {
-      inClass = false;
-      i++;
-      continue;
-    }
-    if (inClass) {
-      i++;
-      continue;
-    }
-    if (re.startsWith('(?<=', i) || re.startsWith('(?<!', i)) {
-      const start = i + 4;
-      let depth = 1;
-      let j = start;
-      let ic = false;
-      let esc = false;
-      while (j < re.length && depth > 0) {
-        if (esc) {
-          esc = false;
-          j++;
-          continue;
-        }
-        if (re[j] === '\\') {
-          esc = true;
-          j++;
-          continue;
-        }
-        if (re[j] === '[' && !ic) {
-          ic = true;
-          j++;
-          continue;
-        }
-        if (re[j] === ']' && ic) {
-          ic = false;
-          j++;
-          continue;
-        }
-        if (!ic) {
-          if (re[j] === '(') depth++;
-          else if (re[j] === ')') depth--;
-        }
-        j++;
-      }
-      const content = re.slice(start, j - 1);
-      if (lookbehindIsVariableWidth(content)) return true;
-      i = j;
-      continue;
-    }
-    i++;
-  }
-  return false;
-}
-
 export function validateRegex(re: string) {
   // validates if pattern is a valid regex in both JavaScript and Python
   // returns true if regex is valid
@@ -222,7 +93,9 @@ export function validateRegex(re: string) {
     return false;
   }
   // Reject JS-only syntax that Python's re module doesn't support.
-  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re) || hasPythonInvalidLookbehind(re)) {
+  // JS named groups (?<name>...) are valid JS but invalid Python (Python uses (?P<name>...)).
+  // Lookbehind (?<=...) and (?<!...) are valid in both, so we allow those.
+  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re)) {
     return false;
   }
   return true;

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -138,10 +138,10 @@ function applyQuantifier(
   if (s[i] === '+' || s[i] === '*') return { added: null, newI: i + 1 };
   if (s[i] === '?') return { added: null, newI: i + 1 };
   if (s[i] === '{') {
-    const close = s.indexOf('}', i + 1);
-    if (close !== -1) {
-      const inner = s.slice(i + 1, close);
-      let newI = close + 1;
+    const closeBrace = s.indexOf('}', i + 1);
+    if (closeBrace !== -1) {
+      const inner = s.slice(i + 1, closeBrace);
+      let newI = closeBrace + 1;
       if (newI < s.length && s[newI] === '?') newI++; // skip lazy modifier
       if (inner.includes(',')) {
         const [lo, hi] = inner.split(',', 2);

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -28,7 +28,7 @@ try {
   // be rejected outright by hasPythonInvalidEscape (fail-safe behavior).
 }
 
-const PYTHON_INVALID_IDENTITY_ESCAPE = /\\[CEFGHIJKLMOPQRTVXYceghijklmnopqyz]/;
+const PYTHON_INVALID_IDENTITY_ESCAPE = /\\[CEFGHIJKLMOPQRTVXYceghijklmopqyz]/;
 const PYTHON_INCOMPLETE_ESCAPE =
   /\\(?:N(?!\{[^}]+\})|u(?![0-9A-Fa-f]{4})|U(?![0-9A-Fa-f]{8})|x(?![0-9A-Fa-f]{2}))/;
 const PYTHON_UNICODE_NAMES = new Set([

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -83,6 +83,293 @@ function hasPythonInvalidEscape(re: string): boolean {
   );
 }
 
+/** Split s on top-level `|` (not inside groups or character classes). */
+function splitTopLevelPipe(s: string): string[] {
+  const result: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let inClass = false;
+  let escaped = false;
+  for (let i = 0; i < s.length; i++) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (s[i] === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (s[i] === '[' && !inClass) {
+      inClass = true;
+      continue;
+    }
+    if (s[i] === ']' && inClass) {
+      inClass = false;
+      continue;
+    }
+    if (inClass) continue;
+    if (s[i] === '(') {
+      depth++;
+      continue;
+    }
+    if (s[i] === ')') {
+      depth--;
+      continue;
+    }
+    if (s[i] === '|' && depth === 0) {
+      result.push(s.slice(start, i));
+      start = i + 1;
+    }
+  }
+  result.push(s.slice(start));
+  return result;
+}
+
+/**
+ * Apply the quantifier at position i in s to an atom of baseWidth.
+ * Returns { added, newI } — added is null if variable-width.
+ */
+function applyQuantifier(
+  s: string,
+  i: number,
+  baseWidth: number
+): { added: number | null; newI: number } {
+  if (i >= s.length) return { added: baseWidth, newI: i };
+  if (s[i] === '+' || s[i] === '*') return { added: null, newI: i + 1 };
+  if (s[i] === '?') return { added: null, newI: i + 1 };
+  if (s[i] === '{') {
+    const close = s.indexOf('}', i + 1);
+    if (close !== -1) {
+      const inner = s.slice(i + 1, close);
+      let newI = close + 1;
+      if (newI < s.length && s[newI] === '?') newI++; // skip lazy modifier
+      if (inner.includes(',')) {
+        const [lo, hi] = inner.split(',', 2);
+        if (hi === '' || lo !== hi) return { added: null, newI };
+        const n = parseInt(lo, 10);
+        return isNaN(n) ? { added: null, newI } : { added: baseWidth * n, newI };
+      }
+      const n = parseInt(inner, 10);
+      return isNaN(n) ? { added: null, newI } : { added: baseWidth * n, newI };
+    }
+  }
+  return { added: baseWidth, newI: i };
+}
+
+/**
+ * Compute the exact fixed width that pattern s always matches.
+ * Returns null if variable-width or undetermined.
+ * Handles alternation: all branches must have the same fixed width.
+ */
+function computePatternWidth(s: string): number | null {
+  const alts = splitTopLevelPipe(s);
+  if (alts.length > 1) {
+    const widths = alts.map(computePatternWidth);
+    if (widths.some(w => w === null)) return null;
+    const unique = new Set(widths);
+    return unique.size === 1 ? (widths[0] as number) : null;
+  }
+
+  let width = 0;
+  let i = 0;
+  let inClass = false;
+  let escaped = false;
+
+  while (i < s.length) {
+    if (escaped) {
+      escaped = false;
+      // Advance past the escaped character itself (e.g., 'd' in '\d') so
+      // that the quantifier check starts at the character after it.
+      i++;
+      const q = applyQuantifier(s, i, 1);
+      if (q.added === null) return null;
+      width += q.added;
+      i = q.newI;
+      continue;
+    }
+    if (s[i] === '\\') {
+      escaped = true;
+      i++;
+      continue;
+    }
+    if (s[i] === '[' && !inClass) {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (s[i] === ']' && inClass) {
+      inClass = false;
+      i++;
+      const q = applyQuantifier(s, i, 1);
+      if (q.added === null) return null;
+      width += q.added;
+      i = q.newI;
+      continue;
+    }
+    if (inClass) {
+      i++;
+      continue;
+    }
+
+    if (s[i] === '(') {
+      // Find matching close paren
+      let depth = 1;
+      let j = i + 1;
+      let ic = false;
+      let esc = false;
+      while (j < s.length && depth > 0) {
+        if (esc) {
+          esc = false;
+          j++;
+          continue;
+        }
+        if (s[j] === '\\') {
+          esc = true;
+          j++;
+          continue;
+        }
+        if (s[j] === '[' && !ic) {
+          ic = true;
+          j++;
+          continue;
+        }
+        if (s[j] === ']' && ic) {
+          ic = false;
+          j++;
+          continue;
+        }
+        if (!ic) {
+          if (s[j] === '(') depth++;
+          else if (s[j] === ')') depth--;
+        }
+        j++;
+      }
+      let inner = s.slice(i + 1, j - 1);
+      i = j;
+
+      // Lookahead/lookbehind — zero width (they assert position, consume nothing)
+      if (/^\?[=!]/.test(inner) || /^\?<[=!]/.test(inner)) {
+        const q = applyQuantifier(s, i, 0);
+        if (q.added === null) return null;
+        width += q.added;
+        i = q.newI;
+        continue;
+      }
+      // Strip non-capturing group prefix (?:, inline flags (?i:, etc.)
+      inner = inner.replace(/^\?[a-z]*:/, '');
+
+      const groupWidth = computePatternWidth(inner);
+      if (groupWidth === null) return null;
+      const q = applyQuantifier(s, i, groupWidth);
+      if (q.added === null) return null;
+      width += q.added;
+      i = q.newI;
+      continue;
+    }
+
+    if (s[i] === '+' || s[i] === '*') return null;
+    if (s[i] === '?') return null; // bare ? (not after a group modifier)
+    if (s[i] === '{' || s[i] === ')') {
+      i++;
+      continue;
+    } // malformed — skip
+
+    // Regular character: width 1
+    i++;
+    const q = applyQuantifier(s, i, 1);
+    if (q.added === null) return null;
+    width += q.added;
+    i = q.newI;
+  }
+  return width;
+}
+
+function lookbehindIsVariableWidth(s: string): boolean {
+  // Python's re requires all lookbehind branches to match a fixed number of
+  // characters. Variable quantifiers (+, *, ?, {m,n}) AND alternation branches
+  // with different fixed widths (e.g. (?<=\d{2}|[a-z]{3})) both cause re.error.
+  return computePatternWidth(s) === null;
+}
+
+function hasPythonInvalidLookbehind(re: string): boolean {
+  // Python's re module only supports fixed-width lookbehind.
+  // Variable-width lookbehind (e.g. (?<=\d+)foo) is valid JS but raises
+  // re.error in Python at compile time, breaking server-side categorization.
+  // This also catches equal-width-check failures: (?<=\d{2}|[a-z]{3}) has
+  // alternation branches with different widths (2 vs 3), which Python rejects.
+  let i = 0;
+  let inClass = false;
+  let escaped = false;
+  while (i < re.length) {
+    if (escaped) {
+      escaped = false;
+      i++;
+      continue;
+    }
+    if (re[i] === '\\') {
+      escaped = true;
+      i++;
+      continue;
+    }
+    if (re[i] === '[' && !inClass) {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (re[i] === ']' && inClass) {
+      inClass = false;
+      i++;
+      continue;
+    }
+    if (inClass) {
+      i++;
+      continue;
+    }
+    // Detect lookbehind: (?<= or (?<!
+    if (re.startsWith('(?<=', i) || re.startsWith('(?<!', i)) {
+      const start = i + 4; // skip (?<= or (?<!
+      // Find matching close paren
+      let depth = 1;
+      let j = start;
+      let ic = false;
+      let esc = false;
+      while (j < re.length && depth > 0) {
+        if (esc) {
+          esc = false;
+          j++;
+          continue;
+        }
+        if (re[j] === '\\') {
+          esc = true;
+          j++;
+          continue;
+        }
+        if (re[j] === '[' && !ic) {
+          ic = true;
+          j++;
+          continue;
+        }
+        if (re[j] === ']' && ic) {
+          ic = false;
+          j++;
+          continue;
+        }
+        if (!ic) {
+          if (re[j] === '(') depth++;
+          else if (re[j] === ')') depth--;
+        }
+        j++;
+      }
+      const body = re.slice(start, j - 1);
+      if (lookbehindIsVariableWidth(body)) return true;
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return false;
+}
+
 export function validateRegex(re: string) {
   // validates if pattern is a valid regex in both JavaScript and Python
   // returns true if regex is valid
@@ -95,7 +382,7 @@ export function validateRegex(re: string) {
   // Reject JS-only syntax that Python's re module doesn't support.
   // JS named groups (?<name>...) are valid JS but invalid Python (Python uses (?P<name>...)).
   // Lookbehind (?<=...) and (?<!...) are valid in both, so we allow those.
-  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re)) {
+  if (hasJavaScriptNamedGroup(re) || hasPythonInvalidEscape(re) || hasPythonInvalidLookbehind(re)) {
     return false;
   }
   return true;

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -361,6 +361,10 @@ function hasPythonInvalidLookbehind(re: string): boolean {
         j++;
       }
       const body = re.slice(start, j - 1);
+      // Python's re module does not support nested lookbehind inside a lookbehind.
+      // The width-check below treats inner (?<=...) as zero-width, so it would
+      // incorrectly pass e.g. (?<=(?<=a)b). Reject any nested lookbehind early.
+      if (/\(\?<[=!]/.test(body)) return true;
       if (lookbehindIsVariableWidth(body)) return true;
       i = j;
       continue;

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -27,6 +27,11 @@ const presetSet: CategorySet = {
   ],
 };
 
+const extraSet: CategorySet = {
+  id: 'extra',
+  categories: [{ name: ['Extra'], rule: { type: 'regex', regex: '^Extra$' } }],
+};
+
 function setPresetGlobal(value: unknown) {
   if (value === undefined) {
     delete (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME];
@@ -82,6 +87,7 @@ describe('parsePresetCategorySets', () => {
           { name: ['Good'], rule: { type: 'regex', regex: '^Good$' } },
           { name: [], rule: { type: 'regex', regex: 'x' } }, // empty name
           { name: ['Bad regex'], rule: { type: 'regex', regex: '[' } }, // uncompilable
+          { name: ['JS only'], rule: { type: 'regex', regex: '(?<year>\\d{4})' } }, // invalid in Python
           { name: ['No rule'] }, // missing rule
           { name: ['Weird'], rule: { type: 'glob' } }, // unknown rule type
           'nonsense',
@@ -212,11 +218,20 @@ describe('getDefaultClasses', () => {
 });
 
 describe('loadCategories with presets', () => {
-  test('first run with no stored settings activates the presets', () => {
+  test('first run with no stored settings activates the preset', () => {
     setPresetGlobal([presetSet]);
     const { sets, activeIds } = loadCategories();
     expect(activeIds).toEqual(['study']);
     expect(sets.map(s => s.id)).toEqual(['study']);
+  });
+
+  test('only the first of several presets is active by default', () => {
+    // Multiple active sets cannot be safely edited/saved (see syncToPrimarySet),
+    // so a shipped default must never land the user in that state.
+    setPresetGlobal([presetSet, extraSet]);
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets.map(s => s.id)).toEqual(['study', 'extra']);
   });
 
   test('first run without presets keeps the legacy default set', () => {
@@ -313,6 +328,24 @@ describe('categories store with presets', () => {
     const classified = classifyEvents(events, categoryStore.classes);
     expect(classified[0].data.$category).toEqual(['Video Streaming']);
     expect(classified[1].data.$category).toEqual(['Uncategorized']);
+  });
+
+  test('edits are synced back into the active preset set on save', () => {
+    // Regression guard: with several sets active the store cannot sync edits
+    // back (syncToPrimarySet bails), so only one preset may be active by default.
+    setPresetGlobal([presetSet, extraSet]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    categoryStore.addClass({ name: ['My Own'], rule: { type: 'regex', regex: '^My Own$' } });
+    expect(categoryStore.classes_unsaved_changes).toBe(true);
+    categoryStore.save();
+
+    const activeSet = categoryStore.category_sets.find(s => s.id === 'study');
+    expect(activeSet.categories.map(c => c.name[0])).toContain('My Own');
+    // untouched sets stay untouched
+    expect(categoryStore.category_sets.find(s => s.id === 'extra').categories).toEqual(
+      extraSet.categories
+    );
   });
 
   test('restore defaults restores the preset, not the built-in categories', () => {

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -1,0 +1,338 @@
+import { setActivePinia, createPinia } from 'pinia';
+
+import {
+  parsePresetCategorySets,
+  getPresetCategorySets,
+  clearPresetCategorySetsCache,
+  PRESET_GLOBAL_NAME,
+} from '~/util/presetCategories';
+import {
+  loadCategories,
+  mergeCategorySets,
+  getDefaultClasses,
+  classifyEvents,
+  defaultCategories,
+  Category,
+  CategorySet,
+} from '~/util/classes';
+import { useSettingsStore } from '~/stores/settings';
+import { useCategoryStore } from '~/stores/categories';
+
+const presetSet: CategorySet = {
+  id: 'study',
+  categories: [
+    { name: ['Music & Audio'], rule: { type: 'regex', regex: '^Music & Audio$' } },
+    { name: ['Video Streaming'], rule: { type: 'regex', regex: '^Video Streaming$' } },
+    { name: ['Excluded'], rule: { type: 'regex', regex: '^Excluded$' } },
+  ],
+};
+
+function setPresetGlobal(value: unknown) {
+  if (value === undefined) {
+    delete (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME];
+  } else {
+    (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME] = value;
+  }
+  clearPresetCategorySetsCache();
+}
+
+beforeEach(() => {
+  setPresetGlobal(undefined);
+  setActivePinia(createPinia());
+});
+
+afterAll(() => {
+  setPresetGlobal(undefined);
+});
+
+describe('parsePresetCategorySets', () => {
+  test('parses a JSON string holding a list of sets', () => {
+    const sets = parsePresetCategorySets(JSON.stringify([presetSet]));
+    expect(sets).toHaveLength(1);
+    expect(sets[0].id).toEqual('study');
+    expect(sets[0].categories).toHaveLength(3);
+  });
+
+  test('accepts an already-parsed value and a single set', () => {
+    expect(parsePresetCategorySets([presetSet])).toHaveLength(1);
+    expect(parsePresetCategorySets(presetSet)).toHaveLength(1);
+  });
+
+  test('returns empty list for absent or empty input', () => {
+    expect(parsePresetCategorySets(undefined)).toEqual([]);
+    expect(parsePresetCategorySets(null)).toEqual([]);
+    expect(parsePresetCategorySets('')).toEqual([]);
+    expect(parsePresetCategorySets('   ')).toEqual([]);
+    expect(parsePresetCategorySets('[]')).toEqual([]);
+  });
+
+  test('never throws on malformed input', () => {
+    expect(parsePresetCategorySets('not json')).toEqual([]);
+    expect(parsePresetCategorySets(42)).toEqual([]);
+    expect(parsePresetCategorySets([{ categories: [] }])).toEqual([]);
+    expect(parsePresetCategorySets([{ id: 'x' }])).toEqual([]);
+    expect(parsePresetCategorySets([{ id: '', categories: [] }])).toEqual([]);
+  });
+
+  test('drops invalid categories but keeps the valid ones', () => {
+    const sets = parsePresetCategorySets([
+      {
+        id: 'mixed',
+        categories: [
+          { name: ['Good'], rule: { type: 'regex', regex: '^Good$' } },
+          { name: [], rule: { type: 'regex', regex: 'x' } }, // empty name
+          { name: ['Bad regex'], rule: { type: 'regex', regex: '[' } }, // uncompilable
+          { name: ['No rule'] }, // missing rule
+          { name: ['Weird'], rule: { type: 'glob' } }, // unknown rule type
+          'nonsense',
+        ],
+      },
+    ]);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].categories.map(c => c.name[0])).toEqual(['Good']);
+  });
+
+  test('drops sets left without any valid category', () => {
+    expect(
+      parsePresetCategorySets([{ id: 'empty', categories: [{ name: ['x'], rule: { type: 42 } }] }])
+    ).toEqual([]);
+  });
+
+  test('normalizes legacy null rule type to none, and keeps data/ignore_case', () => {
+    const sets = parsePresetCategorySets([
+      {
+        id: 'set',
+        categories: [
+          { name: ['Parent'], rule: { type: null } },
+          {
+            name: ['Child'],
+            rule: { type: 'regex', regex: 'x', ignore_case: true },
+            data: { color: '#FFF' },
+          },
+        ],
+      },
+    ]);
+    expect(sets[0].categories[0].rule).toEqual({ type: 'none' });
+    expect(sets[0].categories[1].rule.ignore_case).toBe(true);
+    expect(sets[0].categories[1].data).toEqual({ color: '#FFF' });
+  });
+
+  test('keeps the first of duplicate set ids', () => {
+    const sets = parsePresetCategorySets([
+      presetSet,
+      { id: 'study', categories: [{ name: ['Other'], rule: { type: 'none' } }] },
+    ]);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].categories).toHaveLength(3);
+  });
+});
+
+describe('getPresetCategorySets', () => {
+  test('is empty on a stock build', () => {
+    expect(getPresetCategorySets()).toEqual([]);
+  });
+
+  test('reads presets injected on the global', () => {
+    setPresetGlobal(JSON.stringify([presetSet]));
+    expect(getPresetCategorySets().map(s => s.id)).toEqual(['study']);
+  });
+
+  test('does not hand out a mutable reference to its cache', () => {
+    setPresetGlobal([presetSet]);
+    const first = getPresetCategorySets();
+    first[0].categories[0].name[0] = 'mutated';
+    first[0].categories.pop();
+    expect(getPresetCategorySets()[0].categories.map(c => c.name[0])).toEqual([
+      'Music & Audio',
+      'Video Streaming',
+      'Excluded',
+    ]);
+  });
+});
+
+describe('mergeCategorySets', () => {
+  const setA: CategorySet = {
+    id: 'a',
+    categories: [
+      { name: ['Shared'], rule: { type: 'regex', regex: 'from-a' } },
+      { name: ['OnlyA'], rule: { type: 'regex', regex: 'a' } },
+    ],
+  };
+  const setB: CategorySet = {
+    id: 'b',
+    categories: [
+      { name: ['Shared'], rule: { type: 'regex', regex: 'from-b' } },
+      { name: ['OnlyB'], rule: { type: 'regex', regex: 'b' } },
+    ],
+  };
+
+  test('first set wins on name collision', () => {
+    const merged = mergeCategorySets([setA, setB]);
+    const shared = merged.filter(c => c.name[0] === 'Shared');
+    expect(shared).toHaveLength(1);
+    expect(shared[0].rule.regex).toEqual('from-a');
+  });
+
+  test('priority follows argument order', () => {
+    const merged = mergeCategorySets([setB, setA]);
+    expect(merged.find(c => c.name[0] === 'Shared').rule.regex).toEqual('from-b');
+  });
+
+  test('keeps non-colliding categories from every set, in order', () => {
+    const merged = mergeCategorySets([setA, setB]);
+    expect(merged.map(c => c.name[0])).toEqual(['Shared', 'OnlyA', 'OnlyB']);
+  });
+
+  test('collision is on the full category path, not just the leaf name', () => {
+    const merged = mergeCategorySets([
+      { id: 'a', categories: [{ name: ['Work', 'Email'], rule: { type: 'regex', regex: 'a' } }] },
+      { id: 'b', categories: [{ name: ['Comms', 'Email'], rule: { type: 'regex', regex: 'b' } }] },
+    ]);
+    expect(merged).toHaveLength(2);
+  });
+
+  test('empty input yields no categories', () => {
+    expect(mergeCategorySets([])).toEqual([]);
+  });
+});
+
+describe('getDefaultClasses', () => {
+  test('falls back to the built-in categories without presets', () => {
+    expect(getDefaultClasses()).toEqual(defaultCategories);
+  });
+
+  test('uses the merged presets when the build ships them', () => {
+    setPresetGlobal([presetSet]);
+    expect(getDefaultClasses().map(c => c.name[0])).toEqual([
+      'Music & Audio',
+      'Video Streaming',
+      'Excluded',
+    ]);
+  });
+});
+
+describe('loadCategories with presets', () => {
+  test('first run with no stored settings activates the presets', () => {
+    setPresetGlobal([presetSet]);
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets.map(s => s.id)).toEqual(['study']);
+  });
+
+  test('first run without presets keeps the legacy default set', () => {
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].categories).toEqual(defaultCategories);
+  });
+
+  test('a user with stored classes keeps them; presets are available but inactive', () => {
+    setPresetGlobal([presetSet]);
+    const myClasses: Category[] = [{ name: ['Mine'], rule: { type: 'regex', regex: 'mine' } }];
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({ classes: myClasses, _storedKeys: ['classes'] });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(myClasses);
+    // still selectable by the user
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
+  test('stored sets take precedence over a preset with the same id', () => {
+    setPresetGlobal([presetSet]);
+    const edited: CategorySet = {
+      id: 'study',
+      categories: [{ name: ['Edited'], rule: { type: 'regex', regex: 'edited' } }],
+    };
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [edited],
+      active_set_ids: ['study'],
+      _storedKeys: ['category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].categories.map(c => c.name[0])).toEqual(['Edited']);
+  });
+
+  test('presets are appended to stored sets without changing the active selection', () => {
+    setPresetGlobal([presetSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [{ id: 'mine', categories: defaultCategories }],
+      active_set_ids: ['mine'],
+      _storedKeys: ['category_sets'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['mine']);
+    expect(sets.map(s => s.id)).toEqual(['mine', 'study']);
+  });
+
+  test('drops active ids that no longer resolve to a set', () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [{ id: 'mine', categories: defaultCategories }],
+      active_set_ids: ['gone'],
+      _storedKeys: ['category_sets'],
+    });
+
+    expect(loadCategories().activeIds).toEqual(['mine']);
+  });
+});
+
+describe('categories store with presets', () => {
+  test('loads preset categories on first run', () => {
+    setPresetGlobal([presetSet]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+
+    expect(categoryStore.active_set_ids).toEqual(['study']);
+    expect(categoryStore.classes.map(c => c.name[0])).toEqual([
+      'Music & Audio',
+      'Video Streaming',
+      'Excluded',
+    ]);
+    // ids are assigned so the editor can address them
+    expect(categoryStore.classes.every(c => typeof c.id === 'number')).toBe(true);
+    expect(categoryStore.classes_unsaved_changes).toBe(false);
+  });
+
+  test('rules match on app name, as written by the watcher', () => {
+    setPresetGlobal([presetSet]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+
+    const events = [
+      { timestamp: new Date().toISOString(), duration: 0, data: { app: 'Video Streaming' } },
+      { timestamp: new Date().toISOString(), duration: 0, data: { app: 'Something else' } },
+    ];
+    const classified = classifyEvents(events, categoryStore.classes);
+    expect(classified[0].data.$category).toEqual(['Video Streaming']);
+    expect(classified[1].data.$category).toEqual(['Uncategorized']);
+  });
+
+  test('restore defaults restores the preset, not the built-in categories', () => {
+    setPresetGlobal([presetSet]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    categoryStore.clearAll();
+    categoryStore.restoreDefaultClasses();
+
+    expect(categoryStore.classes.map(c => c.name[0])).toEqual([
+      'Music & Audio',
+      'Video Streaming',
+      'Excluded',
+    ]);
+  });
+
+  test('restore defaults is unchanged on a stock build', () => {
+    const categoryStore = useCategoryStore();
+    categoryStore.restoreDefaultClasses();
+    expect(categoryStore.get_category(['Work'])).toBeTruthy();
+    expect(categoryStore.classes.length).toBeGreaterThan(defaultCategories.length - 1);
+  });
+});

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -82,6 +82,7 @@ describe('parsePresetCategorySets', () => {
           { name: ['Good'], rule: { type: 'regex', regex: '^Good$' } },
           { name: [], rule: { type: 'regex', regex: 'x' } }, // empty name
           { name: ['Bad regex'], rule: { type: 'regex', regex: '[' } }, // uncompilable
+          { name: ['JS only'], rule: { type: 'regex', regex: '(?<year>\\d{4})' } }, // invalid in Python
           { name: ['No rule'] }, // missing rule
           { name: ['Weird'], rule: { type: 'glob' } }, // unknown rule type
           'nonsense',

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -222,6 +222,18 @@ describe('getDefaultClasses', () => {
     setPresetGlobal([presetSet, extraSet]);
     expect(getDefaultClasses().map(c => c.name[0])).not.toContain('Extra');
   });
+
+  test('restores the categories of the named preset set', () => {
+    setPresetGlobal([presetSet, extraSet]);
+    expect(getDefaultClasses('extra').map(c => c.name[0])).toEqual(['Extra']);
+  });
+
+  test('restores the built-in categories for a set the build does not ship', () => {
+    // Never hand one set's categories to another set — the caller writes these
+    // into the active set on save.
+    setPresetGlobal([presetSet, extraSet]);
+    expect(getDefaultClasses('my-own-set')).toEqual(defaultCategories);
+  });
 });
 
 describe('loadCategories with presets', () => {
@@ -368,6 +380,32 @@ describe('categories store with presets', () => {
     expect(activeSet.categories.map(c => c.name[0])).not.toContain('Extra');
     expect(categoryStore.category_sets.find(s => s.id === 'extra').categories).toEqual(
       extraSet.categories
+    );
+  });
+
+  test('restore defaults on a non-preset set does not overwrite it with a preset', () => {
+    setPresetGlobal([presetSet, extraSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [{ id: 'mine', categories: [{ name: ['Mine'], rule: { type: 'none' } }] }],
+      active_set_ids: ['mine'],
+      _storedKeys: ['category_sets'],
+    });
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    expect(categoryStore.active_set_ids).toEqual(['mine']);
+
+    categoryStore.restoreDefaultClasses();
+    categoryStore.save();
+
+    const names = categoryStore.category_sets
+      .find(s => s.id === 'mine')
+      .categories.map(c => c.name[0]);
+    expect(names).not.toContain('Music & Audio');
+    expect(names).toContain('Work');
+    // the preset sets themselves are untouched
+    expect(categoryStore.category_sets.find(s => s.id === 'study').categories).toEqual(
+      presetSet.categories
     );
   });
 

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -27,6 +27,11 @@ const presetSet: CategorySet = {
   ],
 };
 
+const extraSet: CategorySet = {
+  id: 'extra',
+  categories: [{ name: ['Extra'], rule: { type: 'regex', regex: '^Extra$' } }],
+};
+
 function setPresetGlobal(value: unknown) {
   if (value === undefined) {
     delete (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME];
@@ -202,13 +207,20 @@ describe('getDefaultClasses', () => {
     expect(getDefaultClasses()).toEqual(defaultCategories);
   });
 
-  test('uses the merged presets when the build ships them', () => {
+  test('uses the preset when the build ships one', () => {
     setPresetGlobal([presetSet]);
     expect(getDefaultClasses().map(c => c.name[0])).toEqual([
       'Music & Audio',
       'Video Streaming',
       'Excluded',
     ]);
+  });
+
+  test('uses only the first preset — the one activated on a fresh install', () => {
+    // Otherwise "Restore defaults" + save would fold inactive presets into the
+    // active set via syncToPrimarySet().
+    setPresetGlobal([presetSet, extraSet]);
+    expect(getDefaultClasses().map(c => c.name[0])).not.toContain('Extra');
   });
 });
 
@@ -343,6 +355,20 @@ describe('categories store with presets', () => {
       'Video Streaming',
       'Excluded',
     ]);
+  });
+
+  test('restore defaults + save keeps inactive presets out of the active set', () => {
+    setPresetGlobal([presetSet, extraSet]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    categoryStore.restoreDefaultClasses();
+    categoryStore.save();
+
+    const activeSet = categoryStore.category_sets.find(s => s.id === 'study');
+    expect(activeSet.categories.map(c => c.name[0])).not.toContain('Extra');
+    expect(categoryStore.category_sets.find(s => s.id === 'extra').categories).toEqual(
+      extraSet.categories
+    );
   });
 
   test('restore defaults is unchanged on a stock build', () => {

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -27,11 +27,6 @@ const presetSet: CategorySet = {
   ],
 };
 
-const extraSet: CategorySet = {
-  id: 'extra',
-  categories: [{ name: ['Extra'], rule: { type: 'regex', regex: '^Extra$' } }],
-};
-
 function setPresetGlobal(value: unknown) {
   if (value === undefined) {
     delete (globalThis as Record<string, unknown>)[PRESET_GLOBAL_NAME];
@@ -87,7 +82,6 @@ describe('parsePresetCategorySets', () => {
           { name: ['Good'], rule: { type: 'regex', regex: '^Good$' } },
           { name: [], rule: { type: 'regex', regex: 'x' } }, // empty name
           { name: ['Bad regex'], rule: { type: 'regex', regex: '[' } }, // uncompilable
-          { name: ['JS only'], rule: { type: 'regex', regex: '(?<year>\\d{4})' } }, // invalid in Python
           { name: ['No rule'] }, // missing rule
           { name: ['Weird'], rule: { type: 'glob' } }, // unknown rule type
           'nonsense',
@@ -218,20 +212,26 @@ describe('getDefaultClasses', () => {
 });
 
 describe('loadCategories with presets', () => {
-  test('first run with no stored settings activates the preset', () => {
+  test('first run with no stored settings activates the presets', () => {
     setPresetGlobal([presetSet]);
     const { sets, activeIds } = loadCategories();
     expect(activeIds).toEqual(['study']);
     expect(sets.map(s => s.id)).toEqual(['study']);
   });
 
-  test('only the first of several presets is active by default', () => {
-    // Multiple active sets cannot be safely edited/saved (see syncToPrimarySet),
-    // so a shipped default must never land the user in that state.
-    setPresetGlobal([presetSet, extraSet]);
+  test('first run with multiple presets activates only the first (syncToPrimarySet invariant)', () => {
+    const presetSet2: CategorySet = {
+      id: 'work',
+      categories: [{ name: ['Work'], rule: { type: 'regex', regex: '^Work$' } }],
+    };
+    setPresetGlobal([presetSet, presetSet2]);
     const { sets, activeIds } = loadCategories();
+    // Only the first preset is active on first run — activating all would break
+    // syncToPrimarySet, which skips sync when multiple sets are active, causing
+    // category edits to be silently lost on reload.
     expect(activeIds).toEqual(['study']);
-    expect(sets.map(s => s.id)).toEqual(['study', 'extra']);
+    // Both presets are available in the UI
+    expect(sets.map(s => s.id)).toEqual(['study', 'work']);
   });
 
   test('first run without presets keeps the legacy default set', () => {
@@ -328,24 +328,6 @@ describe('categories store with presets', () => {
     const classified = classifyEvents(events, categoryStore.classes);
     expect(classified[0].data.$category).toEqual(['Video Streaming']);
     expect(classified[1].data.$category).toEqual(['Uncategorized']);
-  });
-
-  test('edits are synced back into the active preset set on save', () => {
-    // Regression guard: with several sets active the store cannot sync edits
-    // back (syncToPrimarySet bails), so only one preset may be active by default.
-    setPresetGlobal([presetSet, extraSet]);
-    const categoryStore = useCategoryStore();
-    categoryStore.load();
-    categoryStore.addClass({ name: ['My Own'], rule: { type: 'regex', regex: '^My Own$' } });
-    expect(categoryStore.classes_unsaved_changes).toBe(true);
-    categoryStore.save();
-
-    const activeSet = categoryStore.category_sets.find(s => s.id === 'study');
-    expect(activeSet.categories.map(c => c.name[0])).toContain('My Own');
-    // untouched sets stay untouched
-    expect(categoryStore.category_sets.find(s => s.id === 'extra').categories).toEqual(
-      extraSet.categories
-    );
   });
 
   test('restore defaults restores the preset, not the built-in categories', () => {

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -81,6 +81,9 @@ describe('validateRegex', () => {
     // Alternation with different-width branches: Python raises re.error
     expect(validateRegex('(?<=\\d{2}|[a-z]{3})foo')).toBe(false);
     expect(validateRegex('(?<=a|ab)x')).toBe(false);
+    // Nested lookbehind inside a lookbehind: Python's re does not support it
+    expect(validateRegex('(?<=(?<=a)b)x')).toBe(false);
+    expect(validateRegex('(?<=(?<!a)b)x')).toBe(false);
   });
 });
 

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -8,6 +8,14 @@ describe('validateRegex', () => {
     expect(validateRegex('[a-z]+')).toBe(true);
   });
 
+  test('accepts standard Python regex escape sequences', () => {
+    // \n, \t, \r etc. are valid in both JS and Python regex
+    expect(validateRegex('^app\\nwindow title$')).toBe(true);
+    expect(validateRegex('foo\\tbar')).toBe(true);
+    expect(validateRegex('line\\rend')).toBe(true);
+    expect(validateRegex('\\n+')).toBe(true);
+  });
+
   test('rejects empty string', () => {
     expect(validateRegex('')).toBe(false);
   });

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -56,11 +56,22 @@ describe('validateRegex', () => {
     expect(validateRegex('[abc](?<name>foo)')).toBe(false);
   });
 
+  test('rejects variable-length lookbehind (Python re requires fixed-width)', () => {
+    // Python's re raises re.error for variable-width lookbehind patterns
+    expect(validateRegex('(?<=\\d+)foo')).toBe(false);
+    expect(validateRegex('(?<=a*)bar')).toBe(false);
+    expect(validateRegex('(?<=a?)baz')).toBe(false);
+    expect(validateRegex('(?<=\\d{1,3})foo')).toBe(false);
+    expect(validateRegex('(?<!\\w+)foo')).toBe(false);
+  });
+
   test('accepts lookbehind assertions (valid in both JS and Python)', () => {
     // Positive lookbehind (?<=...) is valid in both
     expect(validateRegex('(?<=foo)bar')).toBe(true);
     // Negative lookbehind (?<!...) is valid in both
     expect(validateRegex('(?<!foo)bar')).toBe(true);
+    // Fixed-width quantifier in lookbehind is fine
+    expect(validateRegex('(?<=\\d{3})foo')).toBe(true);
     // Escaped backslashes and punctuation escapes are accepted by both engines
     expect(validateRegex('foo\\\\qbar')).toBe(true);
     expect(validateRegex('foo\\!bar')).toBe(true);

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -56,22 +56,11 @@ describe('validateRegex', () => {
     expect(validateRegex('[abc](?<name>foo)')).toBe(false);
   });
 
-  test('rejects variable-length lookbehind (Python re requires fixed-width)', () => {
-    // Python's re raises re.error for variable-width lookbehind patterns
-    expect(validateRegex('(?<=\\d+)foo')).toBe(false);
-    expect(validateRegex('(?<=a*)bar')).toBe(false);
-    expect(validateRegex('(?<=a?)baz')).toBe(false);
-    expect(validateRegex('(?<=\\d{1,3})foo')).toBe(false);
-    expect(validateRegex('(?<!\\w+)foo')).toBe(false);
-  });
-
   test('accepts lookbehind assertions (valid in both JS and Python)', () => {
     // Positive lookbehind (?<=...) is valid in both
     expect(validateRegex('(?<=foo)bar')).toBe(true);
     // Negative lookbehind (?<!...) is valid in both
     expect(validateRegex('(?<!foo)bar')).toBe(true);
-    // Fixed-width quantifier in lookbehind is fine
-    expect(validateRegex('(?<=\\d{3})foo')).toBe(true);
     // Escaped backslashes and punctuation escapes are accepted by both engines
     expect(validateRegex('foo\\\\qbar')).toBe(true);
     expect(validateRegex('foo\\!bar')).toBe(true);

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -64,6 +64,23 @@ describe('validateRegex', () => {
     // Escaped backslashes and punctuation escapes are accepted by both engines
     expect(validateRegex('foo\\\\qbar')).toBe(true);
     expect(validateRegex('foo\\!bar')).toBe(true);
+    // Fixed-width quantifiers inside lookbehind are valid
+    expect(validateRegex('(?<=\\d{3})foo')).toBe(true);
+    expect(validateRegex('(?<=abc)foo')).toBe(true);
+    // Lookbehind with equal-width alternation is valid in Python
+    expect(validateRegex('(?<=foo|bar)x')).toBe(true);
+    expect(validateRegex('(?<=\\d{2}|[a-z]{2})x')).toBe(true);
+  });
+
+  test('rejects Python-invalid lookbehind (variable-width or unequal alternation)', () => {
+    // Variable-width quantifiers in lookbehind: invalid in Python
+    expect(validateRegex('(?<=\\d+)foo')).toBe(false);
+    expect(validateRegex('(?<=a*)foo')).toBe(false);
+    expect(validateRegex('(?<=a?)foo')).toBe(false);
+    expect(validateRegex('(?<=\\d{2,3})foo')).toBe(false);
+    // Alternation with different-width branches: Python raises re.error
+    expect(validateRegex('(?<=\\d{2}|[a-z]{3})foo')).toBe(false);
+    expect(validateRegex('(?<=a|ab)x')).toBe(false);
   });
 });
 

--- a/test/unit/validate.test.node.ts
+++ b/test/unit/validate.test.node.ts
@@ -84,6 +84,10 @@ describe('validateRegex', () => {
     // Nested lookbehind inside a lookbehind: Python's re does not support it
     expect(validateRegex('(?<=(?<=a)b)x')).toBe(false);
     expect(validateRegex('(?<=(?<!a)b)x')).toBe(false);
+    // Literal (?<= inside a character class is NOT a nested lookbehind —
+    // the check must be character-class-aware to avoid false rejections.
+    // (?<=[a(?<=z]b) has a fixed-width body [a(?<=z]b (1+1=2 chars) → valid.
+    expect(validateRegex('(?<=[a(?<=z]b)')).toBe(true);
   });
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -91,6 +91,8 @@ export default defineConfig(({ mode }) => {
       PRODUCTION,
       AW_SERVER_URL: process.env.AW_SERVER_URL,
       COMMIT_HASH: process.env.COMMIT_HASH,
+      // Optional JSON preset category sets shipped by this build (see src/util/presetCategories.ts)
+      AW_PRESET_CATEGORY_SETS: JSON.stringify(process.env.AW_PRESET_CATEGORY_SETS || ''),
       'process.env.VUE_APP_ON_ANDROID': process.env.VUE_APP_ON_ANDROID,
     },
   };

--- a/vue.config.js
+++ b/vue.config.js
@@ -52,6 +52,8 @@ export default {
         PRODUCTION: process.env.NODE_ENV === 'production',
         AW_SERVER_URL: process.env.AW_SERVER_URL,
         COMMIT_HASH: JSON.stringify(_COMMIT_HASH),
+        // Optional JSON preset category sets shipped by this build (see src/util/presetCategories.ts)
+        AW_PRESET_CATEGORY_SETS: JSON.stringify(process.env.AW_PRESET_CATEGORY_SETS || ''),
       }),
       new CopyWebpackPlugin({
         patterns: [{ from: 'static/', to: '' }],


### PR DESCRIPTION
## Problem

There is currently no supported way for a build or deployment to ship its own
categorization scheme. The only lever is patching `defaultCategories` in
`src/util/classes.ts`, which is invisible to whoever maintains the build variant
and gets clobbered on every rebase.

This came up while building a research variant of ActivityWatch for a
time-use study: the watcher rewrites `app` to a study category before storing,
but the web UI categorises client-side with its own default regexes, so the
Categories panel showed everything as *Uncategorized* while Top Applications
showed the correct categories. The data was right; the UI disagreed with it.

The `CategorySet` / `active_set_ids` machinery already added for multi-set
support is the right place to fix that generically.

## What this does

Adds a preset mechanism on top of the existing category sets. Nothing
scheme-specific lands in aw-webui — the preset is supplied from outside.

Two sources, checked in order:

1. `globalThis.__AW_PRESET_CATEGORY_SETS__` — for embedders that can set a
   global before boot (Tauri, Android WebView, custom launchers), no rebuild
   needed.
2. `AW_PRESET_CATEGORY_SETS` — a compile-time constant defined by both webpack
   (`vue.config.js`) and Vite (`vite.config.js`) from the env var of the same
   name:

   ```bash
   AW_PRESET_CATEGORY_SETS="$(cat mypreset.json)" npm run build
   ```

Both take the same payload the categorization settings page already
imports/exports: a `CategorySet`, or a list of them.

### Semantics

- Preset sets are **always available** in Settings → Categorization, so the
  user can switch to/combine them.
- They are **only activated by default when the user has no stored
  categorization**. Anyone with saved categories keeps exactly what they had;
  the preset just appears as another set.
- A **stored set with the same id wins** over the preset definition, so user
  edits to a preset survive upgrades.
- **Restore defaults** restores the preset on builds that ship one, instead of
  silently dropping the shipped scheme.
- Presets are validated: unknown rule types, malformed names and
  uncompilable regexes are logged and dropped. A broken preset can never
  prevent the UI from starting.
- **Stock builds ship no presets and behave exactly as before** — every preset
  code path is inert when the list is empty.

### Telling \"never configured\" from \"configured to the default\"

The settings store now records which keys were actually present in storage on
load (`_storedKeys`). It is underscore-prefixed, so it is local to the store and
never persisted — same convention as `_loaded`. Without it there is no way to
distinguish a fresh install from a user whose categories happen to equal the
defaults, and the preset would either never activate or would override real
user config.

## Tests

New `test/unit/presetCategories.test.node.ts` (28 cases):

- payload parsing/validation, including malformed input never throwing
- `mergeCategorySets` priority: first set wins on collision, order preserved,
  collision keyed on the full category path rather than the leaf name
- first run with no stored settings → presets active
- first run without presets → unchanged legacy `default` set
- user with stored classes → their classes kept, preset available but inactive
- stored set shadows the preset with the same id
- dangling active ids are dropped rather than yielding an empty selection
- categories store integration, including rules matching on `app`

`npx tsc --noEmit` and `vue-cli-service lint` are clean (only pre-existing
warnings in the config files). Verified end-to-end that a production build with
`AW_PRESET_CATEGORY_SETS` set bakes the preset into the bundle and the UI loads
it on a fresh profile.

## Docs

README gains a \"Shipping preset categories in a build\" section with the payload
shape and the precedence rules.