### PR TITLE
fix(TopBucketData): refresh selection when instance is reused across views

### DIFF
--- a/src/visualizations/TopBucketData.vue
+++ b/src/visualizations/TopBucketData.vue
@@ -10,7 +10,7 @@ div
         )
     b-col(cols="12", md="6").mb-2
       b-form-group
-        template(#label)
+        template(#label="")
           span Field in event data
           span.info-icon(
             title="Field names come from event data. Dot notation is supported (e.g., data.title)."
@@ -121,6 +121,21 @@ export default {
     },
   },
   watch: {
+    // Vue reuses this component instance when switching between two views that
+    // both have a Top Bucket Data vis at the same position (the v-for in
+    // ActivityView keys by index). data() snapshots the initial* props only on
+    // creation, so a reused instance keeps the previous view's selection and
+    // never refreshes. Re-sync from props whenever they change so each view
+    // shows its own saved bucket/field. Fixes #935.
+    initialBucketId: function () {
+      this.syncFromProps();
+    },
+    initialField: function () {
+      this.syncFromProps();
+    },
+    initialCustomField: function () {
+      this.syncFromProps();
+    },
     selectedBucketId: function () {
       this.emitSelection();
       this.loadEvents();
@@ -148,6 +163,26 @@ export default {
     }
   },
   methods: {
+    syncFromProps() {
+      // Adopt the reused instance to the incoming view's saved selection.
+      // Guard against no-op churn: our own emitSelection() round-trips back
+      // through the parent's stored props, so only react to real changes.
+      const nextBucket = this.initialBucketId || '';
+      const nextField = this.initialField || '';
+      const nextCustom = this.initialCustomField || '';
+      if (
+        nextBucket === this.selectedBucketId &&
+        nextField === this.selectedField &&
+        nextCustom === this.customField
+      ) {
+        return;
+      }
+      this.selectedBucketId = nextBucket;
+      this.selectedField = nextField;
+      this.customField = nextCustom;
+      // If the new view didn't pin a bucket, fall back to the default one.
+      this.setDefaultBucket();
+    },
     setDefaultBucket() {
       if (this.selectedBucketId) return;
       const host = this.activityStore.query_options && this.activityStore.query_options.host;

--- a/test/unit/TopBucketData.test.js
+++ b/test/unit/TopBucketData.test.js
@@ -1,0 +1,83 @@
+import TopBucketData from '~/visualizations/TopBucketData.vue';
+
+// Regression test for #935: switching between two views that both hold a Top
+// Bucket Data vis at the same grid position reused the component instance
+// (ActivityView keys its v-for by index), but the selection lived in data(),
+// snapshotted from the initial* props at creation time, so the reused instance
+// kept the previous view's bucket/field and never refreshed. The fix re-syncs
+// local state from props via syncFromProps() whenever the props change.
+
+const { syncFromProps } = TopBucketData.methods;
+
+function makeCtx(overrides = {}) {
+  const ctx = {
+    initialBucketId: '',
+    initialField: '',
+    initialCustomField: '',
+    selectedBucketId: '',
+    selectedField: '',
+    customField: '',
+    defaultCalls: 0,
+    setDefaultBucket() {
+      ctx.defaultCalls += 1;
+    },
+    ...overrides,
+  };
+  return ctx;
+}
+
+describe('TopBucketData syncFromProps (#935)', () => {
+  test('adopts the incoming view selection when the instance is reused', () => {
+    const ctx = makeCtx({
+      initialBucketId: 'aw-watcher-web_host',
+      initialField: 'url',
+      selectedBucketId: 'aw-watcher-window_host',
+      selectedField: 'app',
+    });
+    syncFromProps.call(ctx);
+    expect(ctx.selectedBucketId).toBe('aw-watcher-web_host');
+    expect(ctx.selectedField).toBe('url');
+    expect(ctx.defaultCalls).toBe(1);
+  });
+
+  test('is a no-op when props already match local state', () => {
+    const ctx = makeCtx({
+      initialBucketId: 'b',
+      initialField: 'app',
+      selectedBucketId: 'b',
+      selectedField: 'app',
+    });
+    syncFromProps.call(ctx);
+    // emitSelection() round-trips our own selection back through the parent's
+    // stored props, so an unchanged prop must not re-trigger a default lookup.
+    expect(ctx.defaultCalls).toBe(0);
+    expect(ctx.selectedBucketId).toBe('b');
+  });
+
+  test('clears stale selection and falls back to default when the new view pins nothing', () => {
+    const ctx = makeCtx({
+      initialBucketId: '',
+      initialField: '',
+      selectedBucketId: 'stale-bucket',
+      selectedField: 'app',
+    });
+    syncFromProps.call(ctx);
+    expect(ctx.selectedBucketId).toBe('');
+    expect(ctx.selectedField).toBe('');
+    expect(ctx.defaultCalls).toBe(1);
+  });
+
+  test('carries a custom field across the switch', () => {
+    const ctx = makeCtx({
+      initialBucketId: 'b',
+      initialField: '__custom',
+      initialCustomField: 'data.title',
+      selectedBucketId: 'b',
+      selectedField: 'app',
+      customField: '',
+    });
+    syncFromProps.call(ctx);
+    expect(ctx.selectedField).toBe('__custom');
+    expect(ctx.customField).toBe('data.title');
+  });
+});


### PR DESCRIPTION
Switching between two views that both have a Top Bucket Data visualization in the same grid position does not refresh its content (bucket / field / events) — you keep seeing the previous view's selection. Reported in #935.

### Root cause

`ActivityView` renders visualizations with `v-for ... :key="index"`, so when two views have a vis in the same slot Vue reuses the component instance across the switch. `TopBucketData` copies its `initial*` props into `data()` — a one-time snapshot taken at creation — so a reused instance never adopts the new view's saved `bucketId` / `field`. Every other visualization binds reactive store data directly, which is why only this one is affected.

### Fix

Watch the `initial*` props and re-sync the local selection whenever they change, falling back to the default bucket when the incoming view pins none. A small guard skips the no-op case, since our own `emitSelection()` round-trips the selection back through the parent's stored props.

### Drive-by (needed for the test)

`template(#label)` → `template(#label="")`. The bare pug attribute is fine in the webpack/vite build (html doctype), but `@vue/vue2-jest` preprocesses pug **without** the html doctype, so `#label` becomes `#label="#label"` and compiles to an invalid `function(#label)` scoped-slot render fn — which made the component impossible to `import` in a unit test. The explicit empty value renders identically in the production build and unblocks the regression test.

### Testing

- Added `test/unit/TopBucketData.test.js` (4 cases: adopts new selection on reuse, no-op when unchanged, clears + falls back when the new view pins nothing, carries a custom field).
- `npm run test:unit` → 67/67 passing (14 suites), lint clean.

Fixes #935