### PR TITLE
fix(timeline): handle synced buckets where origin hostname contains underscores

### DIFF
--- a/src/util/timelineLabels.ts
+++ b/src/util/timelineLabels.ts
@@ -49,11 +49,25 @@ export function formatTimelineBucketLabelHtml(
   options: BucketLabelOptions = {}
 ): string {
   const escaped = escapeHtml(bucketId);
-  const syncMatch = bucketId.match(/^([^_]+)_.*-synced-from-(.+)$/);
 
-  if (syncMatch) {
-    const baseLabel = addWrapOpportunities(escapeHtml(syncMatch[1]));
-    const remoteLabel = addWrapOpportunities(escapeHtml(syncMatch[2]));
+  // Detect synced buckets by searching for the literal '-synced-from-' marker
+  // rather than using an underscore-split regex. The old regex
+  //   /^([^_]+)_.*-synced-from-(.+)$/
+  // failed for bucket ids where the origin hostname contains underscores
+  // (e.g. 'aw-watcher-android-synced-from-my_phone'), because [^_]+ stopped
+  // at the underscore inside the hostname, leaving no room for '-synced-from-'
+  // to match in the remaining string.
+  const syncMarker = '-synced-from-';
+  const syncIdx = bucketId.indexOf(syncMarker);
+  if (syncIdx !== -1) {
+    const basePart = bucketId.slice(0, syncIdx);
+    const remotePart = bucketId.slice(syncIdx + syncMarker.length);
+    // Strip optional '_<hostname>' suffix from the base part, which is present
+    // when the source bucket follows the conventional aw-watcher-type_host format.
+    const underscoreIdx = basePart.indexOf('_');
+    const baseDisplay = underscoreIdx !== -1 ? basePart.slice(0, underscoreIdx) : basePart;
+    const baseLabel = addWrapOpportunities(escapeHtml(baseDisplay));
+    const remoteLabel = addWrapOpportunities(escapeHtml(remotePart));
     return `<span class="timeline-label" title="${escaped}">${baseLabel} (synced from ${remoteLabel})</span>`;
   }
 

--- a/test/unit/timelineLabels.test.node.ts
+++ b/test/unit/timelineLabels.test.node.ts
@@ -44,6 +44,16 @@ describe('formatTimelineBucketLabelHtml', () => {
     );
   });
 
+  it('preserves underscores in origin hostname for synced buckets', () => {
+    // Regression for https://github.com/ActivityWatch/aw-webui/issues/967:
+    // 'aw-watcher-android-synced-from-my_phone' was rendering as
+    // 'android-synced-from-my' because the old underscore-split regex consumed
+    // 'my_phone' as the host separator, leaving no '-synced-from-' to match.
+    expect(formatTimelineBucketLabelHtml('aw-watcher-android-synced-from-my_phone')).toBe(
+      '<span class="timeline-label" title="aw-watcher-android-synced-from-my_phone">aw-​watcher-​android (synced from my_​phone)</span>'
+    );
+  });
+
   it('escapes HTML in bucket IDs', () => {
     expect(formatTimelineBucketLabelHtml('bucket<script>')).toBe(
       '<span class="timeline-label" title="bucket&lt;script&gt;">bucket&lt;script&gt;</span>'


### PR DESCRIPTION
## Problem

Bucket IDs like `aw-watcher-android-synced-from-my_phone` were rendered incorrectly. The formatted label showed `android-synced-from-my` instead of something like `aw-watcher-android (synced from my_phone)`.

Closes #967

## Root cause

The synced-bucket detection used a regex `/^([^_]+)_.*-synced-from-(.+)$/`:

- `[^_]+` matches characters up to the **first underscore**
- For `aw-watcher-android-synced-from-my_phone`, the first `_` is inside the origin hostname (`my_phone`), so `[^_]+` consumed `aw-watcher-android-synced-from-my`
- The rest was just `phone`, which doesn't contain `-synced-from-`, so the regex never matched
- The code fell through to `shortenBucketLabel()`, which cut at the first `_` to yield `android-synced-from-my`

## Fix

Replace the regex with a direct `indexOf('-synced-from-')` search. This detects the marker regardless of whether the origin hostname contains underscores. The base part's optional `_<hostname>` suffix is then stripped separately (needed for desktop buckets like `aw-watcher-window_host-synced-from-...`).

## Changes

- `src/util/timelineLabels.ts`: replace regex with `indexOf` approach
- `test/unit/timelineLabels.test.node.ts`: add regression for the reported case

All 10 existing tests still pass; the new test covers the previously broken case.