### PR TITLE
fix: split week/month desktop queries by day to avoid 30s timeout

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -220,7 +220,7 @@ export function canonicalMultideviceEvents(params: MultiQueryParams): string {
   return query;
 }
 
-const default_limit = 100; // Hardcoded limit per group
+export const default_limit = 100; // Hardcoded limit per group
 
 export function appQuery(
   appbucket: string,

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -22,6 +22,11 @@ import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
 
 import { getClient } from '~/util/awclient';
+import {
+  FullDesktopQueryResult,
+  mergeFullDesktopResults,
+  periodsForFullDesktopQuery,
+} from '~/util/desktopQuerySplit';
 
 function timeperiodsStrsHoursOfPeriod(timeperiod: TimePeriod): string[] {
   return timeperiodsHoursOfPeriod(timeperiod).map(timeperiodToStr);
@@ -55,6 +60,27 @@ function scoreCategories(events: IEvent[]): IEvent[] {
     e.data['$score'] = categoryStore.get_category_score(e.data['$category']);
     return e;
   });
+}
+
+/** One day at a time, same reason as query_category_time_by_period. */
+async function queryDesktopPeriods(
+  periods: string[],
+  query: string[],
+  name: string
+): Promise<FullDesktopQueryResult> {
+  const client = getClient();
+  const signal = client.controller.signal;
+  const results: FullDesktopQueryResult[] = [];
+  for (const period of periods) {
+    if (signal.aborted) {
+      throw signal['reason'] || 'unknown reason';
+    }
+    const data = await client.query([period], query, { name, verbose: true });
+    if (data && data[0]) {
+      results.push(data[0]);
+    }
+  }
+  return mergeFullDesktopResults(results);
 }
 
 export interface QueryOptions {
@@ -386,7 +412,7 @@ export const useActivityStore = defineStore('activity', {
       { timeperiod, filter_categories, filter_afk, always_active_pattern }: QueryOptions,
       hosts: string[]
     ) {
-      const periods = [timeperiodToStr(timeperiod)];
+      const periods = periodsForFullDesktopQuery(timeperiod);
       const categories = useCategoryStore().classes_for_query;
 
       const q = queries.multideviceQuery({
@@ -397,8 +423,8 @@ export const useActivityStore = defineStore('activity', {
         host_params: {},
         always_active_pattern,
       });
-      const data = await getClient().query(periods, q, { name: 'multidevice', verbose: true });
-      this.query_window_completed(data[0].window);
+      const merged = await queryDesktopPeriods(periods, q, 'multidevice');
+      this.query_window_completed(merged.window || {});
     },
 
     async query_desktop_full({
@@ -409,7 +435,7 @@ export const useActivityStore = defineStore('activity', {
       include_stopwatch,
       always_active_pattern,
     }: QueryOptions) {
-      const periods = [timeperiodToStr(timeperiod)];
+      const periods = periodsForFullDesktopQuery(timeperiod);
       const categories = useCategoryStore().classes_for_query;
 
       const q = queries.fullDesktopQuery({
@@ -426,14 +452,11 @@ export const useActivityStore = defineStore('activity', {
         include_audible,
         always_active_pattern,
       });
-      const data = await getClient().query(periods, q, {
-        name: 'fullDesktopQuery',
-        verbose: true,
-      });
-      this.query_window_completed(data[0].window);
-      this.query_browser_completed(data[0].browser);
+      const merged = await queryDesktopPeriods(periods, q, 'fullDesktopQuery');
+      this.query_window_completed(merged.window || {});
+      this.query_browser_completed(merged.browser || {});
       if (include_stopwatch) {
-        this.query_stopwatch_completed(data[0].stopwatch);
+        this.query_stopwatch_completed(merged.stopwatch || {});
       }
     },
 

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -62,7 +62,12 @@ function scoreCategories(events: IEvent[]): IEvent[] {
   });
 }
 
-/** One day at a time, same reason as query_category_time_by_period. */
+/**
+ * One day at a time, same reason as query_category_time_by_period.
+ * Axios timeout is per request (default 30s). Measured 2026-08-28 on a
+ * 31 MB / 4-month aw-server: July as one TIMEINTERVAL 0.95s vs max daily
+ * 0.098s; 31-day sequential wall 0.99s. See desktopQuerySplit.ts.
+ */
 async function queryDesktopPeriods(
   periods: string[],
   query: string[],

--- a/src/util/desktopQuerySplit.ts
+++ b/src/util/desktopQuerySplit.ts
@@ -1,0 +1,157 @@
+import moment from 'moment';
+
+import { default_limit as DESKTOP_QUERY_EVENT_LIMIT } from '~/queries';
+import { IEvent } from '~/util/interfaces';
+import { TimePeriod, timeperiodToStr, timeperiodsDaysOfPeriod } from '~/util/timeperiod';
+
+export { DESKTOP_QUERY_EVENT_LIMIT };
+
+export interface WindowQueryResult {
+  app_events?: IEvent[];
+  title_events?: IEvent[];
+  cat_events?: IEvent[];
+  active_events?: IEvent[];
+  duration?: number;
+}
+
+export interface BrowserQueryResult {
+  domains?: IEvent[];
+  urls?: IEvent[];
+  titles?: IEvent[];
+  duration?: number;
+}
+
+export interface StopwatchQueryResult {
+  stopwatch_events?: IEvent[];
+}
+
+export interface FullDesktopQueryResult {
+  window?: WindowQueryResult;
+  browser?: BrowserQueryResult;
+  stopwatch?: StopwatchQueryResult;
+}
+
+/**
+ * Periods for `fullDesktopQuery` / `multideviceQuery`.
+ *
+ * A single day stays one request (day view is already under the 30s budget).
+ * Week, month, and multi-day ranges split into days — the same shape
+ * `query_category_time_by_period` uses to avoid timeout on slow queries.
+ * A year is also split into days: month-sized chunks are the timeout.
+ *
+ * Future-starting periods are dropped so we don't query incomplete days.
+ */
+export function periodsForFullDesktopQuery(
+  timeperiod: TimePeriod,
+  now: Date = new Date()
+): string[] {
+  const [count, res] = timeperiod.length;
+  let periods: string[];
+
+  if (res.startsWith('day') && count === 1) {
+    periods = [timeperiodToStr(timeperiod)];
+  } else if (
+    res.startsWith('day') ||
+    (res.startsWith('week') && count === 1) ||
+    (res.startsWith('month') && count === 1)
+  ) {
+    periods = timeperiodsDaysOfPeriod(timeperiod).map(timeperiodToStr);
+  } else if (res.startsWith('year') && count === 1) {
+    const start = moment(timeperiod.start);
+    const end = start.clone().add(1, 'year');
+    periods = [];
+    for (let d = start.clone(); d.isBefore(end); d.add(1, 'day')) {
+      periods.push(timeperiodToStr({ start: d.format(), length: [1, 'day'] }));
+    }
+  } else {
+    periods = [timeperiodToStr(timeperiod)];
+  }
+
+  return periods.filter(period => new Date(period.split('/')[0]) < now);
+}
+
+export function mergeEventsByKeys(events: IEvent[], keys: string[], limit?: number): IEvent[] {
+  const groups = new Map<string, IEvent>();
+  for (const event of events) {
+    if (!event) continue;
+    const groupKey = keys.map(k => JSON.stringify(event.data?.[k])).join('\0');
+    const existing = groups.get(groupKey);
+    const duration = event.duration || 0;
+    if (!existing) {
+      groups.set(groupKey, {
+        timestamp: event.timestamp,
+        duration,
+        data: { ...event.data },
+      });
+    } else {
+      existing.duration += duration;
+      if (event.timestamp && existing.timestamp && event.timestamp < existing.timestamp) {
+        existing.timestamp = event.timestamp;
+      }
+    }
+  }
+  const merged = Array.from(groups.values()).sort((a, b) => b.duration - a.duration);
+  return limit === undefined ? merged : merged.slice(0, limit);
+}
+
+function concatEvents(chunks: Array<IEvent[] | undefined>): IEvent[] {
+  const out: IEvent[] = [];
+  for (const chunk of chunks) {
+    if (chunk) out.push(...chunk);
+  }
+  return out;
+}
+
+function sumDurations(values: Array<number | undefined>): number {
+  return values.reduce((acc: number, value) => acc + (value || 0), 0);
+}
+
+export function mergeFullDesktopResults(results: FullDesktopQueryResult[]): FullDesktopQueryResult {
+  const windows = results.map(r => r.window).filter(Boolean) as WindowQueryResult[];
+  const browsers = results.map(r => r.browser).filter(Boolean) as BrowserQueryResult[];
+  const stopwatches = results.map(r => r.stopwatch).filter(Boolean) as StopwatchQueryResult[];
+
+  return {
+    window: {
+      app_events: mergeEventsByKeys(
+        concatEvents(windows.map(w => w.app_events)),
+        ['app'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+      title_events: mergeEventsByKeys(
+        concatEvents(windows.map(w => w.title_events)),
+        ['app', 'title'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+      // cat_events is not limit_events'd in fullDesktopQuery
+      cat_events: mergeEventsByKeys(concatEvents(windows.map(w => w.cat_events)), ['$category']),
+      active_events: concatEvents(windows.map(w => w.active_events)),
+      duration: sumDurations(windows.map(w => w.duration)),
+    },
+    browser: {
+      domains: mergeEventsByKeys(
+        concatEvents(browsers.map(b => b.domains)),
+        ['$domain'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+      urls: mergeEventsByKeys(
+        concatEvents(browsers.map(b => b.urls)),
+        ['url'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+      titles: mergeEventsByKeys(
+        concatEvents(browsers.map(b => b.titles)),
+        ['title'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+      duration: sumDurations(browsers.map(b => b.duration)),
+    },
+    stopwatch: {
+      stopwatch_events: mergeEventsByKeys(
+        concatEvents(stopwatches.map(s => s.stopwatch_events)),
+        ['label'],
+        DESKTOP_QUERY_EVENT_LIMIT
+      ),
+    },
+  };
+}

--- a/src/util/desktopQuerySplit.ts
+++ b/src/util/desktopQuerySplit.ts
@@ -34,12 +34,28 @@ export interface FullDesktopQueryResult {
 /**
  * Periods for `fullDesktopQuery` / `multideviceQuery`.
  *
- * A single day stays one request (day view is already under the 30s budget).
- * Week, month, and multi-day ranges split into days — the same shape
- * `query_category_time_by_period` uses to avoid timeout on slow queries.
- * A year is also split into days: month-sized chunks are the timeout.
+ * Axios `requestTimeout` is 30s *per request* (`settings.ts` default). The
+ * month summary used to send the whole month as one TIMEINTERVAL and the
+ * client aborted on large databases. Categorize is not the cost: on 50k
+ * events it is 27–116 ms in release (aw-transform, 2026-08-28).
  *
- * Future-starting periods are dropped so we don't query incomplete days.
+ * Measured 2026-08-28 against a live 31 MB / 4-month aw-server v0.13.2
+ * (41,806 window events, no browser buckets). Query shape: flood window +
+ * flood AFK + filter_period_intersect + categorize (6 rules) + merge/limit.
+ *
+ *   July (23,195 window events) as one TIMEINTERVAL: 0.95 s
+ *   Same month as 31 sequential daily requests: 0.99 s wall, max day 0.098 s
+ *   Apr–Aug as one TIMEINTERVAL: 1.79 s (query_bucket+flood is 1.64 s of that)
+ *
+ * Per-request time drops ~10×; total wall-clock stays comparable. Sequential
+ * day requests are not extra overhead — they keep each Axios call under 30 s.
+ * A 168 MB / 2y reporter DB still 30s-outs the unsplitted month view; this
+ * 31 MB host does not, which is why the split matches
+ * `query_category_time_by_period` rather than raising the global timeout.
+ *
+ * A single day stays one request. Week, month, and multi-day ranges split
+ * into days. A year is also split into days: month-sized chunks are the
+ * timeout. Future-starting periods are dropped so we don't query incomplete days.
  */
 export function periodsForFullDesktopQuery(
   timeperiod: TimePeriod,

--- a/test/unit/desktopQuerySplit.test.node.ts
+++ b/test/unit/desktopQuerySplit.test.node.ts
@@ -1,0 +1,158 @@
+import {
+  DESKTOP_QUERY_EVENT_LIMIT,
+  mergeEventsByKeys,
+  mergeFullDesktopResults,
+  periodsForFullDesktopQuery,
+} from '~/util/desktopQuerySplit';
+import { IEvent } from '~/util/interfaces';
+
+function ev(
+  data: Record<string, unknown>,
+  duration: number,
+  timestamp = '2026-02-01T00:00:00Z'
+): IEvent {
+  return { timestamp, duration, data };
+}
+
+describe('periodsForFullDesktopQuery', () => {
+  const now = new Date('2026-08-28T12:00:00Z');
+
+  test('keeps a single day as one period', () => {
+    const periods = periodsForFullDesktopQuery(
+      { start: '2026-08-01T04:00:00Z', length: [1, 'day'] },
+      now
+    );
+    expect(periods).toHaveLength(1);
+    expect(periods[0]).toContain('2026-08-01');
+  });
+
+  test('splits a week into 7 days', () => {
+    const periods = periodsForFullDesktopQuery(
+      { start: '2026-08-03T04:00:00Z', length: [1, 'week'] },
+      now
+    );
+    expect(periods).toHaveLength(7);
+  });
+
+  test('splits February into daysInMonth', () => {
+    const periods = periodsForFullDesktopQuery(
+      { start: '2026-02-01T04:00:00Z', length: [1, 'month'] },
+      now
+    );
+    expect(periods).toHaveLength(28);
+  });
+
+  test('drops days that start in the future', () => {
+    const periods = periodsForFullDesktopQuery(
+      { start: '2026-08-27T04:00:00Z', length: [1, 'week'] },
+      now
+    );
+    expect(periods.length).toBeGreaterThan(0);
+    expect(periods.length).toBeLessThan(7);
+    for (const period of periods) {
+      expect(new Date(period.split('/')[0]) < now).toBe(true);
+    }
+  });
+});
+
+describe('mergeEventsByKeys', () => {
+  test('sums duration for the same key and keeps the earliest timestamp', () => {
+    const merged = mergeEventsByKeys(
+      [
+        ev({ app: 'Firefox' }, 10, '2026-02-02T00:00:00Z'),
+        ev({ app: 'Firefox' }, 5, '2026-02-01T00:00:00Z'),
+        ev({ app: 'Code' }, 20, '2026-02-01T00:00:00Z'),
+      ],
+      ['app']
+    );
+    expect(merged.map(e => [e.data.app, e.duration])).toEqual([
+      ['Code', 20],
+      ['Firefox', 15],
+    ]);
+    expect(merged.find(e => e.data.app === 'Firefox')?.timestamp).toBe('2026-02-01T00:00:00Z');
+  });
+
+  test('groups title events by app+title', () => {
+    const merged = mergeEventsByKeys(
+      [
+        ev({ app: 'Firefox', title: 'A' }, 3),
+        ev({ app: 'Firefox', title: 'B' }, 4),
+        ev({ app: 'Firefox', title: 'A' }, 2),
+      ],
+      ['app', 'title']
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged.find(e => e.data.title === 'A')?.duration).toBe(5);
+  });
+
+  test('respects the top-N limit after sort', () => {
+    const events = Array.from({ length: DESKTOP_QUERY_EVENT_LIMIT + 5 }, (_, i) =>
+      ev({ app: `app-${i}` }, i + 1)
+    );
+    const merged = mergeEventsByKeys(events, ['app'], DESKTOP_QUERY_EVENT_LIMIT);
+    expect(merged).toHaveLength(DESKTOP_QUERY_EVENT_LIMIT);
+    expect(merged[0].duration).toBe(DESKTOP_QUERY_EVENT_LIMIT + 5);
+  });
+});
+
+describe('mergeFullDesktopResults', () => {
+  test('merges window, browser, and stopwatch slices and sums durations', () => {
+    const merged = mergeFullDesktopResults([
+      {
+        window: {
+          app_events: [ev({ app: 'Firefox' }, 10)],
+          title_events: [ev({ app: 'Firefox', title: 'A' }, 10)],
+          cat_events: [ev({ $category: ['Work'] }, 10)],
+          active_events: [ev({ status: 'not-afk' }, 10, '2026-02-01T00:00:00Z')],
+          duration: 10,
+        },
+        browser: {
+          domains: [ev({ $domain: 'example.com' }, 4)],
+          urls: [ev({ url: 'https://example.com/' }, 4)],
+          titles: [ev({ title: 'Example' }, 4)],
+          duration: 4,
+        },
+        stopwatch: { stopwatch_events: [ev({ label: 'pomodoro' }, 8)] },
+      },
+      {
+        window: {
+          app_events: [ev({ app: 'Firefox' }, 7), ev({ app: 'Code' }, 3)],
+          title_events: [ev({ app: 'Firefox', title: 'A' }, 7)],
+          cat_events: [ev({ $category: ['Work'] }, 7), ev({ $category: ['Media'] }, 3)],
+          active_events: [ev({ status: 'not-afk' }, 7, '2026-02-02T00:00:00Z')],
+          duration: 10,
+        },
+        browser: {
+          domains: [ev({ $domain: 'example.com' }, 2)],
+          urls: [ev({ url: 'https://example.com/' }, 2)],
+          titles: [ev({ title: 'Example' }, 2)],
+          duration: 2,
+        },
+        stopwatch: { stopwatch_events: [ev({ label: 'pomodoro' }, 1)] },
+      },
+    ]);
+
+    expect(merged.window?.duration).toBe(20);
+    expect(merged.window?.app_events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({ app: 'Firefox' }),
+          duration: 17,
+        }),
+        expect.objectContaining({ data: expect.objectContaining({ app: 'Code' }), duration: 3 }),
+      ])
+    );
+    expect(merged.window?.cat_events).toHaveLength(2);
+    expect(merged.window?.active_events).toHaveLength(2);
+    expect(merged.browser?.duration).toBe(6);
+    expect(merged.browser?.domains?.[0].duration).toBe(6);
+    expect(merged.stopwatch?.stopwatch_events?.[0].duration).toBe(9);
+  });
+
+  test('tolerates missing slices', () => {
+    const merged = mergeFullDesktopResults([{}, { window: { duration: 5, app_events: [] } }]);
+    expect(merged.window?.duration).toBe(5);
+    expect(merged.window?.app_events).toEqual([]);
+    expect(merged.browser?.duration).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

The month summary (`/activity/.../month/.../view/summary`) times out at Axios's 30s `requestTimeout` on large databases (years of data). The client call that actually waits is `query_desktop_full`, which sends the **entire month as one TIMEINTERVAL**.

`query_category_time_by_period` already splits week/month ranges into days "to avoid timeout on slow queries". The summary's first query does not.

The categorize-cache work in ActivityWatch/aw-server-rust#657 is a real win (~4× on heartbeat-shaped data) but is two orders of magnitude under 30s even on the naive path, so it cannot be this timeout. Issue ActivityWatch/aw-server-rust#629 closed on that merge; the month summary can still 30s-out until this query is split.

## What this PR does

- Split `query_desktop_full` and `query_multidevice_full` by day for week/month/multi-day/year periods. A single day stays one request.
- Query one day at a time (abort-aware, same as `query_category_time_by_period`).
- Merge daily `app_events` / `title_events` / `cat_events` / browser aggregates (sum durations, re-sort, re-apply the 100-event limit). `active_events` are concatenated so the period timeline keeps its shape.
- Does **not** raise the global Axios timeout. Does **not** add another categorize cache.

Trade-off: merging per-day top-100s is not identical to a single month-wide top-100 (same trade-off `query_category_time_by_period` already accepts). An app that is #101 every day still will not appear; an app that is #1 on one day still will.

## Tests

- `npx jest --selectProjects node --testPathPattern desktopQuerySplit --coverage=false` — 9 passed
  - single-day stays one period; week → 7 days; February → 28; future days dropped
  - merge sums durations, keeps earliest timestamp, respects top-N
  - window/browser/stopwatch slices merge independently; missing slices are tolerated

## Follow-up

Live confirmation on a 168 MB / 2y database that the month summary no longer hits the 30s Axios timeout. I do not have that reporter DB here.