### PR TITLE
fix(ux): replace prompt() with modals for Android WebView compatibility

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -180,8 +180,9 @@ jobs:
     - name: Print server logs to console
       if: ${{ always() }}
       shell: bash
-      run:
-        for file in ~/.cache/activitywatch/log/*/*.log; do echo $file; cat $file; echo; done
+      run: |
+        shopt -s nullglob
+        for file in ~/.cache/activitywatch*/log/*/*.log; do echo "$file"; cat "$file"; echo; done
     - name: Move logs to subdir
       # Run this step even if e2e tests flag failure
       if: ${{ always() }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -190,7 +190,7 @@ jobs:
         aw_version: ${{ matrix.aw-version }}
       run: |
         mkdir -p logs/dist/$aw_server/$aw_version
-        mv ~/.cache/activitywatch/log/*/*.log logs/dist/$aw_server/$aw_version
+        find ~/.cache/activitywatch/log -name "*.log" -exec mv {} logs/dist/$aw_server/$aw_version/ \; 2>/dev/null || true
     - name: Upload logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v7

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -215,9 +215,10 @@ RETURN = sort_by_duration(merged_events);
       this.showSaveQueryModal = true;
     },
     onSaveQueryConfirm: async function (event) {
+      event.preventDefault();
+
       const trimmedName = this.saveQueryName.trim();
       if (_.isEmpty(trimmedName)) {
-        event.preventDefault();
         this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }
@@ -238,8 +239,7 @@ RETURN = sort_by_duration(merged_events);
       const didPersist = await this.persistSavedQueries([...this.savedQueries, newQuery]);
       if (didPersist) {
         this.selected_saved_query_id = newId;
-      } else {
-        event.preventDefault();
+        this.showSaveQueryModal = false;
       }
     },
     renameSelectedQuery: async function () {
@@ -251,13 +251,14 @@ RETURN = sort_by_duration(merged_events);
       this.showRenameQueryModal = true;
     },
     onRenameQueryConfirm: async function (event) {
+      event.preventDefault();
+
       if (!this.selectedSavedQuery) {
         return;
       }
 
       const trimmedName = this.renameQueryName.trim();
       if (_.isEmpty(trimmedName)) {
-        event.preventDefault();
         this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }
@@ -268,8 +269,8 @@ RETURN = sort_by_duration(merged_events);
           savedQuery.id === selectedQueryId ? { ...savedQuery, name: trimmedName } : savedQuery
         )
       );
-      if (!didPersist) {
-        event.preventDefault();
+      if (didPersist) {
+        this.showRenameQueryModal = false;
       }
     },
     deleteSelectedQuery: async function () {

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -48,6 +48,34 @@ div
   hr
 
   aw-selectable-eventview(:events="events", :event_type="event_type")
+
+  b-modal(
+    v-model="showSaveQueryModal"
+    title="Save Query"
+    ok-title="Save"
+    @ok="onSaveQueryConfirm"
+    @shown="$refs.saveQueryNameInput && $refs.saveQueryNameInput.focus()"
+  )
+    b-form-group(label="Name for the saved query:")
+      b-form-input(
+        ref="saveQueryNameInput"
+        v-model="saveQueryName"
+        placeholder="Query name"
+      )
+
+  b-modal(
+    v-model="showRenameQueryModal"
+    title="Rename Query"
+    ok-title="Rename"
+    @ok="onRenameQueryConfirm"
+    @shown="$refs.renameQueryNameInput && $refs.renameQueryNameInput.focus()"
+  )
+    b-form-group(label="New name for saved query:")
+      b-form-input(
+        ref="renameQueryNameInput"
+        v-model="renameQueryName"
+        placeholder="Query name"
+      )
 </template>
 
 <style scoped lang="scss">
@@ -108,6 +136,10 @@ RETURN = sort_by_duration(merged_events);
       selected_saved_query_id: '',
       startdate: today.format('YYYY-MM-DD'),
       enddate: tomorrow.format('YYYY-MM-DD'),
+      showSaveQueryModal: false,
+      saveQueryName: '',
+      showRenameQueryModal: false,
+      renameQueryName: '',
     };
   },
   computed: {
@@ -178,15 +210,14 @@ RETURN = sort_by_duration(merged_events);
         return;
       }
 
-      const defaultName = getDefaultSavedQueryName(this.query_code);
-      const name = prompt('Name for the saved query:', defaultName);
-      if (name === null) {
-        return;
-      }
-
-      const trimmedName = name.trim();
+      // No existing query — open modal to get a name
+      this.saveQueryName = getDefaultSavedQueryName(this.query_code);
+      this.showSaveQueryModal = true;
+    },
+    onSaveQueryConfirm: async function () {
+      const trimmedName = this.saveQueryName.trim();
       if (_.isEmpty(trimmedName)) {
-        alert('Saved query name cannot be empty.');
+        this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }
 
@@ -213,14 +244,17 @@ RETURN = sort_by_duration(merged_events);
         return;
       }
 
-      const name = prompt('Rename saved query:', this.selectedSavedQuery.name);
-      if (name === null) {
+      this.renameQueryName = this.selectedSavedQuery.name;
+      this.showRenameQueryModal = true;
+    },
+    onRenameQueryConfirm: async function () {
+      if (!this.selectedSavedQuery) {
         return;
       }
 
-      const trimmedName = name.trim();
+      const trimmedName = this.renameQueryName.trim();
       if (_.isEmpty(trimmedName)) {
-        alert('Saved query name cannot be empty.');
+        this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }
 

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -214,9 +214,10 @@ RETURN = sort_by_duration(merged_events);
       this.saveQueryName = getDefaultSavedQueryName(this.query_code);
       this.showSaveQueryModal = true;
     },
-    onSaveQueryConfirm: async function () {
+    onSaveQueryConfirm: async function (event) {
       const trimmedName = this.saveQueryName.trim();
       if (_.isEmpty(trimmedName)) {
+        event.preventDefault();
         this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }
@@ -247,13 +248,14 @@ RETURN = sort_by_duration(merged_events);
       this.renameQueryName = this.selectedSavedQuery.name;
       this.showRenameQueryModal = true;
     },
-    onRenameQueryConfirm: async function () {
+    onRenameQueryConfirm: async function (event) {
       if (!this.selectedSavedQuery) {
         return;
       }
 
       const trimmedName = this.renameQueryName.trim();
       if (_.isEmpty(trimmedName)) {
+        event.preventDefault();
         this.saved_query_error = 'Saved query name cannot be empty.';
         return;
       }

--- a/src/views/QueryExplorer.vue
+++ b/src/views/QueryExplorer.vue
@@ -238,6 +238,8 @@ RETURN = sort_by_duration(merged_events);
       const didPersist = await this.persistSavedQueries([...this.savedQueries, newQuery]);
       if (didPersist) {
         this.selected_saved_query_id = newId;
+      } else {
+        event.preventDefault();
       }
     },
     renameSelectedQuery: async function () {
@@ -261,11 +263,14 @@ RETURN = sort_by_duration(merged_events);
       }
 
       const selectedQueryId = this.selectedSavedQuery.id;
-      await this.persistSavedQueries(
+      const didPersist = await this.persistSavedQueries(
         this.savedQueries.map(savedQuery =>
           savedQuery.id === selectedQueryId ? { ...savedQuery, name: trimmedName } : savedQuery
         )
       );
+      if (!didPersist) {
+        event.preventDefault();
+      }
     },
     deleteSelectedQuery: async function () {
       if (!this.selectedSavedQuery) {

--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -165,8 +165,11 @@ export default {
 
       await useViewsStore().editView({ view_id: this.view.id, el_id: id, type, props: {} });
     },
-    async onCustomVisConfirm() {
-      if (!this.customVisWatcherName || !this.customVisTitle) return;
+    async onCustomVisConfirm(event) {
+      if (!this.customVisWatcherName.trim() || !this.customVisTitle.trim()) {
+        event.preventDefault();
+        return;
+      }
       const props = {
         visname: this.customVisWatcherName,
         title: this.customVisTitle,

--- a/src/views/activity/ActivityView.vue
+++ b/src/views/activity/ActivityView.vue
@@ -54,6 +54,23 @@ div(v-else-if="view")
     br
     br
     | This will delete the view's configuration. You can run #[b Restore defaults] to bring built-in views back.
+
+  b-modal(
+    v-model="showCustomVisModal"
+    title="Add Custom Visualization"
+    ok-title="Add"
+    @ok="onCustomVisConfirm"
+  )
+    b-form-group(label="Watcher name:")
+      b-form-input(
+        v-model="customVisWatcherName"
+        placeholder="aw-watcher-"
+      )
+    b-form-group(label="Visualization title:")
+      b-form-input(
+        v-model="customVisTitle"
+        placeholder="My Visualization"
+      )
 </template>
 
 <script lang="ts">
@@ -75,7 +92,13 @@ export default {
     view_id: { type: String, default: 'default' },
   },
   data() {
-    return { editing: false };
+    return {
+      editing: false,
+      showCustomVisModal: false,
+      customVisWatcherName: 'aw-watcher-',
+      customVisTitle: '',
+      pendingCustomVisId: null as number | null,
+    };
   },
   computed: {
     views: function () {
@@ -131,22 +154,29 @@ export default {
       useViewsStore().addVisualization({ view_id: this.view.id, type: 'top_apps' });
     },
     async onTypeChange(id, type) {
-      let props = {};
-
       if (type === 'custom_vis') {
-        const visname = prompt('Please enter the watcher name', 'aw-watcher-');
-        if (!visname) return;
-
-        const title = prompt('Please enter the visualization title');
-        if (!title) return;
-
-        props = {
-          visname,
-          title,
-        };
+        // Show modal to collect watcher name and visualization title
+        this.pendingCustomVisId = id;
+        this.customVisWatcherName = 'aw-watcher-';
+        this.customVisTitle = '';
+        this.showCustomVisModal = true;
+        return;
       }
 
-      await useViewsStore().editView({ view_id: this.view.id, el_id: id, type, props });
+      await useViewsStore().editView({ view_id: this.view.id, el_id: id, type, props: {} });
+    },
+    async onCustomVisConfirm() {
+      if (!this.customVisWatcherName || !this.customVisTitle) return;
+      const props = {
+        visname: this.customVisWatcherName,
+        title: this.customVisTitle,
+      };
+      await useViewsStore().editView({
+        view_id: this.view.id,
+        el_id: this.pendingCustomVisId,
+        type: 'custom_vis',
+        props,
+      });
     },
     async onRemove(id) {
       await useViewsStore().removeVisualization({ view_id: this.view.id, el_id: id });

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -231,10 +231,14 @@ export default {
       this.newSetName = '';
       this.showCreateSetModal = true;
     },
-    onCreateSetConfirm: function () {
+    onCreateSetConfirm: function (event) {
       const name = this.newSetName.trim();
-      if (!name) return;
+      if (!name) {
+        event.preventDefault();
+        return;
+      }
       if (this.categoryStore.category_sets.find(s => s.id === name)) {
+        event.preventDefault();
         alert(`A set named "${name}" already exists.`);
         return;
       }

--- a/src/views/settings/CategorizationSettings.vue
+++ b/src/views/settings/CategorizationSettings.vue
@@ -85,6 +85,20 @@ div
     b-collapse#category-builder-collapse(v-model="builderOpen")
       div.mt-3(v-if="builderMounted")
         CategoryBuilder(embedded)
+
+  b-modal(
+    v-model="showCreateSetModal"
+    title="New Category Set"
+    ok-title="Create"
+    @ok="onCreateSetConfirm"
+    @shown="$refs.newSetNameInput && $refs.newSetNameInput.focus()"
+  )
+    b-form-group(label="Name for the new category set:")
+      b-form-input(
+        ref="newSetNameInput"
+        v-model="newSetName"
+        placeholder="Category set name"
+      )
 </template>
 <script lang="ts">
 import { mapState, mapGetters } from 'pinia';
@@ -111,6 +125,8 @@ export default {
     activeSetId: 'default',
     builderOpen: false,
     builderMounted: false,
+    showCreateSetModal: false,
+    newSetName: '',
   }),
   computed: {
     ...mapState(useCategoryStore, ['classes_unsaved_changes']),
@@ -212,7 +228,11 @@ export default {
       }
     },
     createSet: function () {
-      const name = prompt('Name for the new category set:');
+      this.newSetName = '';
+      this.showCreateSetModal = true;
+    },
+    onCreateSetConfirm: function () {
+      const name = this.newSetName.trim();
       if (!name) return;
       if (this.categoryStore.category_sets.find(s => s.id === name)) {
         alert(`A set named "${name}" already exists.`);

--- a/test/unit/ActivityView.test.js
+++ b/test/unit/ActivityView.test.js
@@ -21,6 +21,17 @@ describe('ActivityView isVisLarge', () => {
   });
 });
 
+describe('ActivityView custom visualization modal', () => {
+  test('stays open when a required field is blank', async () => {
+    const event = { preventDefault: jest.fn() };
+    const vm = { customVisWatcherName: 'aw-watcher-window', customVisTitle: '   ' };
+
+    await ActivityView.methods.onCustomVisConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
 // Visualizations keep local state — the Top Bucket Data picker holds its
 // selected bucket, field and fetched events in `data` and fills them in
 // `mounted`. Every view renders the same list at the same positions, so if a

--- a/test/unit/QueryExplorer.test.js
+++ b/test/unit/QueryExplorer.test.js
@@ -56,23 +56,55 @@ describe('QueryExplorer saveCurrentQuery', () => {
     expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
   });
 
-  test('keeps save modal open when persistence fails', async () => {
+  test('cancels save modal closure before awaiting persistence failure', async () => {
     const event = { preventDefault: jest.fn() };
+    let resolvePersistence;
+    const persistence = new Promise(resolve => {
+      resolvePersistence = resolve;
+    });
     const vm = {
       enddate: '2026-05-21',
       event_type: 'currentwindow',
-      persistSavedQueries: jest.fn().mockResolvedValue(false),
+      persistSavedQueries: jest.fn().mockReturnValue(persistence),
       query_code: 'RETURN = [];',
       saveQueryName: 'Daily Coding Time',
       savedQueries: [],
       selected_saved_query_id: '',
+      showSaveQueryModal: true,
+      startdate: '2026-05-20',
+    };
+
+    const confirmation = QueryExplorer.methods.onSaveQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.showSaveQueryModal).toBe(true);
+
+    resolvePersistence(false);
+    await confirmation;
+
+    expect(vm.selected_saved_query_id).toBe('');
+    expect(vm.showSaveQueryModal).toBe(true);
+  });
+
+  test('closes save modal after persistence succeeds', async () => {
+    const event = { preventDefault: jest.fn() };
+    const vm = {
+      enddate: '2026-05-21',
+      event_type: 'currentwindow',
+      persistSavedQueries: jest.fn().mockResolvedValue(true),
+      query_code: 'RETURN = [];',
+      saveQueryName: 'Daily Coding Time',
+      savedQueries: [],
+      selected_saved_query_id: '',
+      showSaveQueryModal: true,
       startdate: '2026-05-20',
     };
 
     await QueryExplorer.methods.onSaveQueryConfirm.call(vm, event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect(vm.selected_saved_query_id).toBe('');
+    expect(vm.selected_saved_query_id).not.toBe('');
+    expect(vm.showSaveQueryModal).toBe(false);
   });
 
   test('keeps rename modal open when the query name is blank', async () => {
@@ -89,18 +121,46 @@ describe('QueryExplorer saveCurrentQuery', () => {
     expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
   });
 
-  test('keeps rename modal open when persistence fails', async () => {
+  test('cancels rename modal closure before awaiting persistence failure', async () => {
     const event = { preventDefault: jest.fn() };
+    let resolvePersistence;
+    const persistence = new Promise(resolve => {
+      resolvePersistence = resolve;
+    });
     const selectedSavedQuery = { id: 'daily-coding-time', name: 'Daily Coding Time' };
     const vm = {
-      persistSavedQueries: jest.fn().mockResolvedValue(false),
+      persistSavedQueries: jest.fn().mockReturnValue(persistence),
       renameQueryName: 'Coding Time',
       savedQueries: [selectedSavedQuery],
       selectedSavedQuery,
+      showRenameQueryModal: true,
+    };
+
+    const confirmation = QueryExplorer.methods.onRenameQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.showRenameQueryModal).toBe(true);
+
+    resolvePersistence(false);
+    await confirmation;
+
+    expect(vm.showRenameQueryModal).toBe(true);
+  });
+
+  test('closes rename modal after persistence succeeds', async () => {
+    const event = { preventDefault: jest.fn() };
+    const selectedSavedQuery = { id: 'daily-coding-time', name: 'Daily Coding Time' };
+    const vm = {
+      persistSavedQueries: jest.fn().mockResolvedValue(true),
+      renameQueryName: 'Coding Time',
+      savedQueries: [selectedSavedQuery],
+      selectedSavedQuery,
+      showRenameQueryModal: true,
     };
 
     await QueryExplorer.methods.onRenameQueryConfirm.call(vm, event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.showRenameQueryModal).toBe(false);
   });
 });

--- a/test/unit/QueryExplorer.test.js
+++ b/test/unit/QueryExplorer.test.js
@@ -42,4 +42,31 @@ describe('QueryExplorer saveCurrentQuery', () => {
     confirmSpy.mockRestore();
     promptSpy.mockRestore();
   });
+
+  test('keeps save modal open when the query name is blank', async () => {
+    const event = { preventDefault: jest.fn() };
+    const vm = {
+      saveQueryName: '   ',
+      saved_query_error: '',
+    };
+
+    await QueryExplorer.methods.onSaveQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
+  });
+
+  test('keeps rename modal open when the query name is blank', async () => {
+    const event = { preventDefault: jest.fn() };
+    const vm = {
+      renameQueryName: '   ',
+      saved_query_error: '',
+      selectedSavedQuery: { id: 'daily-coding-time', name: 'Daily Coding Time' },
+    };
+
+    await QueryExplorer.methods.onRenameQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
+  });
 });

--- a/test/unit/QueryExplorer.test.js
+++ b/test/unit/QueryExplorer.test.js
@@ -56,6 +56,25 @@ describe('QueryExplorer saveCurrentQuery', () => {
     expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
   });
 
+  test('keeps save modal open when persistence fails', async () => {
+    const event = { preventDefault: jest.fn() };
+    const vm = {
+      enddate: '2026-05-21',
+      event_type: 'currentwindow',
+      persistSavedQueries: jest.fn().mockResolvedValue(false),
+      query_code: 'RETURN = [];',
+      saveQueryName: 'Daily Coding Time',
+      savedQueries: [],
+      selected_saved_query_id: '',
+      startdate: '2026-05-20',
+    };
+
+    await QueryExplorer.methods.onSaveQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(vm.selected_saved_query_id).toBe('');
+  });
+
   test('keeps rename modal open when the query name is blank', async () => {
     const event = { preventDefault: jest.fn() };
     const vm = {
@@ -68,5 +87,20 @@ describe('QueryExplorer saveCurrentQuery', () => {
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(vm.saved_query_error).toBe('Saved query name cannot be empty.');
+  });
+
+  test('keeps rename modal open when persistence fails', async () => {
+    const event = { preventDefault: jest.fn() };
+    const selectedSavedQuery = { id: 'daily-coding-time', name: 'Daily Coding Time' };
+    const vm = {
+      persistSavedQueries: jest.fn().mockResolvedValue(false),
+      renameQueryName: 'Coding Time',
+      savedQueries: [selectedSavedQuery],
+      selectedSavedQuery,
+    };
+
+    await QueryExplorer.methods.onRenameQueryConfirm.call(vm, event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

`prompt()` is unsupported in Android WebView — it silently returns `null` with no error or feedback, so buttons that use it appear broken on Android.

**Affected call sites (5):**

| File | Purpose |
|------|---------|
| `src/views/settings/CategorizationSettings.vue` | Create new category set name |
| `src/views/QueryExplorer.vue` | Save query name |
| `src/views/QueryExplorer.vue` | Rename saved query |
| `src/views/activity/ActivityView.vue` | Enter watcher name (custom\_vis) |
| `src/views/activity/ActivityView.vue` | Enter visualization title (custom\_vis) |

## Fix

Each `prompt()` call is replaced with a `b-modal` + `b-form-input`:

- **CategorizationSettings**: A new category set modal (name input + Create button)
- **QueryExplorer**: Two separate modals — one for saving a new query (pre-filled with the default name), one for renaming
- **ActivityView**: A single two-field modal for the `custom_vis` type (watcher name + viz title combined, replacing two sequential prompts)

Validation logic is preserved. Uses BootstrapVue's `b-modal` / `b-form-group` / `b-form-input`, consistent with existing modal patterns in the codebase (e.g. `CategoryEditModal`, the remove-view modal in `ActivityView`).