### PR TITLE
fix(categories): don't let persisted install defaults beat a shipped preset

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -79,9 +79,10 @@ interface State {
   // Set to true if settings loaded
   _loaded: boolean;
   // Keys that were actually present in storage (server or localStorage) on load.
-  // Lets us tell "user has never configured this" apart from "user configured it
-  // to the same value as the default" — needed to decide whether build-shipped
-  // preset categories may be activated. See `loadCategories()` in ~/util/classes.
+  // Presence of `classes` alone is not enough to suppress a shipped preset:
+  // first-run `save()` writes every key, including the install-default class
+  // list. `loadCategories()` additionally checks whether those classes still
+  // look unconfigured.
   _storedKeys: string[];
 }
 

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -314,12 +314,12 @@ export function classesLookUnconfigured(classes: Category[] | undefined | null):
   if (!classes || classes.length === 0) return true;
   const signatureOf = (cats: Category[]) =>
     cats
-      .filter(c => c.name.join('>') !== 'Uncategorized')
       .map(c =>
         JSON.stringify([
           c.name,
-          c.rule?.type ?? null,
-          c.rule?.regex ?? null,
+          // `null` and `'none'` are the same rule type after cleanCategory
+          c.rule?.type === 'regex' ? 'regex' : 'none',
+          c.rule?.type === 'regex' ? c.rule?.regex ?? null : null,
           Boolean(c.rule?.ignore_case),
           c.rule?.select_keys ?? null,
           c.rule?.priority ?? c.rule?.weight ?? null,

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -311,7 +311,9 @@ export function saveCategories(sets: CategorySet[], activeIds: string[]) {
  * as a custom taxonomy.
  */
 export function classesLookUnconfigured(classes: Category[] | undefined | null): boolean {
-  if (!classes || classes.length === 0) return true;
+  // Empty array is a deliberate "no categories" save, not an install default.
+  if (classes == null) return true;
+  if (classes.length === 0) return false;
   const signatureOf = (cats: Category[]) =>
     cats
       .map(c =>

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -302,13 +302,38 @@ export function saveCategories(sets: CategorySet[], activeIds: string[]) {
 }
 
 /**
+ * True when `classes` is still an install default, not a user taxonomy.
+ *
+ * Used to tell "the user never configured categories" apart from "the user
+ * kept the built-in defaults on purpose after editing". Name-only: colors and
+ * other `data` fields must not count as customization, or shipping palette
+ * updates would reclassify every existing install as a custom taxonomy.
+ */
+export function classesLookUnconfigured(classes: Category[] | undefined | null): boolean {
+  if (!classes || classes.length === 0) return true;
+  const namesOf = (cats: Category[]) =>
+    cats
+      .map(c => c.name.join('>'))
+      .filter(n => n !== 'Uncategorized')
+      .sort()
+      .join('|');
+  const names = namesOf(classes);
+  if (names === namesOf(defaultCategories)) return true;
+  return getPresetCategorySets().some(p => names === namesOf(p.categories));
+}
+
+/**
  * Load category sets and active set IDs from the settings store.
  * Falls back to the legacy flat `classes` setting if no sets are defined yet.
  *
  * Preset sets shipped by the build/deployment (see `~/util/presetCategories`)
  * are always appended as *available* sets, but are only active by default when
- * the user has no stored categorization of their own. A stored set with the
- * same id always wins over the preset definition, so user edits stick.
+ * the user has no stored categorization of their own. Persisted *install
+ * defaults* (the stock `classes` list, or a copy of a shipped preset) do not
+ * count — `settings.save()` writes every key, so a theme/view save on first
+ * run used to look like a user taxonomy and let `default` silently win over
+ * the preset (ActivityWatch/activitywatch#1439). A stored set with the same
+ * id always wins over the preset definition, so user edits stick.
  */
 export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
   const settingsStore = useSettingsStore();
@@ -319,11 +344,20 @@ export function loadCategories(): { sets: CategorySet[]; activeIds: string[] } {
   let sets: CategorySet[];
   let activeIds: string[];
 
-  if (storedSets && storedSets.length > 0) {
+  const storedOwnSets = Boolean(storedSets && storedSets.length > 0);
+  // `hasStoredCategories` is true as soon as `classes` exists in storage,
+  // which first-run `settings.save()` always writes. Only a *custom* class
+  // list should suppress the shipped preset.
+  const storedCustomClasses =
+    settingsStore.hasStoredCategories &&
+    !storedOwnSets &&
+    !classesLookUnconfigured(settingsStore.classes);
+
+  if (storedOwnSets) {
     sets = [...storedSets];
     activeIds =
       storedActiveIds && storedActiveIds.length > 0 ? [...storedActiveIds] : [storedSets[0].id];
-  } else if (presets.length > 0 && !settingsStore.hasStoredCategories) {
+  } else if (presets.length > 0 && !storedCustomClasses) {
     // First run on a build that ships presets: activate the first preset only.
     //
     // We deliberately limit the initial selection to one set: syncToPrimarySet()

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -304,34 +304,56 @@ export function saveCategories(sets: CategorySet[], activeIds: string[]) {
 /**
  * True when `classes` is still an install default, not a user taxonomy.
  *
- * Used to tell "the user never configured categories" apart from "the user
- * kept the built-in names after editing a rule". Names plus rule fields
- * (type/regex/flags/select_keys/priority); `data` (colors, scores) is ignored
- * so a palette update on a shipped preset does not reclassify every install
- * as a custom taxonomy.
+ * Used to tell "the user never configured categories" apart from a real edit.
+ * Names and rules must match an install default. A missing `data.color` is
+ * still unconfigured (so a later palette on the shipped preset does not look
+ * like user data); a *different* color is a customization and is kept.
  */
+function categoryNameKey(c: Category): string {
+  return c.name.join('>');
+}
+
+function ruleSignature(c: Category): string {
+  return JSON.stringify([
+    // `null` and `'none'` are the same rule type after cleanCategory
+    c.rule?.type === 'regex' ? 'regex' : 'none',
+    c.rule?.type === 'regex' ? c.rule?.regex ?? null : null,
+    Boolean(c.rule?.ignore_case),
+    c.rule?.select_keys ?? null,
+    c.rule?.priority ?? c.rule?.weight ?? null,
+  ]);
+}
+
+function categoryColor(c: Category): string | null {
+  const color = c.data && c.data.color;
+  return typeof color === 'string' && color.length > 0 ? color : null;
+}
+
+/**
+ * True when `stored` is the same taxonomy as `reference`, allowing a missing
+ * color (install default, or a later palette on the preset) but not a color
+ * the user actually changed.
+ */
+function matchesInstallDefault(stored: Category[], reference: Category[]): boolean {
+  if (stored.length !== reference.length) return false;
+  const refByName = new Map(reference.map(c => [categoryNameKey(c), c]));
+  if (refByName.size !== reference.length) return false;
+  for (const cat of stored) {
+    const ref = refByName.get(categoryNameKey(cat));
+    if (!ref) return false;
+    if (ruleSignature(cat) !== ruleSignature(ref)) return false;
+    const storedColor = categoryColor(cat);
+    if (storedColor !== null && storedColor !== categoryColor(ref)) return false;
+  }
+  return true;
+}
+
 export function classesLookUnconfigured(classes: Category[] | undefined | null): boolean {
   // Empty array is a deliberate "no categories" save, not an install default.
   if (classes == null) return true;
   if (classes.length === 0) return false;
-  const signatureOf = (cats: Category[]) =>
-    cats
-      .map(c =>
-        JSON.stringify([
-          c.name,
-          // `null` and `'none'` are the same rule type after cleanCategory
-          c.rule?.type === 'regex' ? 'regex' : 'none',
-          c.rule?.type === 'regex' ? c.rule?.regex ?? null : null,
-          Boolean(c.rule?.ignore_case),
-          c.rule?.select_keys ?? null,
-          c.rule?.priority ?? c.rule?.weight ?? null,
-        ])
-      )
-      .sort()
-      .join('\n');
-  const signature = signatureOf(classes);
-  if (signature === signatureOf(defaultCategories)) return true;
-  return getPresetCategorySets().some(p => signature === signatureOf(p.categories));
+  if (matchesInstallDefault(classes, defaultCategories)) return true;
+  return getPresetCategorySets().some(p => matchesInstallDefault(classes, p.categories));
 }
 
 /**

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -334,8 +334,11 @@ function categoryColor(c: Category): string | null {
  * color (install default, or a later palette on the preset) but not a color
  * the user actually changed.
  *
- * Score and other non-color `data` fields are treated like color: a stored
- * value that differs from the reference is a user customization that is kept.
+ * Score is compared exactly: a stored value that differs from the reference
+ * (including a cleared/undefined score when the reference has one) is a user
+ * customization and is kept.  Unlike color, a missing stored score is NOT
+ * treated as "unconfigured" — "Inherit parent score" explicitly sets it to
+ * undefined, which is a meaningful user action.
  *
  * Duplicate stored names are treated as user edits (one-to-one name matching
  * is required, mirroring the uniqueness check on the reference side).
@@ -354,11 +357,13 @@ function matchesInstallDefault(stored: Category[], reference: Category[]): boole
     if (ruleSignature(cat) !== ruleSignature(ref)) return false;
     const storedColor = categoryColor(cat);
     if (storedColor !== null && storedColor !== categoryColor(ref)) return false;
-    // A stored score (or other data field) that differs from the reference is a
-    // user edit — treat the taxonomy as configured and keep it.
-    const storedScore = cat.data?.score;
-    const refScore = ref.data?.score;
-    if (storedScore != null && storedScore !== refScore) return false;
+    // A stored score that differs from the reference is a user edit — treat the
+    // taxonomy as configured and keep it.  Unlike color, a *cleared* score
+    // (stored undefined when the reference has one) is also a user edit:
+    // "Inherit parent score" explicitly removes the value.
+    const storedScore = cat.data?.score ?? null;
+    const refScore = ref.data?.score ?? null;
+    if (storedScore !== refScore) return false;
   }
   return true;
 }

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -333,17 +333,32 @@ function categoryColor(c: Category): string | null {
  * True when `stored` is the same taxonomy as `reference`, allowing a missing
  * color (install default, or a later palette on the preset) but not a color
  * the user actually changed.
+ *
+ * Score and other non-color `data` fields are treated like color: a stored
+ * value that differs from the reference is a user customization that is kept.
+ *
+ * Duplicate stored names are treated as user edits (one-to-one name matching
+ * is required, mirroring the uniqueness check on the reference side).
  */
 function matchesInstallDefault(stored: Category[], reference: Category[]): boolean {
   if (stored.length !== reference.length) return false;
   const refByName = new Map(reference.map(c => [categoryNameKey(c), c]));
   if (refByName.size !== reference.length) return false;
+  // Require one-to-one name matching: duplicates in stored would let a renamed/
+  // deleted category slip through as "matching" by piggy-backing on a sibling.
+  const storedNames = stored.map(c => categoryNameKey(c));
+  if (new Set(storedNames).size !== stored.length) return false;
   for (const cat of stored) {
     const ref = refByName.get(categoryNameKey(cat));
     if (!ref) return false;
     if (ruleSignature(cat) !== ruleSignature(ref)) return false;
     const storedColor = categoryColor(cat);
     if (storedColor !== null && storedColor !== categoryColor(ref)) return false;
+    // A stored score (or other data field) that differs from the reference is a
+    // user edit — treat the taxonomy as configured and keep it.
+    const storedScore = cat.data?.score;
+    const refScore = ref.data?.score;
+    if (storedScore != null && storedScore !== refScore) return false;
   }
   return true;
 }

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -334,11 +334,12 @@ function categoryColor(c: Category): string | null {
  * color (install default, or a later palette on the preset) but not a color
  * the user actually changed.
  *
- * Score is compared exactly: a stored value that differs from the reference
- * (including a cleared/undefined score when the reference has one) is a user
- * customization and is kept.  Unlike color, a missing stored score is NOT
- * treated as "unconfigured" — "Inherit parent score" explicitly sets it to
- * undefined, which is a meaningful user action.
+ * Score: only an explicitly set stored score that differs from the reference
+ * is treated as a user customization.  A missing/undefined stored score is
+ * indistinguishable from legacy data (categories persisted before scores were
+ * introduced) and is therefore treated as an install default, not a user edit.
+ * This means "Inherit parent score" (stores undefined) does not prevent preset
+ * activation — an acceptable trade-off given the ambiguity.
  *
  * Duplicate stored names are treated as user edits (one-to-one name matching
  * is required, mirroring the uniqueness check on the reference side).
@@ -357,13 +358,11 @@ function matchesInstallDefault(stored: Category[], reference: Category[]): boole
     if (ruleSignature(cat) !== ruleSignature(ref)) return false;
     const storedColor = categoryColor(cat);
     if (storedColor !== null && storedColor !== categoryColor(ref)) return false;
-    // A stored score that differs from the reference is a user edit — treat the
-    // taxonomy as configured and keep it.  Unlike color, a *cleared* score
-    // (stored undefined when the reference has one) is also a user edit:
-    // "Inherit parent score" explicitly removes the value.
-    const storedScore = cat.data?.score ?? null;
-    const refScore = ref.data?.score ?? null;
-    if (storedScore !== refScore) return false;
+    // Only treat score as a user edit if it is explicitly set to a different
+    // value.  A missing/undefined stored score is indistinguishable from legacy
+    // data (persisted before scores existed), so we do not block on it.
+    const storedScore = cat.data?.score;
+    if (storedScore !== undefined && storedScore !== ref.data?.score) return false;
   }
   return true;
 }

--- a/src/util/classes.ts
+++ b/src/util/classes.ts
@@ -305,21 +305,31 @@ export function saveCategories(sets: CategorySet[], activeIds: string[]) {
  * True when `classes` is still an install default, not a user taxonomy.
  *
  * Used to tell "the user never configured categories" apart from "the user
- * kept the built-in defaults on purpose after editing". Name-only: colors and
- * other `data` fields must not count as customization, or shipping palette
- * updates would reclassify every existing install as a custom taxonomy.
+ * kept the built-in names after editing a rule". Names plus rule fields
+ * (type/regex/flags/select_keys/priority); `data` (colors, scores) is ignored
+ * so a palette update on a shipped preset does not reclassify every install
+ * as a custom taxonomy.
  */
 export function classesLookUnconfigured(classes: Category[] | undefined | null): boolean {
   if (!classes || classes.length === 0) return true;
-  const namesOf = (cats: Category[]) =>
+  const signatureOf = (cats: Category[]) =>
     cats
-      .map(c => c.name.join('>'))
-      .filter(n => n !== 'Uncategorized')
+      .filter(c => c.name.join('>') !== 'Uncategorized')
+      .map(c =>
+        JSON.stringify([
+          c.name,
+          c.rule?.type ?? null,
+          c.rule?.regex ?? null,
+          Boolean(c.rule?.ignore_case),
+          c.rule?.select_keys ?? null,
+          c.rule?.priority ?? c.rule?.weight ?? null,
+        ])
+      )
       .sort()
-      .join('|');
-  const names = namesOf(classes);
-  if (names === namesOf(defaultCategories)) return true;
-  return getPresetCategorySets().some(p => names === namesOf(p.categories));
+      .join('\n');
+  const signature = signatureOf(classes);
+  if (signature === signatureOf(defaultCategories)) return true;
+  return getPresetCategorySets().some(p => signature === signatureOf(p.categories));
 }
 
 /**

--- a/src/util/presetCategories.ts
+++ b/src/util/presetCategories.ts
@@ -30,7 +30,9 @@
  *
  * Behaviour of the resulting sets is defined in `loadCategories()` in
  * `~/util/classes`: preset sets are always *available*, but only activated by
- * default when the user has no stored categorization of their own.
+ * default when the user has no stored categorization of their own. A
+ * first-run `settings.save()` that persisted the install-default `classes`
+ * list does not count as user categorization.
  *
  * Malformed input is dropped with a warning rather than thrown — a broken
  * preset must never prevent the UI from starting.

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -340,6 +340,42 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toContain('study');
   });
 
+  test('first-run settings.save of stock defaults does not let default beat the preset', () => {
+    // ActivityWatch/activitywatch#1439: any settings.save() persists every key,
+    // including classes=defaultCategories and active_set_ids=['default']. That
+    // used to trip hasStoredCategories and wrap a competing `default` set.
+    setPresetGlobal([presetSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: defaultCategories,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets.map(s => s.id)).toEqual(['study']);
+  });
+
+  test('first-run settings.save of the preset classes still activates the preset set', () => {
+    // settings.classes defaults to getDefaultClasses(), which *is* the preset
+    // on a research build. Persisting that copy must not create a `default`
+    // set that wins over `research-study`.
+    setPresetGlobal([presetSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: presetSet.categories,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets.map(s => s.id)).toEqual(['study']);
+  });
+
   test('stored sets take precedence over a preset with the same id', () => {
     setPresetGlobal([presetSet]);
     const edited: CategorySet = {

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -327,6 +327,22 @@ describe('loadCategories with presets', () => {
     expect(sets[0].categories).toEqual(defaultCategories);
   });
 
+  test('a saved empty class list is kept instead of being replaced by the preset', () => {
+    setPresetGlobal([presetSet]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: [],
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual([]);
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
   test('a user with stored classes keeps them; presets are available but inactive', () => {
     setPresetGlobal([presetSet]);
     const myClasses: Category[] = [{ name: ['Mine'], rule: { type: 'regex', regex: 'mine' } }];

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -358,6 +358,29 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toEqual(['study']);
   });
 
+  test('edited default rules are kept even when category names still match', () => {
+    // A user who only changed a regex must not be classified as unconfigured
+    // and have that edit replaced by the shipped preset.
+    setPresetGlobal([presetSet]);
+    const edited = defaultCategories.map(c =>
+      c.name[0] === 'Work' && c.name.length === 1
+        ? { ...c, rule: { ...c.rule, regex: c.rule.regex + '|Overleaf' } }
+        : c
+    );
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: edited,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
   test('first-run settings.save of the preset classes still activates the preset set', () => {
     // settings.classes defaults to getDefaultClasses(), which *is* the preset
     // on a research build. Persisting that copy must not create a `default`

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -453,6 +453,52 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toContain('study');
   });
 
+  test('a score-only edit is kept as a custom taxonomy (greptile P1)', () => {
+    // Users can persist a category's productivity score (data.score).
+    // A taxonomy that differs from the install default only by score must be
+    // treated as customized — not classified as unconfigured and replaced by
+    // the shipped preset.
+    setPresetGlobal([presetSet]);
+    const edited = defaultCategories.map(c =>
+      c.name[0] === 'Work' && c.name.length === 1
+        ? { ...c, data: { ...(c.data ?? {}), score: 0.9 } }
+        : c
+    );
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: edited,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
+  test('a taxonomy with duplicate stored names is kept as a custom taxonomy (greptile P1)', () => {
+    // A legacy taxonomy with a duplicate category name must not be misclassified
+    // as an install default: duplicate stored names break the one-to-one name
+    // match requirement and indicate user edits.
+    setPresetGlobal([presetSet]);
+    // Duplicate the first default category name in the stored list.
+    const withDuplicate = [defaultCategories[0], ...defaultCategories];
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: withDuplicate,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    // The taxonomy has a duplicate name → it is not an install default → keep it.
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default')).toBeTruthy();
+  });
+
   test('first-run settings.save of the preset classes still activates the preset set', () => {
     // settings.classes defaults to getDefaultClasses(), which *is* the preset
     // on a research build. Persisting that copy must not create a `default`

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -478,6 +478,32 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toContain('study');
   });
 
+  test('a cleared score (inherit parent) is kept as a custom taxonomy (greptile P1)', () => {
+    // "Inherit parent score" in the category editor stores an undefined score
+    // while the install default (e.g. Work) has score: 10.  This is a user
+    // edit and must not be misclassified as an install default that gets
+    // displaced by the shipped preset.
+    setPresetGlobal([presetSet]);
+    const edited = defaultCategories.map(c =>
+      c.name[0] === 'Work' && c.name.length === 1
+        ? { ...c, data: { ...(c.data ?? {}), score: undefined } }
+        : c
+    );
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: edited,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    // Cleared score → user edit → keep as custom taxonomy, don't activate preset.
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
   test('a taxonomy with duplicate stored names is kept as a custom taxonomy (greptile P1)', () => {
     // A legacy taxonomy with a duplicate category name must not be misclassified
     // as an install default: duplicate stored names break the one-to-one name

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -358,6 +358,24 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toEqual(['study']);
   });
 
+  test('editing the Uncategorized rule is kept as a custom taxonomy', () => {
+    setPresetGlobal([presetSet]);
+    const edited = defaultCategories.map(c =>
+      c.name[0] === 'Uncategorized'
+        ? { ...c, rule: { type: 'regex' as const, regex: 'SomeApp' } }
+        : c
+    );
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: edited,
+      _storedKeys: ['classes'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+  });
+
   test('edited default rules are kept even when category names still match', () => {
     // A user who only changed a regex must not be classified as unconfigured
     // and have that edit replaced by the shipped preset.

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -374,6 +374,44 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toEqual(['study']);
   });
 
+  test('a recolored default category is kept as a custom taxonomy', () => {
+    setPresetGlobal([presetSet]);
+    const edited = defaultCategories.map(c =>
+      c.name[0] === 'Work' && c.name.length === 1
+        ? { ...c, data: { ...c.data, color: '#123456' } }
+        : c
+    );
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: edited,
+      _storedKeys: ['classes'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['default']);
+    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+  });
+
+  test('a colorless copy of a colored preset is still an install default', () => {
+    const coloredPreset: CategorySet = {
+      id: 'study',
+      categories: presetSet.categories.map(c => ({
+        ...c,
+        data: { color: '#ABCDEF' },
+      })),
+    };
+    setPresetGlobal([coloredPreset]);
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: presetSet.categories, // no data.color
+      _storedKeys: ['classes'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    expect(activeIds).toEqual(['study']);
+    expect(sets.map(s => s.id)).toEqual(['study']);
+  });
+
   test('editing the Uncategorized rule is kept as a custom taxonomy', () => {
     setPresetGlobal([presetSet]);
     const edited = defaultCategories.map(c =>

--- a/test/unit/presetCategories.test.node.ts
+++ b/test/unit/presetCategories.test.node.ts
@@ -478,11 +478,11 @@ describe('loadCategories with presets', () => {
     expect(sets.map(s => s.id)).toContain('study');
   });
 
-  test('a cleared score (inherit parent) is kept as a custom taxonomy (greptile P1)', () => {
-    // "Inherit parent score" in the category editor stores an undefined score
-    // while the install default (e.g. Work) has score: 10.  This is a user
-    // edit and must not be misclassified as an install default that gets
-    // displaced by the shipped preset.
+  test('a cleared score (inherit parent) does not block preset activation (greptile P1 trade-off)', () => {
+    // "Inherit parent score" stores an undefined score, which is indistinguishable
+    // from a legacy entry persisted before scores existed.  We cannot tell
+    // them apart in storage, so we treat both as install-default (not a user edit).
+    // The preset activates; the cleared-score intent is acceptable collateral.
     setPresetGlobal([presetSet]);
     const edited = defaultCategories.map(c =>
       c.name[0] === 'Work' && c.name.length === 1
@@ -498,9 +498,33 @@ describe('loadCategories with presets', () => {
     });
 
     const { sets, activeIds } = loadCategories();
-    // Cleared score → user edit → keep as custom taxonomy, don't activate preset.
-    expect(activeIds).toEqual(['default']);
-    expect(sets.find(s => s.id === 'default').categories).toEqual(edited);
+    // Cleared score ≡ legacy absent score → treated as install default → preset activates.
+    expect(activeIds).toContain('study');
+    expect(sets.map(s => s.id)).toContain('study');
+  });
+
+  test('a legacy taxonomy without scores does not suppress preset activation (greptile P1)', () => {
+    // Categories persisted before scores were introduced have no score field.
+    // The comparison must not treat their absent score as a user customization;
+    // otherwise the preset is never activated for upgrading users.
+    setPresetGlobal([presetSet]);
+    // Strip the score field from all categories, simulating legacy persisted data.
+    const legacy = defaultCategories.map(c => {
+      const d = { ...(c.data ?? {}) };
+      delete d.score;
+      return { ...c, data: d };
+    });
+    const settingsStore = useSettingsStore();
+    settingsStore.$patch({
+      classes: legacy,
+      category_sets: [],
+      active_set_ids: ['default'],
+      _storedKeys: ['classes', 'category_sets', 'active_set_ids'],
+    });
+
+    const { sets, activeIds } = loadCategories();
+    // Legacy data (no stored score) must be treated as install default → preset activates.
+    expect(activeIds).toContain('study');
     expect(sets.map(s => s.id)).toContain('study');
   });
 


### PR DESCRIPTION
## Problem

A build that ships a preset category set (Research Edition:
`research-study` via `AW_PRESET_CATEGORY_SETS`) is supposed to activate that
preset on a fresh install. `settings.save()` writes **every** key, so the
first theme/view save persisted `classes=<install default>` and
`active_set_ids=['default']`.

`loadCategories()` treated that as a user taxonomy, wrapped a competing
`default` set, and left the shipped preset inactive. On
`v0.14.0b5-research` the Activity view then used `default` and the study
taxonomy never showed unless the user deleted that set.

Tracked in ActivityWatch/activitywatch#1439.

## What this does

Preset sets still activate only when the user has no stored categorization
of their own. Persisted *install defaults* no longer count:

- stock `defaultCategories` (including after a first-run save)
- a copy of a shipped preset, including a colorless copy of a later
  colored preset (so a palette recut does not look like user data)

Real edits are kept: custom names, edited regexes/flags/select_keys/priority,
a recolored category, a saved empty class list, an Uncategorized-rule edit.
A stored `category_sets` entry still wins outright.

## Tests

`npx jest --selectProjects node --testPathPattern=presetCategories.test.node`

45 passed, including the #1439 reproduction (first-run save of stock
defaults, and of the preset class list) and the edit-preservation cases
above.

## Notes

Does not close ActivityWatch/activitywatch#1439 on its own. Colors are
ActivityWatch/activitywatch#1441. Both need a research recut after the
aw-server-rust webui pin moves.