### PR TITLE
fix(categories): enable Save after switching category set (closes #955)

### DIFF
--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -263,10 +263,16 @@ export const useCategoryStore = defineStore('categories', {
         console.warn('Category set not found:', id);
         return;
       }
+      // Track whether the active set actually changed so we can mark dirty only
+      // when there is something to save (avoids spurious unsaved-changes prompts
+      // when initialising or re-selecting the already-active set).
+      const changed = this.active_set_ids.length !== 1 || this.active_set_ids[0] !== id;
       syncToPrimarySet(this);
       this.active_set_ids = [id];
       this.classes = computeEffectiveClasses(this.category_sets, this.active_set_ids);
-      this.classes_unsaved_changes = false;
+      // When the active set changed, mark unsaved so the Save button activates
+      // and the user can persist the new active_set_ids to storage.
+      this.classes_unsaved_changes = changed;
     },
 
     /**

--- a/test/unit/store/categories.test.node.ts
+++ b/test/unit/store/categories.test.node.ts
@@ -196,4 +196,37 @@ describe('categories store', () => {
     categoryStore.save();
     expect(categoryStore.classes_unsaved_changes).toBeFalsy();
   });
+
+  test('switchToSet marks dirty when switching to a different set', () => {
+    // Regression test for #955: switching category sets did not enable the Save
+    // button because switchToSet reset classes_unsaved_changes to false even
+    // though the new active_set_ids hadn't been persisted yet.
+    categoryStore.$patch({
+      category_sets: [
+        { id: 'setA', categories: [] },
+        { id: 'setB', categories: [{ name: ['Work'], rule: { type: 'none' } }] },
+      ],
+      active_set_ids: ['setA'],
+      classes: [],
+      classes_unsaved_changes: false,
+    });
+
+    categoryStore.switchToSet('setB');
+
+    expect(categoryStore.active_set_ids).toEqual(['setB']);
+    expect(categoryStore.classes_unsaved_changes).toBe(true);
+  });
+
+  test('switchToSet does not mark dirty when re-selecting the already-active set', () => {
+    categoryStore.$patch({
+      category_sets: [{ id: 'setA', categories: [] }],
+      active_set_ids: ['setA'],
+      classes: [],
+      classes_unsaved_changes: false,
+    });
+
+    categoryStore.switchToSet('setA');
+
+    expect(categoryStore.classes_unsaved_changes).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

When switching between category sets in Categorization Settings, the **Save button stays disabled** and the selection change is never persisted. A page refresh silently reverts to the previous set.

Root cause: `switchToSet()` always set `classes_unsaved_changes = false` after switching, even though the new `active_set_ids` value hadn't been written to storage yet. The Save button is gated on `classes_unsaved_changes`, so it stayed disabled.

## Fix

In `src/stores/categories.ts`, `switchToSet()` now:
- Detects whether the active set actually changed (avoids spurious dirty state when re-selecting the same set or initializing)
- Sets `classes_unsaved_changes = true` when the set changed, activating the Save button

Two regression tests added to `test/unit/store/categories.test.node.ts`:
- Switching to a different set marks dirty ✓  
- Re-selecting the already-active set does not mark dirty ✓

## Testing

```
npx jest test/unit/store/categories.test.node.ts  # 12/12 pass
npx jest test/unit/presetCategories.test.node.ts  # 34/34 pass
npx tsc --noEmit                                   # clean
```

Closes #955