### PR TITLE
feat(categories): support force_active preset flag to override stored set selection

### DIFF
--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -52,6 +52,16 @@ export interface Category {
 export interface CategorySet {
   id: string;
   categories: Category[];
+  /**
+   * When true, aw-webui activates this set even when the user already has
+   * stored category sets.  Intended for research or managed builds that need
+   * a specific taxonomy to be active on every install, including machines
+   * that had ActivityWatch before the build was deployed.
+   *
+   * The flag is respected only for sets delivered via `AW_PRESET_CATEGORY_SETS`
+   * — a stored set cannot force-activate itself.
+   */
+  force_active?: boolean;
 }
 
 /**
@@ -319,10 +329,24 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
   let sets: CategorySet[];
   let activeIds: string[];
 
+  // A preset with force_active:true overrides stored active_set_ids so that
+  // managed/research builds activate their taxonomy on every existing install,
+  // not just fresh ones.  We only honour force_active on presets delivered
+  // via AW_PRESET_CATEGORY_SETS (getPresetCategorySets()), never on stored sets
+  // — user edits stored under the same id still win over the preset definition.
+  const forceActivePreset = presets.find(p => p.force_active);
+
   if (storedSets && storedSets.length > 0) {
     sets = [...storedSets];
-    activeIds =
-      storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
+    if (forceActivePreset) {
+      // Activate the force_active preset regardless of what was stored.
+      // We keep only that preset active (same single-set constraint as the
+      // first-run path) so syncToPrimarySet() can write user edits back cleanly.
+      activeIds = [forceActivePreset.id];
+    } else {
+      activeIds =
+        storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
+    }
   } else if (presets.length > 0 && !settingsStore.hasStoredCategories) {
     // First run on a build that ships presets: activate the first preset only.
     //

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -334,7 +334,15 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
   // not just fresh ones.  We only honour force_active on presets delivered
   // via AW_PRESET_CATEGORY_SETS (getPresetCategorySets()), never on stored sets
   // — user edits stored under the same id still win over the preset definition.
-  const forceActivePreset = presets.find(p => p.force_active);
+  const forceActivePresets = presets.filter(p => p.force_active);
+  if (forceActivePresets.length > 1) {
+    console.warn(
+      `[categories] ${forceActivePresets.length} presets have force_active:true ` +
+        `(${forceActivePresets.map(p => p.id).join(', ')}); ` +
+        `only the first will be activated — mark exactly one preset force_active.`
+    );
+  }
+  const forceActivePreset = forceActivePresets[0];
 
   if (storedSets && storedSets.length > 0) {
     sets = [...storedSets];
@@ -359,7 +367,9 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
     // The remaining presets are still appended below and are available in the UI
     // for the user to activate manually.
     sets = [];
-    activeIds = [presets[0].id];
+    // Prefer the force_active preset if present; otherwise activate the first
+    // preset (same single-set constraint — see comment above).
+    activeIds = [forceActivePreset ? forceActivePreset.id : presets[0].id];
   } else {
     // Migration path: no sets defined yet — wrap the existing flat classes into a "default" set
     const legacyClasses = settingsStore.classes || defaultCategories;

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -153,7 +153,9 @@ function parseSet(raw: unknown, index: number): CategorySet | null {
     console.warn(`[presets] set "${raw.id}" has no valid categories, skipping`);
     return null;
   }
-  return { id: raw.id, categories };
+  const set: CategorySet = { id: raw.id, categories };
+  if (raw.force_active === true) set.force_active = true;
+  return set;
 }
 
 /**
@@ -223,6 +225,7 @@ export function getPresetCategorySets(): CategorySet[] {
   // Deep enough copy to keep callers from mutating the cache
   return cached.map(s => ({
     id: s.id,
+    ...(s.force_active ? { force_active: true } : {}),
     categories: s.categories.map(c => ({ ...c, name: [...c.name], rule: { ...c.rule } })),
   }));
 }

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -509,3 +509,66 @@ describe('categories store with presets', () => {
     expect(categoryStore.classes.length).toBeGreaterThan(defaultCategories.length - 1);
   });
 });
+
+// ── force_active preset tests ────────────────────────────────────────────────
+describe('force_active preset', () => {
+  const forceActivePreset: CategorySet = {
+    id: 'research-study',
+    force_active: true,
+    categories: [{ name: ['Music & Audio'], rule: { type: 'regex', regex: '^Music & Audio$' } }],
+  };
+
+  test('parsePresetCategorySets propagates force_active:true', () => {
+    const sets = parsePresetCategorySets([forceActivePreset]);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].force_active).toBe(true);
+  });
+
+  test('parsePresetCategorySets does not set force_active when absent', () => {
+    const sets = parsePresetCategorySets([presetSet]);
+    expect(sets[0].force_active).toBeUndefined();
+  });
+
+  test('parsePresetCategorySets does not set force_active when false', () => {
+    const sets = parsePresetCategorySets([{ ...forceActivePreset, force_active: false }]);
+    expect(sets[0].force_active).toBeUndefined();
+  });
+
+  test('force_active preset activates on a fresh install', () => {
+    setPresetGlobal([forceActivePreset]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    expect(categoryStore.active_set_ids).toEqual(['research-study']);
+  });
+
+  test('force_active preset overrides stored active_set_ids on existing install', () => {
+    // Simulate a user who already has the default set stored
+    setPresetGlobal([forceActivePreset]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [{ id: 'default', categories: defaultCategories }],
+      active_set_ids: ['default'],
+      _storedKeys: ['category_sets'],
+    });
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    // force_active preset must win over the stored selection
+    expect(categoryStore.active_set_ids).toEqual(['research-study']);
+  });
+
+  test('force_active preset is available but not activated when force_active is absent', () => {
+    setPresetGlobal([presetSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      category_sets: [{ id: 'default', categories: defaultCategories }],
+      active_set_ids: ['default'],
+      _storedKeys: ['category_sets'],
+    });
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    // no force_active — stored selection is preserved
+    expect(categoryStore.active_set_ids).toEqual(['default']);
+    // preset is still offered as an available set
+    expect(categoryStore.category_sets.some(s => s.id === 'study')).toBe(true);
+  });
+});

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -556,6 +556,30 @@ describe('force_active preset', () => {
     expect(categoryStore.active_set_ids).toEqual(['research-study']);
   });
 
+  test('force_active preset wins on fresh install even when it is not presets[0]', () => {
+    // Regression: fresh-install branch previously activated presets[0] unconditionally,
+    // ignoring force_active when it was not the first preset in the array.
+    setPresetGlobal([presetSet, forceActivePreset]); // force_active is second
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    expect(categoryStore.active_set_ids).toEqual(['research-study']);
+  });
+
+  test('warns and uses first when multiple presets have force_active', () => {
+    const secondForce: CategorySet = {
+      id: 'also-forced',
+      force_active: true,
+      categories: [{ name: ['Work'], rule: { type: 'regex', regex: '^Work$' } }],
+    };
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    setPresetGlobal([forceActivePreset, secondForce]);
+    const categoryStore = useCategoryStore();
+    categoryStore.load();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('2 presets have force_active'));
+    expect(categoryStore.active_set_ids).toEqual(['research-study']);
+    warnSpy.mockRestore();
+  });
+
   test('force_active preset is available but not activated when force_active is absent', () => {
     setPresetGlobal([presetSet]);
     const settingsStore = useSettingsStore();


### PR DESCRIPTION
## Problem

When a build ships a preset category set via `AW_PRESET_CATEGORY_SETS`, the preset is only activated on a **fresh install** — users who had ActivityWatch before the build was deployed never see the preset activated. `loadCategories()` takes the `storedSets && storedSets.length > 0` branch, which preserves whatever `active_set_ids` were stored (`['default']`), and skips the preset-activation path entirely.

This matters for research builds and managed deployments where a specific taxonomy **must** be active regardless of prior install state.

## Solution

Add an optional `force_active?: boolean` field to `CategorySet`. When a preset has `force_active: true`, `loadCategories()` activates it even when the user has stored sets.

```json
[{
  "id": "research-study",
  "force_active": true,
  "categories": [...]
}]
```

### Invariants preserved
- Only presets delivered via `getPresetCategorySets()` (build-time env var) can use `force_active`. A stored set cannot force-activate itself.
- Single-set activation constraint is kept: only the `force_active` preset is activated (same as the first-run path), so `syncToPrimarySet()` can write user edits back correctly.
- If no `force_active` preset exists, behaviour is identical to before.
- The bug fix in `getPresetCategorySets()`'s deep-copy — it previously stripped `force_active` from the returned objects because the copy only included `{ id, categories }`.

## Changes

- `src/util/classes.ts`: Add `force_active?: boolean` to `CategorySet` interface; check for force-active preset before restoring stored `active_set_ids`
- `src/util/presetCategories.ts`: Parse and propagate `force_active: true` in `parseSet()`; preserve the flag in the `getPresetCategorySets()` copy
- `test/unit/presetCategories.test.node.ts`: 6 new tests covering parser propagation, fresh-install activation, existing-install override, and non-force-active unchanged behaviour