### PR TITLE
docs(ai-summary): link the published agents-and-ai guide

### DIFF
--- a/src/views/AISummaryView.vue
+++ b/src/views/AISummaryView.vue
@@ -6,7 +6,7 @@ div
     | Your API key is kept only in this page's memory and sent directly to the LLM provider.
     |  It is cleared when the page reloads and ActivityWatch does not receive it.
     |  For deeper analysis with agents, see the
-    |  #[a(href="https://docs.activitywatch.net/en/latest/examples/querying-data.html") ActivityWatch querying guide].
+    |  #[a(href="https://docs.activitywatch.net/en/latest/examples/agents-and-ai.html") ActivityWatch agents and AI guide].
 
   div.row.mb-3
     div.col-md-4


### PR DESCRIPTION
## Summary

The dev-mode `/analysis/activity` page still pointed at the querying-data guide as a temporary next step. The privacy-first agents/AI guide from ActivityWatch/docs#176 is now published, so this retargets that link.

- old: https://docs.activitywatch.net/en/latest/examples/querying-data.html
- new: https://docs.activitywatch.net/en/latest/examples/agents-and-ai.html

This is the remaining acceptance step on ActivityWatch/activitywatch#1388 after docs#176 merged. QueryExplorer still links to the querying-data page, which is the right docs page for writing queries.

Follow-up to #922. Does not close ActivityWatch/activitywatch#1388 until this lands on master.

## Test plan

- [x] Published destination returns 200
- [ ] Confirm the analysis page alert link opens the agents-and-ai guide