### PR TITLE
fix(settings): route the notifications settings group

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -78,7 +78,7 @@ const router = new VueRouter({
     // The matcher excludes 'category-builder' so the more specific route above
     // wins; new groups added in Settings.vue should also be added here.
     {
-      path: '/settings/:group(general|appearance|categorization|privacy|developer)',
+      path: '/settings/:group(general|appearance|categorization|privacy|developer|notifications)',
       component: Settings,
       props: true,
     },


### PR DESCRIPTION
Navigating from the settings menu to `/#/settings/notifications` showed the 404 page: the `notifications` group (`AwNotifySettings`, added with the shared aw-notify threshold work) was never added to the `:group` route matcher in `route.js`, whose own comment warns that new groups in Settings.vue must be added there.

One-line fix: add `notifications` to the alternation.

Repro: Settings → Notifications in the menu → 404 ("Woops, this page was not found!"). After fix: panel renders and the URL survives reloads like the other groups.