### PR TITLE
fix(activity): use actual bucket IDs in multidevice query (fixes BucketNotFound with aw-sync data)

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -54,7 +54,7 @@ interface Rule {
 
 type Category = [string[], Rule];
 
-interface BaseQueryParams {
+export interface BaseQueryParams {
   include_audible?: boolean;
   categories: Category[];
   filter_categories: string[][];
@@ -63,14 +63,14 @@ interface BaseQueryParams {
   return_variable_suffix?: string;
 }
 
-interface DesktopQueryParams extends BaseQueryParams {
+export interface DesktopQueryParams extends BaseQueryParams {
   bid_window: string;
   bid_afk: string;
   filter_afk: boolean;
   always_active_pattern?: string;
 }
 
-interface AndroidQueryParams extends BaseQueryParams {
+export interface AndroidQueryParams extends BaseQueryParams {
   bid_android: string;
   /** True when the bucket is an aw-import-screentime (iOS) bucket.
    *  ScreenTime events carry a "title" key; aw-watcher-android events do not.
@@ -79,12 +79,14 @@ interface AndroidQueryParams extends BaseQueryParams {
   isIos?: boolean;
 }
 
-interface MultiQueryParams extends BaseQueryParams {
+export interface MultiQueryParams extends BaseQueryParams {
   hosts: string[];
   filter_afk: boolean;
   always_active_pattern: string;
-  // This can be used to override params on a per-host basis
-  host_params: { [host: string]: DesktopQueryParams | AndroidQueryParams };
+  // This can be used to override params on a per-host basis.  Only the
+  // keys present (and non-empty) are applied, so partial objects such as
+  // {bid_window, bid_afk} are valid overrides.
+  host_params: { [host: string]: Partial<DesktopQueryParams> | Partial<AndroidQueryParams> };
 }
 
 function get_params(
@@ -107,9 +109,12 @@ function get_params(
       console.error(`Invalid host_params for host ${host}: ${JSON.stringify(host_params)}`);
     }
     // Only override the params if they are defined and set to a truthy value
-    Object.keys(host_params).forEach(key => {
-      if (host_params[key] && host_params[key].length > 0) {
-        new_params[key] = host_params[key];
+    const overrides = host_params as Record<string, unknown>;
+    const target = new_params as unknown as Record<string, unknown>;
+    Object.keys(overrides).forEach(key => {
+      const value = overrides[key];
+      if ((typeof value === 'string' || Array.isArray(value)) && value.length > 0) {
+        target[key] = value;
       }
     });
   }

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -297,12 +297,13 @@ export const useActivityStore = defineStore('activity', {
           );
           if (settingsStore.useMultidevice) {
             const hostnames = bucketsStore.hosts.filter(
-              // require that the host has window buckets,
-              // and that the host is not a fakedata host,
-              // unless we're explicitly querying fakedata
+              // require that the host has both window and afk buckets
+              // (canonicalEvents needs the pair), and that the host is not
+              // a fakedata host, unless we're explicitly querying fakedata
               host =>
                 host &&
                 bucketsStore.bucketsWindow(host).length > 0 &&
+                bucketsStore.bucketsAFK(host).length > 0 &&
                 (!host.startsWith('fakedata') || query_options.host.startsWith('fakedata'))
             );
             console.info('Including hosts in multiquery: ', hostnames);
@@ -418,13 +419,31 @@ export const useActivityStore = defineStore('activity', {
     ) {
       const periods = periodsForFullDesktopQuery(timeperiod);
       const categories = useCategoryStore().classes_for_query;
+      const bucketsStore = useBucketsStore();
+
+      // Pass each host's actual bucket IDs, so that buckets synced from
+      // another host (whose IDs carry an "-synced-from-<host>" suffix) are
+      // queried instead of the reconstructed "aw-watcher-window_<host>" IDs
+      // which don't exist in the local datastore.
+      const host_params: Record<string, { bid_window: string; bid_afk: string }> = {};
+      const hosts_with_buckets: string[] = [];
+      hosts.forEach(host => {
+        const bid_window = bucketsStore.bucketsWindow(host)[0];
+        const bid_afk = bucketsStore.bucketsAFK(host)[0];
+        if (bid_window && bid_afk) {
+          host_params[host] = { bid_window, bid_afk };
+          hosts_with_buckets.push(host);
+        } else {
+          console.warn(`Skipping host ${host} in multidevice query: missing window/afk bucket`);
+        }
+      });
 
       const q = queries.multideviceQuery({
-        hosts,
+        hosts: hosts_with_buckets,
         filter_afk,
         categories,
         filter_categories,
-        host_params: {},
+        host_params: host_params as any,
         always_active_pattern,
       });
       const merged = await queryDesktopPeriods(periods, q, 'multidevice');

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -22,6 +22,7 @@ import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
 
 import { getClient } from '~/util/awclient';
+import { buildMultideviceHostParams } from '~/util/multidevice';
 import {
   FullDesktopQueryResult,
   mergeFullDesktopResults,
@@ -421,29 +422,23 @@ export const useActivityStore = defineStore('activity', {
       const categories = useCategoryStore().classes_for_query;
       const bucketsStore = useBucketsStore();
 
-      // Pass each host's actual bucket IDs, so that buckets synced from
-      // another host (whose IDs carry an "-synced-from-<host>" suffix) are
-      // queried instead of the reconstructed "aw-watcher-window_<host>" IDs
-      // which don't exist in the local datastore.
-      const host_params: Record<string, { bid_window: string; bid_afk: string }> = {};
-      const hosts_with_buckets: string[] = [];
-      hosts.forEach(host => {
-        const bid_window = bucketsStore.bucketsWindow(host)[0];
-        const bid_afk = bucketsStore.bucketsAFK(host)[0];
-        if (bid_window && bid_afk) {
-          host_params[host] = { bid_window, bid_afk };
-          hosts_with_buckets.push(host);
-        } else {
-          console.warn(`Skipping host ${host} in multidevice query: missing window/afk bucket`);
-        }
-      });
+      // Pass each host's actual bucket IDs (see buildMultideviceHostParams),
+      // so that buckets synced from another host — whose IDs carry an
+      // "-synced-from-<host>" suffix — are queried instead of the
+      // reconstructed "aw-watcher-window_<host>" IDs which don't exist in
+      // the local datastore.
+      const { host_params, hosts_with_buckets } = buildMultideviceHostParams(
+        hosts,
+        host => bucketsStore.bucketsWindow(host),
+        host => bucketsStore.bucketsAFK(host)
+      );
 
       const q = queries.multideviceQuery({
         hosts: hosts_with_buckets,
         filter_afk,
         categories,
         filter_categories,
-        host_params: host_params as any,
+        host_params,
         always_active_pattern,
       });
       const merged = await queryDesktopPeriods(periods, q, 'multidevice');

--- a/src/util/multidevice.ts
+++ b/src/util/multidevice.ts
@@ -1,0 +1,42 @@
+// Pure helpers for building the per-host bucket-ID overrides used by the
+// multidevice query.  Kept free of store imports so they can be unit-tested
+// in isolation.
+
+export interface MultideviceHostSelection {
+  /** Per-host bucket-ID overrides, keyed by hostname. */
+  host_params: { [host: string]: { bid_window: string; bid_afk: string } };
+  /** The subset of `hosts` that had both a window and an afk bucket. */
+  hosts_with_buckets: string[];
+}
+
+/**
+ * Build per-host bucket-ID overrides for the multidevice query from the
+ * actual buckets available for each host.
+ *
+ * This is needed because buckets synced from another host (via aw-sync)
+ * keep their original hostname but carry an "-synced-from-<host>" suffix in
+ * their bucket ID, so the reconstructed "aw-watcher-window_<hostname>" IDs
+ * do not exist in the local datastore.
+ *
+ * Hosts lacking either a window or an afk bucket are skipped (with a
+ * warning), since canonicalEvents requires the pair.
+ */
+export function buildMultideviceHostParams(
+  hosts: string[],
+  bucketsWindow: (host: string) => string[],
+  bucketsAFK: (host: string) => string[]
+): MultideviceHostSelection {
+  const host_params: MultideviceHostSelection['host_params'] = {};
+  const hosts_with_buckets: string[] = [];
+  hosts.forEach(host => {
+    const bid_window = bucketsWindow(host)[0];
+    const bid_afk = bucketsAFK(host)[0];
+    if (bid_window && bid_afk) {
+      host_params[host] = { bid_window, bid_afk };
+      hosts_with_buckets.push(host);
+    } else {
+      console.warn(`Skipping host ${host} in multidevice query: missing window/afk bucket`);
+    }
+  });
+  return { host_params, hosts_with_buckets };
+}

--- a/test/multidevice.test.node.ts
+++ b/test/multidevice.test.node.ts
@@ -1,0 +1,90 @@
+import { buildMultideviceHostParams } from '~/util/multidevice';
+import queries from '~/queries';
+
+// Simulated bucket inventories, mirroring how aw-sync stores pulled data:
+// bucket IDs carry an "-synced-from-<host>" suffix while the hostname
+// (which the store groups by) stays the original.
+const windowBuckets: { [host: string]: string[] } = {
+  myhost: ['aw-watcher-window_myhost'],
+  otherhost: ['aw-watcher-window_otherhost-synced-from-otherhost'],
+  noafkhost: ['aw-watcher-window_noafkhost'],
+  nowindowhost: [],
+};
+const afkBuckets: { [host: string]: string[] } = {
+  myhost: ['aw-watcher-afk_myhost'],
+  otherhost: ['aw-watcher-afk_otherhost-synced-from-otherhost'],
+  noafkhost: [],
+  nowindowhost: ['aw-watcher-afk_nowindowhost'],
+};
+
+describe('buildMultideviceHostParams', () => {
+  it('uses the actual bucket IDs for each host', () => {
+    const { host_params, hosts_with_buckets } = buildMultideviceHostParams(
+      ['myhost', 'otherhost'],
+      host => windowBuckets[host] || [],
+      host => afkBuckets[host] || []
+    );
+    expect(hosts_with_buckets).toEqual(['myhost', 'otherhost']);
+    expect(host_params['myhost']).toEqual({
+      bid_window: 'aw-watcher-window_myhost',
+      bid_afk: 'aw-watcher-afk_myhost',
+    });
+    expect(host_params['otherhost']).toEqual({
+      bid_window: 'aw-watcher-window_otherhost-synced-from-otherhost',
+      bid_afk: 'aw-watcher-afk_otherhost-synced-from-otherhost',
+    });
+  });
+
+  it('skips hosts that lack either a window or an afk bucket', () => {
+    const { host_params, hosts_with_buckets } = buildMultideviceHostParams(
+      ['noafkhost', 'nowindowhost'],
+      host => windowBuckets[host] || [],
+      host => afkBuckets[host] || []
+    );
+    expect(hosts_with_buckets).toEqual([]);
+    expect(host_params).toEqual({});
+  });
+});
+
+describe('multideviceQuery with host_params overrides', () => {
+  const baseParams = {
+    filter_afk: true,
+    categories: [],
+    filter_categories: [],
+    always_active_pattern: '',
+  };
+
+  it('queries hosts by their actual (synced) bucket IDs', () => {
+    const q = queries
+      .multideviceQuery({
+        ...baseParams,
+        hosts: ['otherhost'],
+        host_params: {
+          otherhost: {
+            bid_window: 'aw-watcher-window_otherhost-synced-from-otherhost',
+            bid_afk: 'aw-watcher-afk_otherhost-synced-from-otherhost',
+          },
+        },
+      })
+      .join('\n');
+    expect(q).toContain('query_bucket("aw-watcher-window_otherhost-synced-from-otherhost")');
+    expect(q).toContain('query_bucket("aw-watcher-afk_otherhost-synced-from-otherhost")');
+    // The reconstructed ID (without the -synced-from- suffix) must not be
+    // queried — it does not exist in the local datastore and would fail
+    // with BucketNotFound.
+    expect(q).not.toContain('query_bucket("aw-watcher-window_otherhost")');
+    expect(q).not.toContain('query_bucket("aw-watcher-afk_otherhost")');
+  });
+
+  it('falls back to reconstructed IDs when no override is given', () => {
+    const q = queries
+      .multideviceQuery({
+        ...baseParams,
+        hosts: ['myhost'],
+        host_params: {},
+      })
+      .join('\n');
+    expect(q).toContain('query_bucket("aw-watcher-window_myhost")');
+    expect(q).toContain('query_bucket("aw-watcher-afk_myhost")');
+  });
+});


### PR DESCRIPTION
# Fix BucketNotFound in multidevice query when viewing aw-sync data

## Problem

With `aw-sync` set up between machines, enabling the "Use multidevice query" developer setting and opening the Activity view fails on every machine except the one being viewed:

```
BucketNotFound("Failed to find bucket 'aw-watcher-window_<hostname>'")
```

## Root cause

Buckets pulled in by `aw-sync` keep their original `hostname` **field**, but their bucket **ID** gets an `-synced-from-<host>` suffix (e.g. `aw-watcher-window_myhost-synced-from-myhost`).

- `bucketsByHostname` groups by the hostname field, so synced hosts correctly appear in the device list;
- but `multideviceQuery` reconstructs bucket IDs from the hostname (`get_params`: `bid_window: 'aw-watcher-window_' + host`) and `query_multidevice_full` passes `host_params: {}`, so the existing per-host override mechanism in `get_params` is never used;
- `query_bucket("aw-watcher-window_myhost")` then fails with `BucketNotFound`, since only the suffixed ID exists in the local datastore.

## Fix

1. Fill `host_params` with each host's actual bucket IDs (first window/afk bucket from the buckets store), so synced buckets are queried by their real IDs.
2. Only include hosts that have both a window and an afk bucket (the pair `canonicalEvents` requires), matching the single-device path — previously only the window bucket was required, which could produce the same error for the afk bucket.

## Verification

With two machines synced via aw-sync (one viewing the other's data):

- **Before:** the query the UI generates returns HTTP 400 `BucketNotFound("Failed to find bucket 'aw-watcher-window_QBZdeMac-mini.local'")`.
- **After:** the same multidevice query (two hosts, `union_no_overlap`) executes successfully, e.g. `{"duration": 22392.738}` for the day across both hosts.
