### PR TITLE
fix(ci): find server logs under the testing cache root, never fail on absence

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -177,20 +177,38 @@ jobs:
       with:
         name: screenshots-${{ matrix.aw-server }}-${{ matrix.aw-version }}
         path: screenshots/dist/*
+    # NOTE: the glob covers both cache roots. Since ActivityWatch/aw-server-rust#652
+    # a --testing server on a machine with no legacy testing data logs under
+    # ~/.cache/activitywatch-testing/, while released builds still use
+    # ~/.cache/activitywatch/. These are diagnostic steps, so a missing log
+    # directory must never fail the job.
     - name: Print server logs to console
       if: ${{ always() }}
       shell: bash
-      run:
-        for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done
+      run: |
+        shopt -s nullglob
+        logs=(~/.cache/activitywatch*/log/*/*.log)
+        if [ ${#logs[@]} -eq 0 ]; then
+          echo "No server logs found under ~/.cache/activitywatch*/log/"
+          exit 0
+        fi
+        for file in "${logs[@]}"; do echo "$file"; cat "$file"; echo; done
     - name: Move logs to subdir
       # Run this step even if e2e tests flag failure
       if: ${{ always() }}
+      shell: bash
       env:
         aw_server: ${{ matrix.aw-server }}
         aw_version: ${{ matrix.aw-version }}
       run: |
-        mkdir -p logs/dist/$aw_server/$aw_version
-        mv ~/.cache/activitywatch/log/*/*.log logs/dist/$aw_server/$aw_version
+        shopt -s nullglob
+        logs=(~/.cache/activitywatch*/log/*/*.log)
+        if [ ${#logs[@]} -eq 0 ]; then
+          echo "No server logs to move"
+          exit 0
+        fi
+        mkdir -p "logs/dist/$aw_server/$aw_version"
+        mv "${logs[@]}" "logs/dist/$aw_server/$aw_version"
     - name: Upload logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
The `Test (node-20, py-3.9, aw-server-rust master)` matrix leg is failing on **every** PR right now (e.g. #960, #961). The tests themselves pass — the job dies in the post-test log-collection steps:

```
cat: '/home/runner/.cache/activitywatch/log/*/*.log': No such file or directory
##[error]Process completed with exit code 1.
mv: cannot stat '/home/runner/.cache/activitywatch/log/*/*.log': No such file or directory
##[error]Process completed with exit code 1.
```

## Root cause

ActivityWatch/aw-server-rust#652 (named instance profiles, merged 2026-08-31) changed `get_user_log_dir()` from a hardcoded `activitywatch` root to `appname()`:

```rust
-    Ok(dirs::cache_dir().ok_or(())?.join("activitywatch").join("log"))
+    Ok(dirs::cache_dir().ok_or(())?.join(appname()).join("log"))
```

`appname()` returns `activitywatch-<profile>` unless the profile is `default`, or unless it is `testing` **and** legacy testing data already exists on disk. GitHub runners are fresh, so there is no legacy data and `aw-server --testing` now logs under `~/.cache/activitywatch-testing/`.

That explains the exact pass/fail split we see: the `master` leg runs the nightly (post-#652) binary and fails, while the `v0.12.3b18` legs run released pre-#652 binaries and still pass.

## Fix

- Glob `~/.cache/activitywatch*/log/*/*.log` so both roots are covered — this restores the diagnostics, which have been silently missing (`No files were found with the provided path: logs/dist/*`) rather than merely unblocking the job.
- Guard with `nullglob` and an explicit empty check so these `always()`-gated steps exit 0 when there is nothing to collect. A diagnostic step should never gate a merge.

No behavior change when logs are present.

## Verification

The glob/`nullglob` logic was exercised locally for both the empty case (prints a notice, exits 0) and the both-roots case (finds logs under `activitywatch/` and `activitywatch-testing/`). Since this is a `pull_request` workflow, CI on this PR runs the patched file — the `aw-server-rust master` leg going green here is the real test.