### PR TITLE
fix(timeline): prevent mobile horizontal overflow

### DIFF
--- a/src/components/InputTimeInterval.vue
+++ b/src/components/InputTimeInterval.vue
@@ -68,10 +68,11 @@ div
   display: grid;
   // Fixed label column keeps Mode/Range labels aligned and the controls
   // start at the same X regardless of which mode is active.
-  grid-template-columns: 4rem 1fr;
+  grid-template-columns: 4rem minmax(0, 1fr);
   column-gap: 0.75rem;
   row-gap: 0.5rem;
   align-items: center;
+  min-width: 0;
 }
 
 .btn-group {
@@ -79,6 +80,16 @@ div
     background-color: #495057;
     color: #fff;
     border-color: #495057;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .time-interval-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .btn-group {
+    flex-wrap: wrap;
   }
 }
 </style>

--- a/test/e2e/screenshot.test.js
+++ b/test/e2e/screenshot.test.js
@@ -73,6 +73,12 @@ async function checkNoError(t) {
   }
 }
 
+async function checkNoHorizontalOverflow(t) {
+  await t
+    .expect(Selector('html').scrollWidth)
+    .lte(await t.eval(() => document.documentElement.clientWidth));
+}
+
 const logJsErrorCode = `
   window.addEventListener('error', function (e) {
       console.error(e.message);
@@ -140,6 +146,13 @@ test.clientScripts({
     fullPage: true,
   });
   await checkNoError(t);
+});
+
+test('Timeline has no horizontal page overflow on mobile', async t => {
+  await t.resizeWindow(360, 800);
+  await hide_devonly(t);
+  await waitForLoading(t);
+  await checkNoHorizontalOverflow(t);
 
   // Debugging
   // console.log(await t.getBrowserConsoleMessages());


### PR DESCRIPTION
## Summary

- let the Timeline time-range grid shrink inside a phone viewport
- stack its labels and wrap quick-range buttons below Bootstrap's small breakpoint
- add a 360px end-to-end assertion against horizontal document overflow

## Reproduction

At a 360px viewport on current `master`, `document.documentElement.scrollWidth` is 450px. The `InputTimeInterval` grid is 433px wide because its `1fr` track and unwrapped button groups preserve their intrinsic width.

After this change, document width remains 360px and the grid is 326px wide.

## Verification

- `./node_modules/.bin/jest --selectProjects jsdom --runInBand test/unit/VisTimeline.test.js` (8 passed)
- `./node_modules/.bin/vue-cli-service lint src/components/InputTimeInterval.vue test/e2e/screenshot.test.js`
- `PRE_COMMIT_ALLOW_NO_CONFIG=1 prek run --files src/components/InputTimeInterval.vue test/e2e/screenshot.test.js`
- headless Chromium probe at 360×800: page width 450px before, 360px after

Related: ActivityWatch/activitywatch#1430
