### PR TITLE
fix(layout): preserve bottom margin on small screens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@ div#wrapper(v-if="loaded")
   aw-header
 
   div(:class="{'container': !fullContainer, 'container-fluid': fullContainer}").px-0.px-md-2
-    div.aw-container.my-sm-3.p-3
+    div.aw-container.my-sm-3.mb-3.p-3
       error-boundary
         user-satisfaction-poll
         new-release-notification(v-if="isNewReleaseCheckEnabled")


### PR DESCRIPTION
Fixes the missing bottom margin above the footer content on small screens.

The `my-sm-3` class only applies vertical margin on `sm`+ breakpoints, leaving no bottom margin on extra-small screens. Adding `mb-3` preserves the bottom spacing on all screen sizes while the top margin removal on small screens (the intent of `my-sm-3` alone) is maintained.

**Before**: no bottom padding above footer "Made with ❤" on small screens
**After**: consistent `mb-3` bottom spacing on all screen sizes

Closes ActivityWatch/aw-android#236 (footer margin nit)