### PR TITLE
fix(query): use native date inputs in query options

### DIFF
--- a/src/components/QueryOptions.vue
+++ b/src/components/QueryOptions.vue
@@ -60,6 +60,8 @@ export default Vue.extend({
       ...this.queryOptionsData,
       hostname: this.hostnameChoices[0],
       ...this.queryOptions,
+      start: moment(this.queryOptions?.start || this.queryOptionsData.start).format('YYYY-MM-DD'),
+      stop: moment(this.queryOptions?.stop || this.queryOptionsData.stop).format('YYYY-MM-DD'),
     };
     this.$emit('input', this.queryOptionsData);
   },

--- a/src/components/QueryOptions.vue
+++ b/src/components/QueryOptions.vue
@@ -5,9 +5,9 @@ div
       option(v-for="hostname in hostnameChoices")
         | {{hostname}}
   b-form-group(label="Start" label-cols=2)
-    b-form-datepicker(v-model="queryOptionsData.start")
+    input.form-control(type="date" v-model="queryOptionsData.start")
   b-form-group(label="Stop" label-cols=2)
-    b-form-datepicker(v-model="queryOptionsData.stop")
+    input.form-control(type="date" v-model="queryOptionsData.stop")
   b-form-group(label="Toggles" label-cols=2)
     b-form-checkbox(type="checkbox" v-model="queryOptionsData.filter_afk" label="Filter AFK" description="")
       label Exclude time away from computer

--- a/src/components/QueryOptions.vue
+++ b/src/components/QueryOptions.vue
@@ -60,8 +60,6 @@ export default Vue.extend({
       ...this.queryOptionsData,
       hostname: this.hostnameChoices[0],
       ...this.queryOptions,
-      start: moment(this.queryOptions?.start || this.queryOptionsData.start).format('YYYY-MM-DD'),
-      stop: moment(this.queryOptions?.stop || this.queryOptionsData.stop).format('YYYY-MM-DD'),
     };
     this.$emit('input', this.queryOptionsData);
   },

--- a/src/views/Graph.vue
+++ b/src/views/Graph.vue
@@ -207,7 +207,9 @@ export default {
       return { nodes, links };
     },
     extendByWeek() {
-      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.queryOptions.start = moment(this.queryOptions.start)
+        .subtract(1, 'week')
+        .format('YYYY-MM-DD');
       this.generate();
     },
   },

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -176,7 +176,9 @@ export default {
     },
 
     extendByWeek() {
-      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.queryOptions.start = moment(this.queryOptions.start)
+        .subtract(1, 'week')
+        .format('YYYY-MM-DD');
       this.generate();
     },
   },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -64,8 +64,8 @@ export default {
       // Options
       show_options: false,
       queryOptions: {
-        start: moment().subtract(1, 'day'),
-        stop: moment().add(1, 'day'),
+        start: moment().subtract(1, 'day').format('YYYY-MM-DD'),
+        stop: moment().add(1, 'day').format('YYYY-MM-DD'),
       },
     };
   },
@@ -97,7 +97,9 @@ export default {
       }
     },
     extendByWeek() {
-      this.queryOptions.start = moment(this.queryOptions.start).subtract(1, 'week');
+      this.queryOptions.start = moment(this.queryOptions.start)
+        .subtract(1, 'week')
+        .format('YYYY-MM-DD');
       this.search();
     },
   },

--- a/src/views/settings/CategoryBuilder.vue
+++ b/src/views/settings/CategoryBuilder.vue
@@ -150,8 +150,8 @@ export default {
       show_options: false,
       queryOptions: {
         hostname: '',
-        start: moment().subtract(1, 'day'),
-        stop: moment().add(1, 'day'),
+        start: moment().subtract(1, 'day').format('YYYY-MM-DD'),
+        stop: moment().add(1, 'day').format('YYYY-MM-DD'),
       },
 
       // TODO: Support inspecting a different category than Uncategorized (e.g. to make some category more precise)

--- a/test/unit/QueryOptions.test.js
+++ b/test/unit/QueryOptions.test.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import { createPinia, setActivePinia } from 'pinia';
 import { shallowMount } from '@vue/test-utils';
 import QueryOptions from '~/components/QueryOptions.vue';
+import Search from '~/views/Search.vue';
 
 const mockEnsureLoaded = jest.fn().mockResolvedValue(undefined);
 
@@ -18,12 +19,12 @@ describe('QueryOptions', () => {
     mockEnsureLoaded.mockClear();
   });
 
-  test('normalizes Moment date props for native date inputs', async () => {
+  test('renders date range values in native date inputs', async () => {
     const wrapper = shallowMount(QueryOptions, {
       propsData: {
         queryOptions: {
-          start: moment('2026-08-15'),
-          stop: moment('2026-08-16'),
+          start: '2026-08-15',
+          stop: '2026-08-16',
         },
       },
       stubs: {
@@ -40,5 +41,24 @@ describe('QueryOptions', () => {
     expect(dateInputs).toHaveLength(2);
     expect(dateInputs.at(0).element.value).toBe('2026-08-15');
     expect(dateInputs.at(1).element.value).toBe('2026-08-16');
+  });
+
+  test.each([Search])('initializes date ranges as YYYY-MM-DD strings', view => {
+    const data = view.data();
+
+    expect(data.queryOptions.start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(data.queryOptions.stop).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test.each([Search])('keeps extended ranges compatible with date inputs', view => {
+    const vm = {
+      queryOptions: { start: moment('2026-08-15') },
+      search: jest.fn(),
+      generate: jest.fn(),
+    };
+
+    view.methods.extendByWeek.call(vm);
+
+    expect(vm.queryOptions.start).toBe('2026-08-08');
   });
 });

--- a/test/unit/QueryOptions.test.js
+++ b/test/unit/QueryOptions.test.js
@@ -1,0 +1,44 @@
+import moment from 'moment';
+import { createPinia, setActivePinia } from 'pinia';
+import { shallowMount } from '@vue/test-utils';
+import QueryOptions from '~/components/QueryOptions.vue';
+
+const mockEnsureLoaded = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('~/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    ensureLoaded: mockEnsureLoaded,
+    hosts: ['laptop'],
+  }),
+}));
+
+describe('QueryOptions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockEnsureLoaded.mockClear();
+  });
+
+  test('normalizes Moment date props for native date inputs', async () => {
+    const wrapper = shallowMount(QueryOptions, {
+      propsData: {
+        queryOptions: {
+          start: moment('2026-08-15'),
+          stop: moment('2026-08-16'),
+        },
+      },
+      stubs: {
+        'b-form-group': { template: '<div><slot /></div>' },
+        'b-form-select': true,
+        'b-form-checkbox': true,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const dateInputs = wrapper.findAll('input[type="date"]');
+    expect(dateInputs).toHaveLength(2);
+    expect(dateInputs.at(0).element.value).toBe('2026-08-15');
+    expect(dateInputs.at(1).element.value).toBe('2026-08-16');
+  });
+});


### PR DESCRIPTION
## What changed

Replace the Start and Stop BootstrapVue date pickers in `QueryOptions.vue` with native `input type="date"` controls. Search, Report, Graph, and Category Builder share this component, so they now support keyboard date entry and platform-native date selection consistently with Query Explorer.

The affected callers now keep date values in `YYYY-MM-DD` form both initially and when extending a range, preserving query semantics while satisfying native input requirements.

Fixes ActivityWatch/aw-webui#944

## Verification

- `vue-cli-service lint` on all changed Vue/test files
- `tsc --noEmit --pretty false`
- `jest --selectProjects jsdom --runInBand test/unit/QueryOptions.test.js` (3 tests)
- Playwright smoke test on Search, Report, and Graph: two visible native date controls per view; keyboard-filled `2026-08-15` / `2026-08-16` values persisted