### PR TITLE
Resolve outstanding webui TODO/FIXME markers

### DIFF
--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -92,7 +92,7 @@ export default {
       categoryStore: useCategoryStore(),
 
       editing: {
-        id: 0, // FIXME: Use ID assigned to category in store, in order for saves to be uniquely targeted
+        id: 0, // Placeholder; replaced with the stored category id by resetModal()
         name: null,
         rule: {},
         parent: [],

--- a/src/components/EventEditor.vue
+++ b/src/components/EventEditor.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEditModal", title="Edit event", centered, hide-footer)
+b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEditModal", title="Edit event", centered, hide-footer, :no-close-on-backdrop="busy", :no-close-on-esc="busy", :hide-header-close="busy")
   div(v-if="!editedEvent")
     | Loading event...
 
@@ -37,15 +37,18 @@ b-modal(v-if="event && event.id", :id="'edit-modal-' + event.id", ref="eventEdit
 
     hr
 
+    b-alert(v-if="error" show variant="danger")
+      | {{ error }}
+
     div.float-left
-      b-button.mx-1(@click="delete_(); close();" variant="danger")
+      b-button.mx-1(@click="delete_", variant="danger", :disabled="busy")
         icon.mx-1(name="trash")
         | Delete
     div.float-right
-      b-button.mx-1(@click="close")
+      b-button.mx-1(@click="close", :disabled="busy")
         icon.mx-1(name="times")
         | Cancel
-      b-button.mx-1(@click="save(); close();", variant="primary")
+      b-button.mx-1(@click="save", variant="primary", :disabled="busy")
         icon.mx-1(name="save")
         | Save
 </template>
@@ -76,9 +79,15 @@ export default {
   data() {
     return {
       editedEvent: null,
+      // Name of the mutation in flight ('save' / 'delete'), else null.
+      pending: null,
+      error: '',
     };
   },
   computed: {
+    busy() {
+      return this.pending !== null;
+    },
     start: {
       get: function () {
         return moment(this.editedEvent.timestamp).format();
@@ -101,6 +110,7 @@ export default {
   },
   watch: {
     async event() {
+      this.error = '';
       await this.getEvent();
     },
   },
@@ -109,16 +119,56 @@ export default {
   },
   methods: {
     async save() {
-      // This emit needs to be called first, otherwise it won't occur for some reason
-      // FIXME: but what if the replace fails? Then UI will incorrectly think event was replaced?
-      this.$emit('save', this.editedEvent);
-      await this.$aw.replaceEvent(this.bucket_id, this.editedEvent);
+      if (!this.editedEvent) return;
+      await this.runMutation('save', this.editedEvent, () =>
+        this.$aw.replaceEvent(this.bucket_id, this.editedEvent)
+      );
     },
     async delete_() {
-      // This emit needs to be called first, otherwise it won't occur for some reason
-      // FIXME: but what if the replace fails? Then UI will incorrectly think event was deleted?
-      this.$emit('delete', this.event);
-      await this.$aw.deleteEvent(this.bucket_id, this.event.id);
+      await this.runMutation('delete', this.event, () =>
+        this.$aw.deleteEvent(this.bucket_id, this.event.id)
+      );
+    },
+    // Runs one mutation against the server. Parents are told it succeeded only
+    // once the request actually has, so a failure leaves the editor open with
+    // the user's input intact and retryable.
+    //
+    // The modal is hidden before the success event is emitted: a parent
+    // reacting to it may destroy this component (it is usually rendered behind
+    // a v-if on the event being edited), and the ref would be gone by then.
+    async runMutation(name, payload, request) {
+      if (this.pending) return;
+      const editingId = this.event && this.event.id;
+      this.pending = name;
+      this.error = '';
+      try {
+        await request();
+      } catch (e) {
+        console.error(e);
+        this.error = this.requestErrorMessage(e, name);
+        return;
+      } finally {
+        this.pending = null;
+      }
+
+      // The editor may have been pointed at a different event while the
+      // request was in flight; a late response must not act on the new one.
+      if (!this.event || this.event.id !== editingId) return;
+
+      this.hideModal();
+      this.$emit(name, payload);
+    },
+    requestErrorMessage(e, name) {
+      const response = e && e.response;
+      const serverMessage = response && response.data && response.data.message;
+      const verb = name === 'delete' ? 'delete' : 'save';
+      return serverMessage || (e && e.message) || `Failed to ${verb} event.`;
+    },
+    // Hiding is best-effort: the modal may already be gone if a parent
+    // re-rendered or destroyed this component.
+    hideModal() {
+      const modal = this.$refs.eventEditModal;
+      if (modal) modal.hide();
     },
     async getEvent() {
       if (this.bucket_id && this.event && this.event.id) {
@@ -128,7 +178,8 @@ export default {
       }
     },
     close() {
-      this.$refs.eventEditModal.hide();
+      if (this.pending) return;
+      this.hideModal();
       this.$emit('close', this.event);
     },
   },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -468,9 +468,7 @@ export function editorActivityQuery(editorbuckets: string[]): string[] {
 
 // Returns a query that yields a single event with the duration set to
 // the sum of all non-afk time in the queried period
-// TODO: Would ideally account for `filter_afk` and `always_active_pattern`
-// TODO: rename to something like `activeDurationQuery`
-// FIXME: Doesn't respect audible-as-active and always-active-pattern
+// AFK-only fallback for hosts without window/browser activity.
 export function activityQuery(afkbuckets: string[]): string[] {
   let q = ['not_afk = [];'];
   for (const afkbucket of afkbuckets) {
@@ -482,6 +480,64 @@ export function activityQuery(afkbuckets: string[]): string[] {
   }
   q = q.concat(['not_afk = merge_events_by_keys(not_afk, ["status"]);', 'RETURN = not_afk;']);
   return q;
+}
+
+export interface ActivityQuerySource {
+  bid_afk: string;
+  bid_window?: string;
+  bid_browsers?: string[];
+}
+
+export interface ActivityQueryOptions {
+  filter_afk?: boolean;
+  include_audible?: boolean;
+  always_active_pattern?: string;
+}
+
+// History measures active evidence, independent of category filters. With AFK
+// filtering disabled it measures window coverage instead. Union periods before
+// returning them so overlapping evidence and devices are counted only once.
+export function activeDurationQuery(
+  sources: ActivityQuerySource[],
+  options: ActivityQueryOptions = {}
+): string[] {
+  let code = 'history_events = [];';
+  for (const source of sources) {
+    if (source.bid_window) {
+      code += canonicalEvents({
+        ...options,
+        filter_afk: options.filter_afk !== false,
+        bid_window: escape_doublequote(source.bid_window),
+        bid_afk: escape_doublequote(source.bid_afk),
+        bid_browsers: (source.bid_browsers || []).map(escape_doublequote),
+        always_active_pattern: options.always_active_pattern
+          ? escape_doublequote(options.always_active_pattern)
+          : undefined,
+        categories: null,
+        filter_categories: null,
+      });
+      code += `history_events = union_no_overlap(history_events, ${
+        options.filter_afk === false ? 'events' : 'not_afk'
+      });`;
+    } else {
+      // No window source means there is no app/title or browser context; retain
+      // the observed AFK signal even when filter_afk is disabled.
+      //
+      // Built inline rather than via activityQuery, whose trailing
+      // merge_events_by_keys(not_afk, ["status"]) collapses every not-afk
+      // period into one event carrying the first timestamp and the summed
+      // duration. That is no longer an interval, so unioning it against
+      // another source's real periods trims time that was never concurrent,
+      // and multidevice with an AFK-only host under-counted.
+      const bid_afk = escape_doublequote(source.bid_afk);
+      code += `
+        not_afk = flood(${queryBucket(bid_afk)});
+        not_afk = filter_keyvals(not_afk, "status", ["not-afk"]);
+      `;
+      code += 'history_events = union_no_overlap(history_events, not_afk);';
+    }
+  }
+  return querystr_to_array(code + 'RETURN = history_events;');
 }
 
 // Equivalent function to activityQuery, but for Android (which doesn't have an afk bucket)
@@ -508,6 +564,7 @@ export default {
   multideviceQuery,
   appQuery,
   activityQuery,
+  activeDurationQuery,
   activityQueryAndroid,
   categoryQuery,
   editorActivityQuery,

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -511,6 +511,7 @@ export const useActivityStore = defineStore('activity', {
             host: query_options.host,
             useMultidevice: settingsStore.useMultidevice,
             startOfDay: settingsStore.startOfDay,
+            filter_afk: query_options.filter_afk,
             include_audible: query_options.include_audible,
             always_active_pattern: query_options.always_active_pattern,
           },

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -18,6 +18,7 @@ import {
 } from '~/util/timeperiod';
 
 import { useSettingsStore } from '~/stores/settings';
+import { activeHistoryCacheKey, selectPeriodsToQuery } from '~/util/activeHistory';
 import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
 
@@ -160,6 +161,12 @@ interface State {
     events: IEvent[];
     // Aggregated events for current and past periods
     history: Record<any, IEvent[]>;
+    // Identity of the context `history` was fetched for. Cached periods are
+    // only reusable while this matches; see util/activeHistory.
+    history_key: string | null;
+    // Bumped whenever the cache is invalidated, so a response that was already
+    // in flight for the previous context cannot populate the new one.
+    history_generation: number;
   };
 
   android: {
@@ -230,6 +237,8 @@ export const useActivityStore = defineStore('activity', {
       events: [],
       // Aggregated events for current and past periods
       history: {},
+      history_key: null,
+      history_generation: 0,
     },
 
     android: {
@@ -490,20 +499,41 @@ export const useActivityStore = defineStore('activity', {
     },
 
     async query_active_history({ timeperiod, ...query_options }: QueryOptions) {
-      // Filter out periods that are already in the history, and that are in the future
-      const periods = timeperiodStrsAroundTimeperiod(timeperiod).filter(tp_str => {
-        return (
-          !_.includes(this.active.history, tp_str) && new Date(tp_str.split('/')[0]) < new Date()
-        );
+      const settingsStore = useSettingsStore();
+      const sources = activeHistorySources(this, query_options);
+
+      // Drop anything fetched for a different question before deciding what is
+      // still missing, so incompatible periods can never be reused.
+      const generation = this.invalidate_active_history({
+        cache_key: activeHistoryCacheKey(
+          {
+            platform: 'desktop',
+            host: query_options.host,
+            useMultidevice: settingsStore.useMultidevice,
+            startOfDay: settingsStore.startOfDay,
+            include_audible: query_options.include_audible,
+            always_active_pattern: query_options.always_active_pattern,
+          },
+          sources
+        ),
+        force: query_options.force,
       });
-      const query = queries.activeDurationQuery(
-        activeHistorySources(this, query_options),
-        query_options
+
+      const periods = selectPeriodsToQuery(
+        timeperiodStrsAroundTimeperiod(timeperiod),
+        this.active.history
       );
+      // Nothing missing: no request at all.
+      if (periods.length === 0) return;
+
+      const query = queries.activeDurationQuery(sources, query_options);
       const data = await getClient().query(periods, query, {
         name: 'activityQuery',
         verbose: true,
       });
+      // The context moved on while this was in flight (host switch, settings
+      // change, force reload); its result describes the old one.
+      if (this.active.history_generation !== generation) return;
       const active_history = _.zipObject(
         periods,
         data.map(events => events.map(e => ({ ...e, data: { ...e.data, status: 'not-afk' } })))
@@ -623,18 +653,38 @@ export const useActivityStore = defineStore('activity', {
       this.query_category_time_by_period_completed({ by_period });
     },
 
-    async query_active_history_android({ timeperiod }: QueryOptions) {
-      const periods = timeperiodStrsAroundTimeperiod(timeperiod).filter(tp_str => {
-        return !_.includes(this.active.history, tp_str);
-      });
+    async query_active_history_android({ timeperiod, ...query_options }: QueryOptions) {
+      const settingsStore = useSettingsStore();
       // Prefer ScreenTime bucket over Android watcher for consistency with query_android
       const iosOrAndroidBucket =
         this.buckets.android.find((id: string) => id.startsWith('aw-import-screentime')) ||
         this.buckets.android[0];
+
+      const generation = this.invalidate_active_history({
+        cache_key: activeHistoryCacheKey(
+          {
+            platform: 'android',
+            host: query_options.host,
+            useMultidevice: settingsStore.useMultidevice,
+            startOfDay: settingsStore.startOfDay,
+          },
+          [iosOrAndroidBucket]
+        ),
+        force: query_options.force,
+      });
+
+      // Same freshness policy as desktop, including skipping future periods.
+      const periods = selectPeriodsToQuery(
+        timeperiodStrsAroundTimeperiod(timeperiod),
+        this.active.history
+      );
+      if (periods.length === 0) return;
+
       const data = await getClient().query(
         periods,
         queries.activityQueryAndroid(iosOrAndroidBucket)
       );
+      if (this.active.history_generation !== generation) return;
       const active_history = _.zipObject(periods, data);
       const active_history_events = _.mapValues(
         active_history,
@@ -784,12 +834,9 @@ export const useActivityStore = defineStore('activity', {
 
       this.active.duration = null;
 
-      // Ensures that active history isn't being fully reloaded on every date change
-      // (see caching done in query_active_history and query_active_history_android)
-      // FIXME: Better detection of when to actually clear (such as on force reload, hostname change)
-      if (Object.keys(this.active.history).length === 0) {
-        this.active.history = {};
-      }
+      // active.history is deliberately preserved here so navigating dates
+      // reuses periods already fetched for the same context. Clearing it is
+      // decided by cache identity instead, in invalidate_active_history.
     },
 
     query_window_completed(
@@ -831,6 +878,18 @@ export const useActivityStore = defineStore('activity', {
       this.editor.top_files = data.files;
       this.editor.top_languages = data.languages;
       this.editor.top_projects = data.projects;
+    },
+
+    // Clears cached periods when they belong to a different question, or when
+    // the user explicitly asked for fresh data. Returns the generation that a
+    // response must still match to be accepted.
+    invalidate_active_history(this: State, { cache_key, force = false }) {
+      if (force || this.active.history_key !== cache_key) {
+        this.active.history = {};
+        this.active.history_key = cache_key;
+        this.active.history_generation += 1;
+      }
+      return this.active.history_generation;
     },
 
     query_active_history_completed(this: State, { active_history } = { active_history: {} }) {

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -239,17 +239,11 @@ export const useActivityStore = defineStore('activity', {
 
   getters: {
     getActiveHistoryAroundTimeperiod(this: State) {
-      return (timeperiod: TimePeriod): IEvent[][] => {
-        const periods = timeperiodStrsAroundTimeperiod(timeperiod);
-        const _history = periods.map(tp => {
-          if (_.has(this.active.history, tp)) {
-            return this.active.history[tp];
-          } else {
-            // A zero-duration placeholder until new data has been fetched
-            return [{ timestamp: moment(tp.split('/')[0]).format(), duration: 0, data: {} }];
-          }
-        });
-        return _history;
+      return (timeperiod: TimePeriod) => {
+        return timeperiodsAroundTimeperiod(timeperiod).map(period => ({
+          period,
+          events: this.active.history[timeperiodToStr(period)] || [],
+        }));
       };
     },
     uncategorizedDuration(this: State): [number, number] | null {

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -5,7 +5,7 @@ import { map, filter, values, groupBy, sortBy, flow, reverse } from 'lodash/fp';
 import { IEvent } from '~/util/interfaces';
 
 import { window_events } from '~/util/fakedata';
-import queries from '~/queries';
+import queries, { ActivityQuerySource } from '~/queries';
 import { get_day_start_with_offset } from '~/util/time';
 import {
   TimePeriod,
@@ -42,6 +42,27 @@ function timeperiodsStrsMonthsOfPeriod(timeperiod: TimePeriod): string[] {
 
 function timeperiodStrsAroundTimeperiod(timeperiod: TimePeriod): string[] {
   return timeperiodsAroundTimeperiod(timeperiod).map(timeperiodToStr);
+}
+
+function activeHistorySources(state: State, options: QueryOptions): ActivityQuerySource[] {
+  if (!useSettingsStore().useMultidevice) {
+    return state.buckets.afk.slice(0, 1).map(bid_afk => ({
+      bid_afk,
+      bid_window: state.buckets.window[0],
+      bid_browsers: state.buckets.browser,
+    }));
+  }
+  const buckets = useBucketsStore();
+  return buckets.hosts
+    .filter(host => host && (!host.startsWith('fakedata') || options.host.startsWith('fakedata')))
+    .sort()
+    .flatMap(host =>
+      buckets.bucketsAFK(host).map(bid_afk => ({
+        bid_afk,
+        bid_window: buckets.bucketsWindow(host)[0],
+        bid_browsers: buckets.bucketsBrowser(host),
+      }))
+    );
 }
 
 function colorCategories(events: IEvent[]): IEvent[] {
@@ -469,39 +490,23 @@ export const useActivityStore = defineStore('activity', {
     },
 
     async query_active_history({ timeperiod, ...query_options }: QueryOptions) {
-      const settingsStore = useSettingsStore();
-      const bucketsStore = useBucketsStore();
       // Filter out periods that are already in the history, and that are in the future
       const periods = timeperiodStrsAroundTimeperiod(timeperiod).filter(tp_str => {
         return (
           !_.includes(this.active.history, tp_str) && new Date(tp_str.split('/')[0]) < new Date()
         );
       });
-      let afk_buckets: string[] = [];
-      if (settingsStore.useMultidevice) {
-        // get all hostnames that qualify for the multidevice query
-        const hostnames = bucketsStore.hosts.filter(
-          // require that the host has afk buckets,
-          // and that the host is not a fakedata host,
-          // unless we're explicitly querying fakedata
-          host =>
-            host &&
-            bucketsStore.bucketsAFK(host).length > 0 &&
-            (!host.startsWith('fakedata') || query_options.host.startsWith('fakedata'))
-        );
-        // get all afk buckets for all hosts
-        afk_buckets = _.flatten(hostnames.map(bucketsStore.bucketsAFK));
-      } else {
-        afk_buckets = [this.buckets.afk[0]];
-      }
-      const query = queries.activityQuery(afk_buckets);
+      const query = queries.activeDurationQuery(
+        activeHistorySources(this, query_options),
+        query_options
+      );
       const data = await getClient().query(periods, query, {
         name: 'activityQuery',
         verbose: true,
       });
       const active_history = _.zipObject(
         periods,
-        _.map(data, pair => _.filter(pair, e => e.data.status == 'not-afk'))
+        data.map(events => events.map(e => ({ ...e, data: { ...e.data, status: 'not-afk' } })))
       );
       this.query_active_history_completed({ active_history });
     },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -3,6 +3,7 @@ import moment, { Moment } from 'moment';
 import { getClient } from '~/util/awclient';
 import { Category, CategorySet, getDefaultClasses, cleanCategory } from '~/util/classes';
 import { SavedQuery } from '~/util/savedQueries';
+import { AlertGoal, cleanAlertGoals } from '~/util/alerts';
 import { View, defaultViews } from '~/stores/views';
 import type { PrivacyFilterRule } from '~/util/privacyFilters';
 import { isEqual } from 'lodash';
@@ -66,6 +67,9 @@ interface State {
   active_set_ids: string[];
   views: View[];
   saved_queries: SavedQuery[];
+  // Alert goals for the Alerts view. Empty by default; `hasStoredAlerts`
+  // distinguishes "user saved an empty list" from "never saved".
+  alerts: AlertGoal[];
 
   // Whether to show certain WIP features
   devmode: boolean;
@@ -123,6 +127,7 @@ export const useSettingsStore = defineStore('settings', {
     active_set_ids: ['default'],
     views: defaultViews,
     saved_queries: [],
+    alerts: [],
 
     // Developer settings
     // NOTE: PRODUCTION might be undefined (in tests, for example)
@@ -143,6 +148,11 @@ export const useSettingsStore = defineStore('settings', {
     /** Whether the user has a stored categorization of their own (as opposed to defaults). */
     hasStoredCategories(state: State) {
       return state._storedKeys.includes('classes') || state._storedKeys.includes('category_sets');
+    },
+    /** Whether alert goals have ever been stored, so a saved empty list is not
+     * mistaken for a first run (which seeds sample goals). */
+    hasStoredAlerts(state: State) {
+      return state._storedKeys.includes('alerts');
     },
   },
 
@@ -183,7 +193,8 @@ export const useSettingsStore = defineStore('settings', {
           console.warn('Ignoring invalid locale from server:', server_settings[key]);
           continue;
         }
-        storage[key] = server_settings[key];
+        storage[key] =
+          key === 'alerts' ? cleanAlertGoals(server_settings[key]) : server_settings[key];
         used.add(key);
       }
 
@@ -200,12 +211,15 @@ export const useSettingsStore = defineStore('settings', {
           key == 'classes' ||
           key == 'category_sets' ||
           key == 'active_set_ids' ||
-          key == 'saved_queries';
+          key == 'saved_queries' ||
+          key == 'alerts';
         try {
           if (isJsonKey) {
             let parsed = JSON.parse(raw);
             if (key == 'classes') {
               parsed = parsed.map(cleanCategory);
+            } else if (key == 'alerts') {
+              parsed = cleanAlertGoals(parsed);
             }
             storage[key] = parsed;
           } else if (raw === 'true' || raw === 'false') {

--- a/src/util/activeHistory.ts
+++ b/src/util/activeHistory.ts
@@ -16,7 +16,10 @@ export interface ActiveHistoryContext {
   useMultidevice: boolean;
   // Period boundaries themselves depend on this.
   startOfDay: string;
-  // Semantic inputs to the active-period union.
+  // Semantic inputs to the active-period union. filter_afk matters because
+  // with AFK filtering disabled the query measures window coverage instead of
+  // AFK-filtered intervals, so the two are not interchangeable results.
+  filter_afk?: boolean;
   include_audible?: boolean;
   always_active_pattern?: string;
 }
@@ -46,6 +49,9 @@ export function activeHistoryCacheKey(
     host: context.host || '',
     useMultidevice: !!context.useMultidevice,
     startOfDay: context.startOfDay || '',
+    // Normalized the same way activeDurationQuery reads it, so an omitted
+    // value and an explicit true share one cache.
+    filter_afk: context.filter_afk !== false,
     include_audible: !!context.include_audible,
     always_active_pattern: context.always_active_pattern || '',
     sources: normalized_sources,

--- a/src/util/activeHistory.ts
+++ b/src/util/activeHistory.ts
@@ -1,0 +1,95 @@
+// Cache policy for the active-duration history behind the period-usage chart.
+//
+// Two separate concerns live here: whether previously fetched periods may be
+// reused at all (cache identity), and which periods still need to be fetched
+// (freshness).
+
+import { ActivityQuerySource } from '~/queries';
+
+// Everything that changes what the active-duration query would return. If any
+// of it differs, previously fetched periods describe a different question and
+// must not be reused.
+export interface ActiveHistoryContext {
+  // Desktop and Android/iOS use different queries and bucket sets.
+  platform: 'desktop' | 'android';
+  host: string;
+  useMultidevice: boolean;
+  // Period boundaries themselves depend on this.
+  startOfDay: string;
+  // Semantic inputs to the active-period union.
+  include_audible?: boolean;
+  always_active_pattern?: string;
+}
+
+// Returns a stable identity for the given context and resolved source buckets.
+// Bucket ids are sorted so that source discovery order cannot invalidate an
+// otherwise-identical cache.
+export function activeHistoryCacheKey(
+  context: ActiveHistoryContext,
+  sources: (ActivityQuerySource | string)[]
+): string {
+  const normalized_sources = sources
+    .map(source => {
+      if (typeof source === 'string') return { bid_afk: source };
+      return source;
+    })
+    .map(source => [
+      source.bid_afk || '',
+      source.bid_window || '',
+      [...(source.bid_browsers || [])].sort().join(','),
+    ])
+    .map(parts => parts.join('|'))
+    .sort();
+
+  return JSON.stringify({
+    platform: context.platform,
+    host: context.host || '',
+    useMultidevice: !!context.useMultidevice,
+    startOfDay: context.startOfDay || '',
+    include_audible: !!context.include_audible,
+    always_active_pattern: context.always_active_pattern || '',
+    sources: normalized_sources,
+  });
+}
+
+// Parses the "<start>/<end>" period strings the store works in.
+function periodBounds(period_str: string): { start: number; end: number } {
+  const [start, end] = period_str.split('/');
+  return { start: new Date(start).getTime(), end: new Date(end).getTime() };
+}
+
+/**
+ * Selects the periods that must actually be queried.
+ *
+ * A period is skipped when it is already cached, and cached includes a
+ * completed empty result: nothing happened then, and that answer does not
+ * change. Two kinds of period are never served from the cache:
+ *
+ *  - the period containing `now`, which is still open and whose duration keeps
+ *    growing, so it is always refetched;
+ *  - periods starting at or after `now`, which cannot have data yet. This is
+ *    the existing desktop policy, now applied to Android/iOS as well so both
+ *    platforms behave the same.
+ */
+export function selectPeriodsToQuery(
+  period_strs: string[],
+  cached: Record<string, unknown>,
+  now: Date = new Date()
+): string[] {
+  const now_ms = now.getTime();
+
+  return period_strs.filter(period_str => {
+    const { start, end } = periodBounds(period_str);
+
+    // Unparseable period: query it rather than silently dropping it.
+    if (Number.isNaN(start) || Number.isNaN(end)) return true;
+
+    // Nothing to measure yet.
+    if (start >= now_ms) return false;
+
+    // The open period is always refreshed so its duration can grow.
+    if (now_ms < end) return true;
+
+    return !Object.prototype.hasOwnProperty.call(cached, period_str);
+  });
+}

--- a/src/util/alerts.ts
+++ b/src/util/alerts.ts
@@ -1,0 +1,46 @@
+// Alert goals ("spend at least N minutes in category X today"), as persisted
+// in settings. Only the definition is stored — never query results or other
+// transient view state.
+
+export interface AlertGoal {
+  name: string;
+  // Category path, e.g. ['Work', 'Programming']. An empty path is not a valid
+  // goal, since the view needs a concrete category to sum time for.
+  category: string[];
+  // Target duration in minutes.
+  goal: number;
+}
+
+// Sample goals shown on first use, before the user has stored any of their own.
+// A stored empty list is a deliberate choice and must not bring these back.
+export function getDefaultAlertGoals(): AlertGoal[] {
+  return [
+    { name: 'Work', category: ['Work'], goal: 100 },
+    { name: 'Media', category: ['Media'], goal: 10 },
+  ];
+}
+
+// Coerce one candidate into a valid goal, or return null if it cannot be used.
+// Accepts the string values that number inputs produce.
+export function cleanAlertGoal(candidate: unknown): AlertGoal | null {
+  if (typeof candidate !== 'object' || candidate === null) return null;
+  const { name, category, goal } = candidate as Record<string, unknown>;
+
+  if (typeof name !== 'string' || name.trim() === '') return null;
+  if (!Array.isArray(category) || category.length === 0) return null;
+  if (!category.every(segment => typeof segment === 'string')) return null;
+
+  const goalNumber = typeof goal === 'string' ? Number(goal.trim()) : goal;
+  if (typeof goalNumber !== 'number' || !Number.isFinite(goalNumber) || goalNumber < 0) {
+    return null;
+  }
+
+  return { name: name.trim(), category: [...(category as string[])], goal: goalNumber };
+}
+
+// Drop malformed entries from stored (and therefore untrusted) data, so a bad
+// value in settings cannot break the view.
+export function cleanAlertGoals(candidates: unknown): AlertGoal[] {
+  if (!Array.isArray(candidates)) return [];
+  return candidates.map(cleanAlertGoal).filter((goal): goal is AlertGoal => goal !== null);
+}

--- a/src/util/calendar.ts
+++ b/src/util/calendar.ts
@@ -1,0 +1,32 @@
+import moment from 'moment';
+
+interface CalendarEvent {
+  start: string;
+  end: string;
+}
+
+export function calendarTimeBounds(events: CalendarEvent[], fitToActive: boolean) {
+  const fullDay = { slotMinTime: '00:00:00', slotMaxTime: '24:00:00' };
+  if (!fitToActive || !events.length) return fullDay;
+
+  let firstHour = 24;
+  let lastHour = 0;
+  for (const event of events) {
+    const start = moment(event.start, moment.ISO_8601, true);
+    const end = moment(event.end, moment.ISO_8601, true);
+    if (!start.isValid() || !end.isValid() || !end.isAfter(start)) return fullDay;
+
+    // Midnight is a valid exclusive upper bound. Events continuing into
+    // another day need the full grid so neither daily segment is clipped.
+    const nextMidnight = start.clone().startOf('day').add(1, 'day');
+    if (end.isAfter(nextMidnight)) return fullDay;
+    const endHour = end.isSame(nextMidnight)
+      ? 24
+      : end.hour() + (end.minute() || end.second() || end.millisecond() ? 1 : 0);
+    firstHour = Math.min(firstHour, start.hour());
+    lastHour = Math.max(lastHour, endHour, start.hour() + 1);
+  }
+
+  const formatHour = (hour: number) => `${String(hour).padStart(2, '0')}:00:00`;
+  return { slotMinTime: formatHour(firstHour), slotMaxTime: formatHour(lastHour) };
+}

--- a/src/util/datasets.ts
+++ b/src/util/datasets.ts
@@ -4,7 +4,6 @@ import { split_by_hour_into_data } from '~/util/transforms';
 import { getColorFromCategory } from '~/util/color';
 import { Category } from '~/util/classes';
 import { IEvent } from './interfaces';
-import { useCategoryStore } from '~/stores/categories';
 
 interface HourlyData {
   cat_events: IEvent[];
@@ -13,44 +12,35 @@ interface HourlyData {
 interface Dataset {
   label: string;
   backgroundColor: string;
-  data: number[];
+  data: (number | null)[];
 }
 
 export function buildBarchartDataset(data_by_hour: HourlyData[], classes: Category[]): Dataset[] {
-  const SEP = '>>>';
   const data = data_by_hour;
   if (data) {
     const category_names: Set<string> = new Set(
       Object.values(data)
         .map(result => {
-          return result.cat_events.map(e => e.data['$category'].join(SEP));
+          return result.cat_events.map(e => JSON.stringify(e.data['$category'] || []));
         })
         .flat()
     );
-    const ds: Dataset[] = [...category_names]
-      .map(c_ => {
-        const categoryStore = useCategoryStore();
-        const c = categoryStore.get_category(c_.split(SEP));
+    const ds: Dataset[] = [...category_names].map(c_ => {
+      const path: string[] = JSON.parse(c_);
+      const c = classes.find(category => _.isEqual(category.name, path));
 
-        if (c) {
-          const values = Object.values(data).map(results => {
-            const cat = results.cat_events.find(e => _.isEqual(e.data['$category'], c.name));
-            if (cat) return Math.round((cat.duration / (60 * 60)) * 1000) / 1000;
-            else return null;
-          });
-          return {
-            label: c.name.join(' > '),
-            backgroundColor: getColorFromCategory(c, classes),
-            data: values,
-          } as Dataset;
-        } else {
-          // FIXME: This shouldn't happen
-          // This may for example happen if one doesn't have an 'Uncategorized' category,
-          // as can happen when one upgrades from an old version where there wasn't one in the default classes.
-          console.error('missing category:', c_);
-        }
-      })
-      .filter(x => x);
+      const values = Object.values(data).map(results => {
+        const events = results.cat_events.filter(e => _.isEqual(e.data['$category'] || [], path));
+        if (events.length)
+          return Math.round((_.sumBy(events, 'duration') / (60 * 60)) * 1000) / 1000;
+        else return null;
+      });
+      return {
+        label: path.length ? path.join(' > ') : 'Uncategorized',
+        backgroundColor: getColorFromCategory(c, classes),
+        data: values,
+      } as Dataset;
+    });
     return ds;
   } else {
     return [];

--- a/src/util/swimlane.js
+++ b/src/util/swimlane.js
@@ -1,23 +1,31 @@
-import DOMPurify from 'dompurify';
+import _ from 'lodash';
 
-const sanitize = DOMPurify.sanitize;
+const escapeText = value => _.escape(value == null ? 'unknown' : String(value));
 
 export function getSwimlane(bucket, color, groupBy, e) {
-  // WARNING: XSS risk, make sure to sanitize properly
-  // FIXME: Not actually tested against XSS attacks, implementation needs to be verified in tests.
   let subgroup = 'unknown';
 
+  // A bucket with no type, or an event with no data, must not throw and take
+  // the whole visualization down with it.
+  const data = (e && e.data) || {};
+  const type = String((bucket && bucket.type) || '');
+
   if (groupBy == 'category') {
-    subgroup = sanitize(color);
+    subgroup = escapeText(color);
   } else if (groupBy == 'bucketType') {
-    if (bucket.type == 'currentwindow') {
-      subgroup = sanitize(e.data.app);
-    } else if (bucket.type == 'web.tab.current') {
-      subgroup = sanitize(new URL(e.data.url).hostname.replace('www.', ''));
-    } else if (bucket.type.startsWith('app.editor')) {
-      subgroup = sanitize(e.data.language);
-    } else if (bucket.type.startsWith('general.stopwatch')) {
-      subgroup = sanitize(e.data.label);
+    if (type == 'currentwindow') {
+      subgroup = escapeText(data.app);
+    } else if (type == 'web.tab.current') {
+      try {
+        const hostname = new URL(data.url).hostname;
+        subgroup = hostname ? escapeText(hostname.replace(/^www\./, '')) : 'unknown';
+      } catch {
+        subgroup = 'unknown';
+      }
+    } else if (type.startsWith('app.editor')) {
+      subgroup = escapeText(data.language);
+    } else if (type.startsWith('general.stopwatch')) {
+      subgroup = escapeText(data.label);
     }
   }
 

--- a/src/util/tooltip.js
+++ b/src/util/tooltip.js
@@ -3,12 +3,27 @@ import { seconds_to_duration } from './time';
 import DOMPurify from 'dompurify';
 import _ from 'lodash';
 
-const sanitize = DOMPurify.sanitize;
+const escapeText = value => _.escape(value == null ? '' : String(value));
+
+function urlLink(value) {
+  const text = escapeText(value);
+  try {
+    const url = new URL(value);
+    if (['http:', 'https:'].includes(url.protocol)) {
+      return `<a href="${escapeText(url.href)}">${text}</a>`;
+    }
+  } catch {
+    // Missing or malformed URLs remain readable as plain text.
+  }
+  return text;
+}
 
 export function buildTooltip(bucket, e) {
-  // WARNING: XSS risk, make sure to sanitize properly
-  // FIXME: Not actually tested against XSS attacks, implementation needs to be verified in tests.
   let inner = 'Unknown bucket type';
+  // A bucket with no type, or an event with no data, must still render a
+  // tooltip rather than throwing and taking the whole timeline down.
+  const data = (e && e.data) || {};
+  const type = String((bucket && bucket.type) || '');
 
   // if same day, don't show date
   let start = moment(e.timestamp);
@@ -21,36 +36,37 @@ export function buildTooltip(bucket, e) {
     stop = stop.format('YYYY-MM-DD HH:mm:ss');
   }
 
-  if (bucket.type == 'currentwindow') {
+  if (type == 'currentwindow') {
     inner = `
-      <tr><th>App</th><td>${sanitize(e.data.app)}</td></tr>
-      <tr><th>Title</th><td>${sanitize(e.data.title)}</td></tr>
+      <tr><th>App</th><td>${escapeText(data.app)}</td></tr>
+      <tr><th>Title</th><td>${escapeText(data.title)}</td></tr>
       `;
-  } else if (bucket.type == 'web.tab.current') {
+  } else if (type == 'web.tab.current') {
     inner = `
-      <tr><th>Title</th><td>${sanitize(e.data.title)}</td></tr>
-      <tr><th>URL</th><td><a href=${sanitize(e.data.url)}>${sanitize(e.data.url)}</a></td></tr>
+      <tr><th>Title</th><td>${escapeText(data.title)}</td></tr>
+      <tr><th>URL</th><td>${urlLink(data.url)}</td></tr>
       `;
-  } else if (bucket.type.startsWith('app.editor')) {
+  } else if (type.startsWith('app.editor')) {
     inner = `
-      <tr><th>Filename</th><td>${sanitize(_.last(e.data.file.split('/')))}</td></tr>
-      <tr><th>Path</th><td>${sanitize(e.data.file)}</td></tr>
-      <tr><th>Language</th><td>${sanitize(e.data.language)}</td></tr>
+      <tr><th>Filename</th><td>${escapeText(_.last(String(data.file || '').split('/')))}</td></tr>
+      <tr><th>Path</th><td>${escapeText(data.file)}</td></tr>
+      <tr><th>Language</th><td>${escapeText(data.language)}</td></tr>
       `;
-  } else if (bucket.type.startsWith('general.stopwatch')) {
+  } else if (type.startsWith('general.stopwatch')) {
     inner = `
-      <tr><th>Label</th><td>${sanitize(e.data.label)}</td></tr>
+      <tr><th>Label</th><td>${escapeText(data.label)}</td></tr>
       `;
   } else {
     inner = `
-      <tr><th>Data</th><td>${sanitize(JSON.stringify(e.data))}</td></tr>
+      <tr><th>Data</th><td>${escapeText(JSON.stringify(data))}</td></tr>
       `;
   }
-  return `<table>
+  // Escape text in its insertion context, then sanitize the complete markup.
+  return DOMPurify.sanitize(`<table>
     <tr></tr>
     <tr><th>Start</th><td>${start}</td></tr>
     <tr><th>Stop</th><td>${stop}</td></tr>
     <tr><th>Duration&nbsp;</th><td>${seconds_to_duration(e.duration)}</td></tr>
     ${inner}
-    </table>`;
+    </table>`);
 }

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -17,7 +17,7 @@ div
     | Install #[a(href="https://docs.activitywatch.net/en/latest/watchers.html") aw-watcher-window and aw-watcher-afk] to enable this view.
 
   b-card(v-for="alert in alerts", :key="alert.name")
-    b-button.float-right(@click="deleteAlert(alert.name)" size="sm" variant="outline-danger")
+    b-button.float-right(@click="deleteAlert(alert.name)" size="sm" variant="outline-danger" :disabled="saving")
       icon(name="trash")
 
     div Goal name: {{ alert.name }}
@@ -49,7 +49,7 @@ div
         b-input(v-model="editing_alert.goal" type="number")
 
     div
-      b-btn(@click="addAlert" variant="success")
+      b-btn(@click="addAlert" variant="success" :disabled="saving")
         icon(name="plus")
         | Add alert
 </template>
@@ -70,6 +70,7 @@ import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
 import { useSettingsStore } from '~/stores/settings';
 import { get_day_start_with_offset, get_offset_duration } from '~/util/time';
+import { cleanAlertGoal, cleanAlertGoals, getDefaultAlertGoals } from '~/util/alerts';
 
 export default {
   name: 'Alerts',
@@ -80,11 +81,13 @@ export default {
       settingsStore: useSettingsStore(),
 
       // TODO: Support negative goals (avoid distractions)
-      alerts: [
-        { name: 'Work', category: ['Work'], goal: 100 },
-        { name: 'Media', category: ['Media'], goal: 10 },
-      ],
+      // Loaded from settings in mounted(); sample goals are seeded there only
+      // when nothing has been stored yet.
+      alerts: [],
       editing_alert: {},
+
+      // Set while an add/delete is being persisted, to block duplicate writes.
+      saving: false,
 
       alert_times: {},
 
@@ -122,6 +125,11 @@ export default {
   },
   mounted: async function () {
     await this.settingsStore.ensureLoaded();
+    // A stored empty list is a deliberate "no goals" and must be preserved;
+    // only a first run (nothing ever stored) gets the sample goals.
+    this.alerts = this.settingsStore.hasStoredAlerts
+      ? cleanAlertGoals(this.settingsStore.alerts)
+      : getDefaultAlertGoals();
     await this.bucketsStore.ensureLoaded();
     await this.categoryStore.load();
     // Filter to hosts that actually have the buckets we query against.
@@ -134,12 +142,40 @@ export default {
     this.hostname = this.hostnames[0];
   },
   methods: {
-    addAlert: function () {
-      // TODO: Persist to settings/localstorage
-      this.alerts = this.alerts.concat({ ...this.editing_alert });
+    addAlert: async function () {
+      const goal = cleanAlertGoal(this.editing_alert);
+      if (goal === null) {
+        this.error = 'A goal needs a name, a category, and a positive number of minutes.';
+        return;
+      }
+      if (await this.persistAlerts(this.alerts.concat(goal))) {
+        this.editing_alert = {};
+      }
     },
-    deleteAlert: function (name) {
-      this.alerts = this.alerts.filter(a => a.name !== name);
+    deleteAlert: async function (name) {
+      await this.persistAlerts(this.alerts.filter(a => a.name !== name));
+    },
+
+    // Save the given goals, keeping the shown list and storage in step. Returns
+    // whether the write succeeded; on failure the previous list is restored so
+    // the view never implies a failed write was durable.
+    persistAlerts: async function (alerts) {
+      if (this.saving) return false;
+      const previous = this.alerts;
+      this.saving = true;
+      this.alerts = alerts;
+      try {
+        await this.settingsStore.update({ alerts });
+        this.error = '';
+        return true;
+      } catch (e) {
+        console.error(e);
+        this.alerts = previous;
+        this.error = 'Failed to save alert goals. Please try again.';
+        return false;
+      } finally {
+        this.saving = false;
+      }
     },
 
     toggleAutoRefresh: function () {

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -5,7 +5,6 @@ div
   // TODO: Call this "goals" instead? (alerts is more general, but goals might fit the most common use better
   // TODO: Support 'less than' goals
   // TODO: Send notifications when goals met
-  // TODO: Query from day start, not 24h ago
 
   b-alert(variant="warning" show)
     | This feature is still in early development.
@@ -69,6 +68,8 @@ import 'vue-awesome/icons/trash';
 
 import { useBucketsStore } from '~/stores/buckets';
 import { useCategoryStore } from '~/stores/categories';
+import { useSettingsStore } from '~/stores/settings';
+import { get_day_start_with_offset, get_offset_duration } from '~/util/time';
 
 export default {
   name: 'Alerts',
@@ -76,6 +77,7 @@ export default {
     return {
       bucketsStore: useBucketsStore(),
       categoryStore: useCategoryStore(),
+      settingsStore: useSettingsStore(),
 
       // TODO: Support negative goals (avoid distractions)
       alerts: [
@@ -119,6 +121,7 @@ export default {
     },
   },
   mounted: async function () {
+    await this.settingsStore.ensureLoaded();
     await this.bucketsStore.ensureLoaded();
     await this.categoryStore.load();
     // Filter to hosts that actually have the buckets we query against.
@@ -165,10 +168,15 @@ export default {
 
       const query_array = querystr_to_array(query);
 
-      // Get start of today
-      const start = moment().subtract(1, 'days').startOf('day');
-      const end = moment(start).add(1, 'days');
-      const timeperiods = [start.format() + '/' + end.format()];
+      // Query from the start of the current activity day through now. The
+      // activity day respects the user's startOfDay setting (default 04:00),
+      // so before that boundary we are still on the previous calendar day.
+      // `now` is captured once so the interval stays consistent even if the
+      // query straddles the boundary.
+      const now = moment();
+      const activity_day = moment(now).subtract(get_offset_duration()).startOf('day');
+      const start = moment(get_day_start_with_offset(activity_day));
+      const timeperiods = [start.format() + '/' + now.format()];
 
       try {
         this.status = 'searching';

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -51,7 +51,7 @@ div
         title="More ranges"
         aria-label="More date ranges"
       )
-        template(v-slot:button-content)
+        template(v-slot:button-content="")
           icon(name="ellipsis-v")
         b-dropdown-item-button(
           v-for="opt in extendedPeriods"
@@ -117,7 +117,7 @@ div
         b-form-select(v-model="filter_category", :options="categoryStore.category_select(true)" size="sm")
 
 
-  aw-periodusage(:periodusage_arr="periodusage", @update="setDate")
+  aw-periodusage(:periodusage_arr="periodusage", @update="setUsagePeriod")
 
   aw-uncategorized-notification(:periodLength="periodLength")
 
@@ -212,7 +212,7 @@ div
 import { mapState } from 'pinia';
 import moment from 'moment';
 import { get_day_start_with_offset, get_today_with_offset } from '~/util/time';
-import { periodLengthConvertMoment } from '~/util/timeperiod';
+import { TimePeriod, periodLengthConvertMoment } from '~/util/timeperiod';
 import _ from 'lodash';
 
 import 'vue-awesome/icons/arrow-left';
@@ -476,6 +476,13 @@ export default {
         .format('YYYY-MM-DD');
     },
 
+    setUsagePeriod: function (period: TimePeriod) {
+      const anchor = moment(period.start);
+      if (this.periodLength === 'last7d' || this.periodLength === 'last30d') {
+        anchor.add(period.length[0] - 1, 'days');
+      }
+      this.setDate(anchor.format('YYYY-MM-DD'));
+    },
     setDate: function (date, periodLength) {
       // periodLength is an optional argument, default to this.periodLength
       if (!periodLength) {
@@ -514,6 +521,8 @@ export default {
       } else if (periodLength == '30 days') {
         periodLength = 'last30d';
         new_date = anchorDate.clone().add(1, 'days').format('YYYY-MM-DD');
+      } else if (periodLength === 'last7d' || periodLength === 'last30d') {
+        new_date = anchorDate.format('YYYY-MM-DD');
       } else {
         const new_period_length_moment = periodLengthConvertMoment(periodLength);
         new_date = anchorDate.clone().startOf(new_period_length_moment).format('YYYY-MM-DD');

--- a/src/visualizations/Calendar.vue
+++ b/src/visualizations/Calendar.vue
@@ -20,6 +20,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import FullCalendar from '@fullcalendar/vue';
 import timeGridPlugin from '@fullcalendar/timegrid';
+import { calendarTimeBounds } from '~/util/calendar';
 
 // TODO: Use canonical timeline query, with flooding and categorization
 // TODO: Checkbox for toggling category-view, where adjacent events with same category are merged and the events are labeled by category
@@ -37,26 +38,13 @@ export default {
   computed: {
     calendarOptions: function () {
       const events = this.events;
-      const first = _.minBy(events, e => e.start);
-      const last = _.maxBy(events, e => e.end);
-      // FIXME: end must be at least one slot (1 hour) after start, otherwise it fails hard
-      let start, end;
-      if (this.fitToActive && events.length > 0) {
-        console.log(first.start);
-        start = moment(first.start).startOf('hour').format().slice(11, 16);
-        end = moment(last.end).endOf('hour').format().slice(11, 16);
-      } else {
-        start = '00:00:00';
-        end = '24:00:00';
-      }
       return {
         plugins: [timeGridPlugin],
         initialView: this.view,
         eventClick: this.onEventClick,
         events: events,
         allDaySlot: false,
-        slotMinTime: start,
-        slotMaxTime: end,
+        ...calendarTimeBounds(events, this.fitToActive),
         nowIndicator: true,
         expandRows: true,
         slotLabelFormat: {
@@ -73,7 +61,7 @@ export default {
 
       const bucket = _.find(this.buckets, b => b.id == this.selectedBucket);
       if (bucket == null) {
-        return;
+        return [];
       }
       let events = bucket.events;
       events = _.filter(events, e => e.duration > 10);

--- a/src/visualizations/PeriodUsage.vue
+++ b/src/visualizations/PeriodUsage.vue
@@ -14,7 +14,7 @@ svg {
 </style>
 
 <script lang="ts">
-// NOTE: This is just a Vue.js component wrapper for periodusage.js
+// NOTE: This is just a Vue.js component wrapper for periodusage.ts
 //       Code should generally go in the framework-independent file.
 
 import periodusage from './periodusage';
@@ -24,6 +24,7 @@ export default {
   props: {
     periodusage_arr: {
       type: Array,
+      default: () => [],
     },
   },
   watch: {
@@ -33,7 +34,7 @@ export default {
   },
   mounted: function () {
     periodusage.create(this.$el);
-    periodusage.set_status(this.$el, 'Loading...');
+    periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
   },
   methods: {
     onPeriodClicked: function (period) {

--- a/src/visualizations/TimelineBarChart.vue
+++ b/src/visualizations/TimelineBarChart.vue
@@ -75,8 +75,7 @@ export default {
           return format_weekday_short(date);
         });
       } else if (resolution.startsWith('month')) {
-        // FIXME: Needs access to the timeperiod start to know which month
-        // How many days are in the given month?
+        // How many days are in the month containing `start`?
         const date = new Date(start);
         const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
         return _.range(1, daysInMonth + 1).map(d =>

--- a/src/visualizations/periodusage.ts
+++ b/src/visualizations/periodusage.ts
@@ -2,7 +2,9 @@ import * as d3 from 'd3';
 import _ from 'lodash';
 import moment from 'moment';
 
-import { seconds_to_duration, get_hour_offset } from '../util/time.ts';
+import { seconds_to_duration } from '../util/time.ts';
+import { TimePeriod, timeperiodToStr } from '../util/timeperiod';
+import { IEvent } from '../util/interfaces';
 
 function create(svg_elem: SVGElement) {
   // Clear element
@@ -29,11 +31,15 @@ const diagramcolor = '#aaa';
 const diagramcolor_selected = '#fc5';
 const diagramcolor_focused = '#adf';
 
-function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
+function update(
+  svg_elem: SVGElement,
+  usage_arr: { period: TimePeriod; events: IEvent[] }[],
+  onPeriodClicked: (period: TimePeriod) => void
+) {
   const dateformat = 'YYYY-MM-DD';
 
-  // No apps, sets status to "No data"
-  if (usage_arr.length <= 0) {
+  // No periods at all, sets status to "No data"
+  if (!usage_arr || usage_arr.length <= 0) {
     set_status(svg_elem, 'No data');
     return;
   }
@@ -41,36 +47,41 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   const svg = d3.select(svg_elem);
 
   function get_usage_time(day_events) {
-    const day_event = _.head(_.filter(day_events, e => e.data.status == 'not-afk'));
-    return day_event != undefined ? day_event.duration : 0;
+    return _.sumBy(
+      day_events.filter(e => e.data.status === 'not-afk'),
+      'duration'
+    );
   }
 
-  const usage_times = usage_arr.map(day_events => get_usage_time(day_events));
+  const usage_times = usage_arr.map(({ events }) => get_usage_time(events));
   let longest_usage = Math.max.apply(null, usage_times);
   // Avoid division by zero
   if (longest_usage <= 0) {
     longest_usage = 0.00000000001;
   }
 
-  const padding = 0.3 * (100 / (usage_arr.length - 1));
+  const padding = 0.3 * (100 / usage_arr.length);
   const width = 100 / usage_arr.length - padding;
   const center_elem = Math.floor(usage_arr.length / 2);
 
-  _.each(usage_arr, (events, i: number) => {
+  const now = moment();
+  _.each(usage_arr, ({ period, events }, i: number) => {
     const usage_time = get_usage_time(events);
     const height = 85 * (usage_time / longest_usage);
-    let date = '';
-    if (events.length > 0) {
-      // slice off so it's only the day
-      date = moment(events[0].timestamp).subtract(get_hour_offset(), 'hours').format(dateformat);
-    }
+    const [start, end] = timeperiodToStr(period)
+      .split('/')
+      .map(value => moment(value));
+    const date = start.format(dateformat);
+    const label =
+      period.length[0] === 1 && period.length[1].startsWith('day')
+        ? date
+        : `${date} – ${end.clone().subtract(1, 'day').format(dateformat)}`;
     const color = i === center_elem ? diagramcolor_selected : diagramcolor;
     const offset = 50;
 
     const x = i * padding + i * width + 0.25 * width;
 
-    // FIXME: Doesn't work well, notably breaks on last7d and last30d
-    if (moment(date).isSame(moment(), 'day')) {
+    if (now.isSameOrAfter(start) && now.isBefore(end)) {
       svg
         .append('line')
         .attr('x1', x + width / 2 + '%')
@@ -82,7 +93,8 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
 
       svg
         .append('text')
-        .attr('x', x + 1.5 * width + '%')
+        .attr('x', x + width / 2 + '%')
+        .attr('text-anchor', 'middle')
         .attr('y', '30')
         .text('Today');
     }
@@ -109,9 +121,9 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
         rect.style('fill', e.target.attributes.color.value);
       })
       .on('click', function () {
-        onPeriodClicked(date);
+        onPeriodClicked(period);
       });
-    rect.append('title').text(date + '\n' + seconds_to_duration(usage_time));
+    rect.append('title').text(label + '\n' + seconds_to_duration(usage_time));
   });
 }
 

--- a/src/visualizations/sunburst-clock.ts
+++ b/src/visualizations/sunburst-clock.ts
@@ -281,9 +281,13 @@ function update(
         drawClock(start_hour, start_min, `${root_start.format('HH:mm')} ☀`);
       }
 
-      // TODO: Draw only if showing today
+      // Only mark "Now" when the current instant falls inside the displayed
+      // day, so historical and future periods get no marker. Start-inclusive,
+      // end-exclusive against the whole-day bounds computed above.
       const now = moment();
-      drawClock(now.hour(), now.minute(), 'Now');
+      if (!now.isBefore(root_start) && now.isBefore(root_end)) {
+        drawClock(now.hour(), now.minute(), 'Now');
+      }
     }
 
     nodes = root_node

--- a/test/unit/Alerts.test.js
+++ b/test/unit/Alerts.test.js
@@ -7,6 +7,7 @@ import Alerts from '~/views/Alerts.vue';
 import { useSettingsStore } from '~/stores/settings';
 import { useCategoryStore } from '~/stores/categories';
 import { useBucketsStore } from '~/stores/buckets';
+import { getDefaultAlertGoals } from '~/util/alerts';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -15,10 +16,21 @@ localVue.filter('friendlytime', v => String(v));
 
 // Mounts the view with a stubbed $aw client. Buckets are pre-seeded so
 // mounted() resolves a hostname without reaching for the global AWClient.
-function mountAlerts({ startOfDay = '04:00' } = {}) {
+function mountAlerts({ startOfDay = '04:00', storedAlerts = undefined } = {}) {
   const query = jest.fn().mockResolvedValue([[]]);
 
-  useSettingsStore().$patch({ startOfDay, _loaded: true });
+  const settingsStore = useSettingsStore();
+  settingsStore.$patch({ startOfDay, _loaded: true });
+  // `_storedKeys` is what tells the view a saved list exists, so seeding
+  // `alerts` alone must not be mistaken for a first run.
+  if (storedAlerts !== undefined) {
+    settingsStore.$patch({ alerts: storedAlerts, _storedKeys: ['alerts'] });
+  }
+  // `update` would otherwise hit the network; record what would be persisted.
+  const update = jest
+    .spyOn(settingsStore, 'update')
+    .mockImplementation(async patch => settingsStore.$patch(patch));
+
   useCategoryStore().load([]);
   useBucketsStore().update_buckets([
     { id: 'aw-watcher-window_testhost', type: 'currentwindow', hostname: 'testhost', data: {} },
@@ -32,7 +44,7 @@ function mountAlerts({ startOfDay = '04:00' } = {}) {
   });
   wrapper.setData({ hostname: 'testhost' });
 
-  return { wrapper, query };
+  return { wrapper, query, update, settingsStore };
 }
 
 // Mounts and runs one check(), returning the mocked client call.
@@ -144,5 +156,174 @@ describe('Alerts query range', () => {
     expect(wrapper.vm.alert_times).toEqual({ Work: 60, 'Work,Code': 30 });
     expect(wrapper.vm.last_updated).not.toBeNull();
     expect(wrapper.vm.error).toBe('');
+  });
+});
+
+describe('Alerts goal persistence', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // mounted() is async; drain its microtasks before asserting. A microtask
+  // loop is used rather than a timer so it works under fake timers too.
+  const settle = async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  };
+
+  test('seeds sample goals when nothing has ever been stored', async () => {
+    const { wrapper } = mountAlerts();
+    await settle();
+    expect(wrapper.vm.alerts).toEqual(getDefaultAlertGoals());
+  });
+
+  test('restores stored goals instead of the samples', async () => {
+    const stored = [{ name: 'Reading', category: ['Media', 'Reading'], goal: 20 }];
+    const { wrapper } = mountAlerts({ storedAlerts: stored });
+    await settle();
+    expect(wrapper.vm.alerts).toEqual(stored);
+  });
+
+  test('preserves a stored empty list rather than re-seeding samples', async () => {
+    const { wrapper } = mountAlerts({ storedAlerts: [] });
+    await settle();
+    expect(wrapper.vm.alerts).toEqual([]);
+  });
+
+  test('drops malformed stored goals without crashing', async () => {
+    const { wrapper } = mountAlerts({
+      storedAlerts: [{ name: 'Good', category: ['Work'], goal: 5 }, { name: '' }, 'garbage'],
+    });
+    await settle();
+    expect(wrapper.vm.alerts).toEqual([{ name: 'Good', category: ['Work'], goal: 5 }]);
+  });
+
+  test('persists an added goal, normalizing the numeric input', async () => {
+    const { wrapper, update } = mountAlerts({ storedAlerts: [] });
+    await settle();
+
+    wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: '90' };
+    await wrapper.vm.addAlert();
+
+    expect(update).toHaveBeenCalledWith({
+      alerts: [{ name: 'Code', category: ['Work', 'Code'], goal: 90 }],
+    });
+    expect(wrapper.vm.alerts).toEqual([{ name: 'Code', category: ['Work', 'Code'], goal: 90 }]);
+    // The form is cleared only on success.
+    expect(wrapper.vm.editing_alert).toEqual({});
+    expect(wrapper.vm.error).toBe('');
+  });
+
+  test('an added goal survives a remount', async () => {
+    const { wrapper, settingsStore } = mountAlerts({ storedAlerts: [] });
+    await settle();
+    wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: 90 };
+    await wrapper.vm.addAlert();
+
+    // Remount against the settings the previous instance wrote.
+    const remounted = mountAlerts({ storedAlerts: settingsStore.alerts });
+    await settle();
+    expect(remounted.wrapper.vm.alerts).toEqual([
+      { name: 'Code', category: ['Work', 'Code'], goal: 90 },
+    ]);
+  });
+
+  test('persists a deletion, and it stays deleted after a remount', async () => {
+    const stored = [
+      { name: 'Work', category: ['Work'], goal: 100 },
+      { name: 'Media', category: ['Media'], goal: 10 },
+    ];
+    const { wrapper, update, settingsStore } = mountAlerts({ storedAlerts: stored });
+    await settle();
+
+    await wrapper.vm.deleteAlert('Work');
+
+    expect(update).toHaveBeenCalledWith({
+      alerts: [{ name: 'Media', category: ['Media'], goal: 10 }],
+    });
+    const remounted = mountAlerts({ storedAlerts: settingsStore.alerts });
+    await settle();
+    expect(remounted.wrapper.vm.alerts).toEqual([{ name: 'Media', category: ['Media'], goal: 10 }]);
+  });
+
+  test('deleting every goal persists an empty list that stays empty', async () => {
+    const { wrapper, settingsStore } = mountAlerts({
+      storedAlerts: [{ name: 'Work', category: ['Work'], goal: 100 }],
+    });
+    await settle();
+
+    await wrapper.vm.deleteAlert('Work');
+    expect(settingsStore.alerts).toEqual([]);
+
+    const remounted = mountAlerts({ storedAlerts: settingsStore.alerts });
+    await settle();
+    expect(remounted.wrapper.vm.alerts).toEqual([]);
+  });
+
+  test('rejects an invalid goal without persisting anything', async () => {
+    const { wrapper, update } = mountAlerts({ storedAlerts: [] });
+    await settle();
+
+    // The "All" category option has a null value, which is not a usable goal.
+    wrapper.vm.editing_alert = { name: 'Everything', category: null, goal: 10 };
+    await wrapper.vm.addAlert();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(wrapper.vm.alerts).toEqual([]);
+    expect(wrapper.vm.error).not.toBe('');
+    // Input is retained so the user can correct it.
+    expect(wrapper.vm.editing_alert.name).toBe('Everything');
+  });
+
+  test('restores the previous list and surfaces an error when the save fails', async () => {
+    const stored = [{ name: 'Work', category: ['Work'], goal: 100 }];
+    const { wrapper, update } = mountAlerts({ storedAlerts: stored });
+    await settle();
+
+    update.mockRejectedValueOnce(new Error('offline'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: 90 };
+    await wrapper.vm.addAlert();
+
+    expect(wrapper.vm.alerts).toEqual(stored);
+    expect(wrapper.vm.error).toMatch(/failed to save/i);
+    // The unsaved input is kept so the user can retry.
+    expect(wrapper.vm.editing_alert.name).toBe('Code');
+
+    // Retry succeeds.
+    await wrapper.vm.addAlert();
+    expect(wrapper.vm.alerts).toHaveLength(2);
+    expect(wrapper.vm.error).toBe('');
+  });
+
+  test('a second click while a save is pending does not write twice', async () => {
+    const { wrapper, update } = mountAlerts({ storedAlerts: [] });
+    await settle();
+
+    let release;
+    update.mockImplementationOnce(() => new Promise(resolve => (release = resolve)));
+
+    wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: 90 };
+    const first = wrapper.vm.addAlert();
+    const second = wrapper.vm.addAlert();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    release();
+    await Promise.all([first, second]);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not persist transient view state alongside the goals', async () => {
+    const { wrapper, update } = mountAlerts({ storedAlerts: [] });
+    await settle();
+
+    wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: 90 };
+    await wrapper.vm.addAlert();
+
+    const patch = update.mock.calls[0][0];
+    expect(Object.keys(patch)).toEqual(['alerts']);
+    for (const goal of patch.alerts) {
+      expect(Object.keys(goal).sort()).toEqual(['category', 'goal', 'name']);
+    }
   });
 });

--- a/test/unit/Alerts.test.js
+++ b/test/unit/Alerts.test.js
@@ -1,0 +1,148 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import BootstrapVue from 'bootstrap-vue';
+import moment from 'moment';
+
+import Alerts from '~/views/Alerts.vue';
+import { useSettingsStore } from '~/stores/settings';
+import { useCategoryStore } from '~/stores/categories';
+import { useBucketsStore } from '~/stores/buckets';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+localVue.filter('friendlyduration', v => String(v));
+localVue.filter('friendlytime', v => String(v));
+
+// Mounts the view with a stubbed $aw client. Buckets are pre-seeded so
+// mounted() resolves a hostname without reaching for the global AWClient.
+function mountAlerts({ startOfDay = '04:00' } = {}) {
+  const query = jest.fn().mockResolvedValue([[]]);
+
+  useSettingsStore().$patch({ startOfDay, _loaded: true });
+  useCategoryStore().load([]);
+  useBucketsStore().update_buckets([
+    { id: 'aw-watcher-window_testhost', type: 'currentwindow', hostname: 'testhost', data: {} },
+    { id: 'aw-watcher-afk_testhost', type: 'afkstatus', hostname: 'testhost', data: {} },
+  ]);
+
+  const wrapper = shallowMount(Alerts, {
+    localVue,
+    mocks: { $aw: { query } },
+    stubs: { icon: true },
+  });
+  wrapper.setData({ hostname: 'testhost' });
+
+  return { wrapper, query };
+}
+
+// Mounts and runs one check(), returning the mocked client call.
+async function runCheck(opts) {
+  const { wrapper, query } = mountAlerts(opts);
+  await wrapper.vm.check();
+  return { wrapper, query };
+}
+
+// The single timeperiod string check() submitted, split into start/end.
+function submittedPeriod(query) {
+  expect(query).toHaveBeenCalledTimes(1);
+  const timeperiods = query.mock.calls[0][0];
+  expect(timeperiods).toHaveLength(1);
+  const [start, end] = timeperiods[0].split('/');
+  return { start: moment(start), end: moment(end) };
+}
+
+describe('Alerts query range', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function freeze(local) {
+    jest.useFakeTimers().setSystemTime(moment(local).toDate());
+  }
+
+  test('with a 00:00 boundary, queries from midnight through now', async () => {
+    freeze('2026-09-10T15:30:00');
+    const { query } = await runCheck({ startOfDay: '00:00' });
+
+    const { start, end } = submittedPeriod(query);
+    expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 00:00:00');
+    expect(end.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 15:30:00');
+  });
+
+  test('with a 04:00 boundary before the boundary, queries from the previous day', async () => {
+    freeze('2026-09-10T02:00:00');
+    const { query } = await runCheck({ startOfDay: '04:00' });
+
+    const { start, end } = submittedPeriod(query);
+    expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-09 04:00:00');
+    expect(end.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 02:00:00');
+  });
+
+  test('with a 04:00 boundary after the boundary, queries from the same day', async () => {
+    freeze('2026-09-10T15:30:00');
+    const { query } = await runCheck({ startOfDay: '04:00' });
+
+    const { start, end } = submittedPeriod(query);
+    expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 04:00:00');
+    expect(end.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 15:30:00');
+  });
+
+  test('exactly at the boundary, the interval starts at now and is not negative', async () => {
+    freeze('2026-09-10T04:00:00');
+    const { query } = await runCheck({ startOfDay: '04:00' });
+
+    const { start, end } = submittedPeriod(query);
+    expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-10 04:00:00');
+    expect(end.diff(start)).toBe(0);
+  });
+
+  test('respects a fractional-hour boundary without going negative', async () => {
+    freeze('2026-09-10T04:15:00');
+    const { query } = await runCheck({ startOfDay: '04:30' });
+
+    const { start, end } = submittedPeriod(query);
+    expect(start.format('YYYY-MM-DD HH:mm:ss')).toBe('2026-09-09 04:30:00');
+    expect(end.diff(start)).toBeGreaterThan(0);
+  });
+
+  test('zeroes seconds and milliseconds on the boundary', async () => {
+    freeze('2026-09-10T15:30:45.123');
+    const { query } = await runCheck({ startOfDay: '04:00' });
+
+    const { start } = submittedPeriod(query);
+    expect(start.seconds()).toBe(0);
+    expect(start.milliseconds()).toBe(0);
+  });
+
+  test('retains the local UTC offset in the submitted period', async () => {
+    freeze('2026-09-10T15:30:00');
+    const { query } = await runCheck({ startOfDay: '04:00' });
+
+    const timeperiods = query.mock.calls[0][0];
+    const [startStr, endStr] = timeperiods[0].split('/');
+    // moment().format() emits an ISO-8601 string with the local offset.
+    expect(startStr).toMatch(/[+-]\d{2}:\d{2}$|Z$/);
+    expect(endStr).toMatch(/[+-]\d{2}:\d{2}$|Z$/);
+  });
+
+  test('still processes the query response', async () => {
+    freeze('2026-09-10T15:30:00');
+    const { wrapper } = mountAlerts({ startOfDay: '04:00' });
+
+    wrapper.vm.$aw.query.mockResolvedValue([
+      [
+        { duration: 60, data: { $category: ['Work'] } },
+        { duration: 30, data: { $category: ['Work', 'Code'] } },
+      ],
+    ]);
+    await wrapper.vm.check();
+
+    expect(wrapper.vm.alert_times).toEqual({ Work: 60, 'Work,Code': 30 });
+    expect(wrapper.vm.last_updated).not.toBeNull();
+    expect(wrapper.vm.error).toBe('');
+  });
+});

--- a/test/unit/Alerts.test.js
+++ b/test/unit/Alerts.test.js
@@ -280,7 +280,7 @@ describe('Alerts goal persistence', () => {
     await settle();
 
     update.mockRejectedValueOnce(new Error('offline'));
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     wrapper.vm.editing_alert = { name: 'Code', category: ['Work', 'Code'], goal: 90 };
     await wrapper.vm.addAlert();

--- a/test/unit/Calendar.test.js
+++ b/test/unit/Calendar.test.js
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment-options {"customExportConditions": ["node", "node-addons"]}
+ */
+import { mount } from '@vue/test-utils';
+import Calendar from '~/visualizations/Calendar.vue';
+
+const stubs = ['b-form', 'b-form-group', 'b-checkbox'];
+
+test('renders an empty FullCalendar safely when fitting without a selected bucket', async () => {
+  const wrapper = mount(Calendar, { propsData: { buckets: [] }, stubs });
+  try {
+    await wrapper.setData({ fitToActive: true });
+    expect(wrapper.vm.events).toEqual([]);
+    expect(wrapper.findAll('.fc-timegrid-slot[data-time="00:00:00"]').length).toBeGreaterThan(0);
+    expect(wrapper.vm.calendarOptions.slotMaxTime).toBe('24:00:00');
+  } finally {
+    wrapper.destroy();
+  }
+});
+
+test('renders fitted day/week grids and recovers when the selected bucket disappears', async () => {
+  const wrapper = mount(Calendar, {
+    propsData: {
+      buckets: [
+        {
+          id: 'window',
+          type: 'currentwindow',
+          events: [
+            {
+              timestamp: '2026-09-10T10:15:00',
+              duration: 300,
+              data: { app: 'Test', title: 'Short event' },
+            },
+          ],
+        },
+      ],
+    },
+    stubs,
+  });
+  try {
+    await wrapper.setData({ selectedBucket: 'window', fitToActive: true });
+    const api = wrapper.vm.$refs.fullCalendar.getApi();
+    api.gotoDate('2026-09-10');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.fc-event-title').text()).toContain('Test');
+    expect(wrapper.vm.calendarOptions.slotMaxTime).toBe('11:00:00');
+    expect(wrapper.findAll('.fc-timegrid-slot[data-time="10:30:00"]').length).toBeGreaterThan(0);
+    await wrapper.setData({ view: 'timeGridWeek' });
+    expect(api.view.type).toBe('timeGridWeek');
+    expect(wrapper.find('.fc-event-title').exists()).toBe(true);
+    await wrapper.setProps({ buckets: [] });
+    expect(wrapper.vm.events).toEqual([]);
+    expect(wrapper.vm.calendarOptions.slotMaxTime).toBe('24:00:00');
+  } finally {
+    wrapper.destroy();
+  }
+});
+
+test('renders both daily segments of an overnight event in the week grid', async () => {
+  const wrapper = mount(Calendar, {
+    propsData: {
+      buckets: [
+        {
+          id: 'window',
+          type: 'currentwindow',
+          events: [
+            {
+              timestamp: '2026-09-10T23:30:00',
+              duration: 3600,
+              data: { app: 'Test', title: 'Overnight' },
+            },
+          ],
+        },
+      ],
+    },
+    stubs,
+  });
+  try {
+    await wrapper.setData({ selectedBucket: 'window', fitToActive: true, view: 'timeGridWeek' });
+    wrapper.vm.$refs.fullCalendar.getApi().gotoDate('2026-09-10');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.calendarOptions.slotMinTime).toBe('00:00:00');
+    expect(wrapper.vm.calendarOptions.slotMaxTime).toBe('24:00:00');
+    expect(wrapper.findAll('.fc-timegrid-event')).toHaveLength(2);
+  } finally {
+    wrapper.destroy();
+  }
+});

--- a/test/unit/EventEditor.test.js
+++ b/test/unit/EventEditor.test.js
@@ -65,7 +65,7 @@ function mountEditor({ event = makeEvent(), replaceEvent, deleteEvent } = {}) {
 describe('EventEditor save', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
   });
 
   afterEach(() => {
@@ -73,9 +73,9 @@ describe('EventEditor save', () => {
   });
 
   test('does not emit save or close while the request is in flight', async () => {
-    const pending = deferred();
+    const inFlight = deferred();
     const { wrapper } = mountEditor({
-      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+      replaceEvent: jest.fn().mockReturnValue(inFlight.promise),
     });
     await flush();
     const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
@@ -87,7 +87,7 @@ describe('EventEditor save', () => {
     expect(hide).not.toHaveBeenCalled();
     expect(wrapper.vm.busy).toBe(true);
 
-    pending.resolve();
+    inFlight.resolve();
     await flush();
   });
 
@@ -114,7 +114,9 @@ describe('EventEditor save', () => {
     await flush();
 
     const order = [];
-    jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide').mockImplementation(() => order.push('hide'));
+    jest
+      .spyOn(wrapper.vm.$refs.eventEditModal, 'hide')
+      .mockImplementation(() => order.push('hide'));
     wrapper.vm.$on('save', () => order.push('emit'));
 
     await wrapper.vm.save();
@@ -177,8 +179,8 @@ describe('EventEditor save', () => {
   });
 
   test('repeated clicks while pending cause only one request', async () => {
-    const pending = deferred();
-    const replaceEvent = jest.fn().mockReturnValue(pending.promise);
+    const inFlight = deferred();
+    const replaceEvent = jest.fn().mockReturnValue(inFlight.promise);
     const { wrapper } = mountEditor({ replaceEvent });
     await flush();
 
@@ -189,7 +191,7 @@ describe('EventEditor save', () => {
 
     expect(replaceEvent).toHaveBeenCalledTimes(1);
 
-    pending.resolve();
+    inFlight.resolve();
     await Promise.all([first, second, third]);
     await flush();
 
@@ -198,8 +200,8 @@ describe('EventEditor save', () => {
   });
 
   test('a late response is ignored once the editor moved to another event', async () => {
-    const pending = deferred();
-    const replaceEvent = jest.fn().mockReturnValue(pending.promise);
+    const inFlight = deferred();
+    const replaceEvent = jest.fn().mockReturnValue(inFlight.promise);
     const { wrapper } = mountEditor({ replaceEvent });
     await flush();
 
@@ -210,7 +212,7 @@ describe('EventEditor save', () => {
     wrapper.setProps({ event: makeEvent(2) });
     await flush();
 
-    pending.resolve();
+    inFlight.resolve();
     await save;
     await flush();
 
@@ -220,7 +222,7 @@ describe('EventEditor save', () => {
 
 describe('EventEditor delete', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
   });
 
   afterEach(() => {
@@ -228,9 +230,9 @@ describe('EventEditor delete', () => {
   });
 
   test('does not emit delete while the request is in flight', async () => {
-    const pending = deferred();
+    const inFlight = deferred();
     const { wrapper } = mountEditor({
-      deleteEvent: jest.fn().mockReturnValue(pending.promise),
+      deleteEvent: jest.fn().mockReturnValue(inFlight.promise),
     });
     await flush();
     const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
@@ -241,7 +243,7 @@ describe('EventEditor delete', () => {
     expect(wrapper.emitted('delete')).toBeUndefined();
     expect(hide).not.toHaveBeenCalled();
 
-    pending.resolve();
+    inFlight.resolve();
     await flush();
   });
 
@@ -274,8 +276,8 @@ describe('EventEditor delete', () => {
   });
 
   test('repeated delete clicks while pending cause only one request', async () => {
-    const pending = deferred();
-    const deleteEvent = jest.fn().mockReturnValue(pending.promise);
+    const inFlight = deferred();
+    const deleteEvent = jest.fn().mockReturnValue(inFlight.promise);
     const { wrapper } = mountEditor({ deleteEvent });
     await flush();
 
@@ -283,7 +285,7 @@ describe('EventEditor delete', () => {
     const second = wrapper.vm.delete_();
     expect(deleteEvent).toHaveBeenCalledTimes(1);
 
-    pending.resolve();
+    inFlight.resolve();
     await Promise.all([first, second]);
     expect(deleteEvent).toHaveBeenCalledTimes(1);
   });
@@ -305,9 +307,9 @@ describe('EventEditor cancel', () => {
   });
 
   test('does not close while a request is pending', async () => {
-    const pending = deferred();
+    const inFlight = deferred();
     const { wrapper } = mountEditor({
-      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+      replaceEvent: jest.fn().mockReturnValue(inFlight.promise),
     });
     await flush();
     const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
@@ -319,14 +321,14 @@ describe('EventEditor cancel', () => {
     expect(hide).not.toHaveBeenCalled();
     expect(wrapper.emitted('close')).toBeUndefined();
 
-    pending.resolve();
+    inFlight.resolve();
     await flush();
   });
 
   test('dismissal is blocked only while busy', async () => {
-    const pending = deferred();
+    const inFlight = deferred();
     const { wrapper } = mountEditor({
-      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+      replaceEvent: jest.fn().mockReturnValue(inFlight.promise),
     });
     await flush();
 
@@ -341,7 +343,7 @@ describe('EventEditor cancel', () => {
     expect(modal.props('noCloseOnBackdrop')).toBe(true);
     expect(modal.props('hideHeaderClose')).toBe(true);
 
-    pending.resolve();
+    inFlight.resolve();
     await flush();
   });
 });
@@ -349,7 +351,7 @@ describe('EventEditor cancel', () => {
 describe('EventEditor inside a parent that reacts to success', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
   });
 
   afterEach(() => {

--- a/test/unit/EventEditor.test.js
+++ b/test/unit/EventEditor.test.js
@@ -1,0 +1,435 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import EventEditor from '~/components/EventEditor.vue';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+localVue.filter('friendlyduration', v => String(v));
+
+// A promise whose settlement the test controls, so "request in flight" is an
+// observable state rather than a race.
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = async () => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+// BootstrapVue renders modal body content into document.body, and only once
+// the modal is shown — so visible-text assertions have to open it first.
+async function showModal(wrapper) {
+  wrapper.vm.$refs.eventEditModal.show();
+  await flush();
+  await wrapper.vm.$nextTick();
+}
+
+const visibleText = () => document.body.textContent;
+
+function makeEvent(id = 1) {
+  return {
+    id,
+    timestamp: '2026-09-10T12:00:00+00:00',
+    duration: 60,
+    data: { title: 'original' },
+  };
+}
+
+// Mounts the editor with a stubbed client. getEvent resolves immediately with a
+// copy, mirroring the real flow where the editor re-fetches the event.
+function mountEditor({ event = makeEvent(), replaceEvent, deleteEvent } = {}) {
+  const $aw = {
+    getEvent: jest.fn().mockImplementation(async () => JSON.parse(JSON.stringify(event))),
+    replaceEvent: replaceEvent || jest.fn().mockResolvedValue(undefined),
+    deleteEvent: deleteEvent || jest.fn().mockResolvedValue(undefined),
+  };
+
+  const wrapper = mount(EventEditor, {
+    localVue,
+    propsData: { event, bucket_id: 'test-bucket' },
+    mocks: { $aw },
+    stubs: { datetime: true, icon: true },
+    attachTo: document.body,
+  });
+
+  return { wrapper, $aw };
+}
+
+describe('EventEditor save', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not emit save or close while the request is in flight', async () => {
+    const pending = deferred();
+    const { wrapper } = mountEditor({
+      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+    });
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.save();
+    await flush();
+
+    expect(wrapper.emitted('save')).toBeUndefined();
+    expect(hide).not.toHaveBeenCalled();
+    expect(wrapper.vm.busy).toBe(true);
+
+    pending.resolve();
+    await flush();
+  });
+
+  test('emits save once with the edited event, then closes', async () => {
+    const { wrapper, $aw } = mountEditor();
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.editedEvent.data.title = 'edited';
+    await wrapper.vm.save();
+    await flush();
+
+    expect($aw.replaceEvent).toHaveBeenCalledTimes(1);
+    expect($aw.replaceEvent).toHaveBeenCalledWith('test-bucket', wrapper.vm.editedEvent);
+    expect(wrapper.emitted('save')).toHaveLength(1);
+    // Payload compatibility: save emits the edited event.
+    expect(wrapper.emitted('save')[0][0].data.title).toBe('edited');
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.busy).toBe(false);
+  });
+
+  test('closes the modal before notifying the parent', async () => {
+    const { wrapper } = mountEditor();
+    await flush();
+
+    const order = [];
+    jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide').mockImplementation(() => order.push('hide'));
+    wrapper.vm.$on('save', () => order.push('emit'));
+
+    await wrapper.vm.save();
+    await flush();
+
+    expect(order).toEqual(['hide', 'emit']);
+  });
+
+  test('a failed request emits nothing, shows the error, and keeps the input', async () => {
+    const failure = Object.assign(new Error('Request failed'), {
+      response: { data: { message: 'server exploded' } },
+    });
+    const replaceEvent = jest.fn().mockRejectedValue(failure);
+    const { wrapper } = mountEditor({ replaceEvent });
+    await flush();
+    await showModal(wrapper);
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.editedEvent.data.title = 'edited';
+    await wrapper.vm.save();
+    await flush();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('save')).toBeUndefined();
+    expect(hide).not.toHaveBeenCalled();
+    expect(wrapper.vm.error).toBe('server exploded');
+    expect(visibleText()).toContain('server exploded');
+    // The user's edit is still there to retry with.
+    expect(wrapper.vm.editedEvent.data.title).toBe('edited');
+    expect(wrapper.vm.busy).toBe(false);
+  });
+
+  test('falls back to the error message when the server sends no detail', async () => {
+    const replaceEvent = jest.fn().mockRejectedValue(new Error('Network Error'));
+    const { wrapper } = mountEditor({ replaceEvent });
+    await flush();
+
+    await wrapper.vm.save();
+    expect(wrapper.vm.error).toBe('Network Error');
+  });
+
+  test('a retry after a failure succeeds and clears the error', async () => {
+    const replaceEvent = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValueOnce(undefined);
+    const { wrapper } = mountEditor({ replaceEvent });
+    await flush();
+
+    await wrapper.vm.save();
+    expect(wrapper.vm.error).toBe('Network Error');
+    expect(wrapper.emitted('save')).toBeUndefined();
+
+    await wrapper.vm.save();
+    await flush();
+
+    expect(replaceEvent).toHaveBeenCalledTimes(2);
+    expect(wrapper.vm.error).toBe('');
+    expect(wrapper.emitted('save')).toHaveLength(1);
+  });
+
+  test('repeated clicks while pending cause only one request', async () => {
+    const pending = deferred();
+    const replaceEvent = jest.fn().mockReturnValue(pending.promise);
+    const { wrapper } = mountEditor({ replaceEvent });
+    await flush();
+
+    const first = wrapper.vm.save();
+    const second = wrapper.vm.save();
+    const third = wrapper.vm.save();
+    await flush();
+
+    expect(replaceEvent).toHaveBeenCalledTimes(1);
+
+    pending.resolve();
+    await Promise.all([first, second, third]);
+    await flush();
+
+    expect(replaceEvent).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('save')).toHaveLength(1);
+  });
+
+  test('a late response is ignored once the editor moved to another event', async () => {
+    const pending = deferred();
+    const replaceEvent = jest.fn().mockReturnValue(pending.promise);
+    const { wrapper } = mountEditor({ replaceEvent });
+    await flush();
+
+    const save = wrapper.vm.save();
+    await flush();
+
+    // The editor gets pointed at a different event mid-request.
+    wrapper.setProps({ event: makeEvent(2) });
+    await flush();
+
+    pending.resolve();
+    await save;
+    await flush();
+
+    expect(wrapper.emitted('save')).toBeUndefined();
+  });
+});
+
+describe('EventEditor delete', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not emit delete while the request is in flight', async () => {
+    const pending = deferred();
+    const { wrapper } = mountEditor({
+      deleteEvent: jest.fn().mockReturnValue(pending.promise),
+    });
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.delete_();
+    await flush();
+
+    expect(wrapper.emitted('delete')).toBeUndefined();
+    expect(hide).not.toHaveBeenCalled();
+
+    pending.resolve();
+    await flush();
+  });
+
+  test('emits delete once with the original event, then closes', async () => {
+    const event = makeEvent();
+    const { wrapper, $aw } = mountEditor({ event });
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    await wrapper.vm.delete_();
+    await flush();
+
+    expect($aw.deleteEvent).toHaveBeenCalledWith('test-bucket', event.id);
+    expect(wrapper.emitted('delete')).toHaveLength(1);
+    // Payload compatibility: delete emits the original event.
+    expect(wrapper.emitted('delete')[0][0]).toBe(event);
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failed delete emits nothing and surfaces the error', async () => {
+    const deleteEvent = jest.fn().mockRejectedValue(new Error('nope'));
+    const { wrapper } = mountEditor({ deleteEvent });
+    await flush();
+
+    await wrapper.vm.delete_();
+    await flush();
+
+    expect(wrapper.emitted('delete')).toBeUndefined();
+    expect(wrapper.vm.error).toBe('nope');
+  });
+
+  test('repeated delete clicks while pending cause only one request', async () => {
+    const pending = deferred();
+    const deleteEvent = jest.fn().mockReturnValue(pending.promise);
+    const { wrapper } = mountEditor({ deleteEvent });
+    await flush();
+
+    const first = wrapper.vm.delete_();
+    const second = wrapper.vm.delete_();
+    expect(deleteEvent).toHaveBeenCalledTimes(1);
+
+    pending.resolve();
+    await Promise.all([first, second]);
+    expect(deleteEvent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('EventEditor cancel', () => {
+  test('closes without sending a mutation request when idle', async () => {
+    const { wrapper, $aw } = mountEditor();
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.close();
+    await flush();
+
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    expect($aw.replaceEvent).not.toHaveBeenCalled();
+    expect($aw.deleteEvent).not.toHaveBeenCalled();
+  });
+
+  test('does not close while a request is pending', async () => {
+    const pending = deferred();
+    const { wrapper } = mountEditor({
+      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+    });
+    await flush();
+    const hide = jest.spyOn(wrapper.vm.$refs.eventEditModal, 'hide');
+
+    wrapper.vm.save();
+    await flush();
+    wrapper.vm.close();
+
+    expect(hide).not.toHaveBeenCalled();
+    expect(wrapper.emitted('close')).toBeUndefined();
+
+    pending.resolve();
+    await flush();
+  });
+
+  test('dismissal is blocked only while busy', async () => {
+    const pending = deferred();
+    const { wrapper } = mountEditor({
+      replaceEvent: jest.fn().mockReturnValue(pending.promise),
+    });
+    await flush();
+
+    const modal = wrapper.findComponent({ ref: 'eventEditModal' });
+    expect(modal.props('noCloseOnEsc')).toBe(false);
+    expect(modal.props('noCloseOnBackdrop')).toBe(false);
+
+    wrapper.vm.save();
+    await wrapper.vm.$nextTick();
+
+    expect(modal.props('noCloseOnEsc')).toBe(true);
+    expect(modal.props('noCloseOnBackdrop')).toBe(true);
+    expect(modal.props('hideHeaderClose')).toBe(true);
+
+    pending.resolve();
+    await flush();
+  });
+});
+
+describe('EventEditor inside a parent that reacts to success', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Mirrors VisTimeline/EventList: the editor is rendered behind a v-if on the
+  // event being edited, so a parent clearing it on save destroys the editor.
+  function mountParent({ replaceEvent } = {}) {
+    const $aw = {
+      getEvent: jest.fn().mockImplementation(async () => makeEvent()),
+      replaceEvent: replaceEvent || jest.fn().mockResolvedValue(undefined),
+      deleteEvent: jest.fn().mockResolvedValue(undefined),
+    };
+    const saved = [];
+
+    const Parent = {
+      components: { EventEditor },
+      data() {
+        return { event: makeEvent() };
+      },
+      methods: {
+        onSave(e) {
+          saved.push(e);
+          // Destroys the editor, as the real consumers do.
+          this.event = null;
+        },
+      },
+      render(h) {
+        return h(
+          'div',
+          this.event
+            ? [
+                h(EventEditor, {
+                  props: { event: this.event, bucket_id: 'test-bucket' },
+                  on: { save: this.onSave },
+                }),
+              ]
+            : []
+        );
+      },
+    };
+
+    const wrapper = mount(Parent, {
+      localVue,
+      mocks: { $aw },
+      stubs: { datetime: true, icon: true },
+      attachTo: document.body,
+    });
+    return { wrapper, $aw, saved };
+  }
+
+  test('a parent destroying the editor on save does not throw', async () => {
+    const { wrapper, saved } = mountParent();
+    await flush();
+
+    const editor = wrapper.findComponent(EventEditor);
+    await editor.vm.save();
+    await flush();
+
+    expect(saved).toHaveLength(1);
+    expect(wrapper.findComponent(EventEditor).exists()).toBe(false);
+    // No "cannot read property hide of undefined" from the teardown.
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('a failed save leaves the editor mounted in the parent', async () => {
+    const { wrapper, saved } = mountParent({
+      replaceEvent: jest.fn().mockRejectedValue(new Error('nope')),
+    });
+    await flush();
+
+    const editor = wrapper.findComponent(EventEditor);
+    await showModal(editor);
+    await editor.vm.save();
+    await flush();
+    await editor.vm.$nextTick();
+
+    expect(saved).toHaveLength(0);
+    expect(wrapper.findComponent(EventEditor).exists()).toBe(true);
+    expect(visibleText()).toContain('nope');
+  });
+});

--- a/test/unit/PeriodUsage.test.js
+++ b/test/unit/PeriodUsage.test.js
@@ -117,7 +117,7 @@ describe('renderer geometry', () => {
     const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     document.body.appendChild(el);
     periodusage.create(el);
-    periodusage.update(el, entries, () => {});
+    periodusage.update(el, entries, jest.fn());
     return el;
   }
 
@@ -156,7 +156,9 @@ describe('renderer geometry', () => {
   });
 
   test('a single all-zero bar produces finite geometry', () => {
-    expectFinite(render([active(period('2026-09-10T04:00:00'), 0)]));
+    const el = render([active(period('2026-09-10T04:00:00'), 0)]);
+    expect(el.querySelectorAll('rect')).toHaveLength(1);
+    expectFinite(el);
   });
 
   test('empty entries still render a bar with finite geometry', () => {
@@ -198,12 +200,12 @@ describe('renderer geometry', () => {
     periodusage.update(
       el,
       [active(period('2026-09-09T04:00:00'), 100), active(period('2026-09-08T04:00:00'), 50)],
-      () => {}
+      jest.fn()
     );
     expect(el.querySelectorAll('rect')).toHaveLength(2);
     expect(todays()).toBe(1);
 
-    periodusage.update(el, [active(period('2020-01-01T04:00:00'), 100)], () => {});
+    periodusage.update(el, [active(period('2020-01-01T04:00:00'), 100)], jest.fn());
     expect(el.querySelectorAll('rect')).toHaveLength(1);
     expect(todays()).toBe(0);
   });

--- a/test/unit/PeriodUsage.test.js
+++ b/test/unit/PeriodUsage.test.js
@@ -1,0 +1,210 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import moment from 'moment';
+import PeriodUsage from '~/visualizations/PeriodUsage.vue';
+import periodusage from '~/visualizations/periodusage';
+import Activity from '~/views/activity/Activity.vue';
+import { useActivityStore } from '~/stores/activity';
+import { timeperiodToStr } from '~/util/timeperiod';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  jest.useFakeTimers().setSystemTime(new Date('2026-09-10T02:00:00'));
+});
+afterEach(() => jest.useRealTimers());
+
+const period = (start, periodLength = [1, 'day']) => ({ start, length: periodLength });
+const entry = (p, events = []) => ({ period: p, events });
+
+test.each([
+  [1, 'day'],
+  [1, 'week'],
+  [1, 'month'],
+  [7, 'days'],
+  [30, 'days'],
+])('store preserves boundaries and empty entries for %s %s', (count, unit) => {
+  const store = useActivityStore();
+  const p = period('2026-09-01T04:00:00', [count, unit]);
+  const events = [{ timestamp: '2026-09-02T12:00:00', duration: 300, data: { status: 'not-afk' } }];
+  store.active.history[timeperiodToStr(p)] = events;
+  const bars = store.getActiveHistoryAroundTimeperiod(p);
+  expect(bars).toHaveLength(31);
+  expect(moment(bars[15].period.start).valueOf()).toBe(moment(p.start).valueOf());
+  expect(bars[15].events).toEqual(events);
+  expect(bars[0].events).toEqual([]);
+  expect(bars[0].period.length).toEqual([count, unit]);
+});
+
+test('renders provided data on mount, sums events, and emits the original period', () => {
+  const p = period('2026-09-09T04:00:00');
+  const wrapper = mount(PeriodUsage, {
+    propsData: {
+      periodusage_arr: [
+        entry(p, [
+          { timestamp: '2026-09-10T01:00:00', duration: 60, data: { status: 'not-afk' } },
+          { timestamp: '2026-09-09T12:00:00', duration: 120, data: { status: 'not-afk' } },
+        ]),
+      ],
+    },
+  });
+  try {
+    expect(wrapper.find('rect title').text()).toBe('2026-09-09\n3m 0s');
+    expect(wrapper.findAll('line')).toHaveLength(1);
+    wrapper.find('rect').element.dispatchEvent(new MouseEvent('click'));
+    expect(wrapper.emitted('update')[0][0]).toEqual(p);
+    for (const attr of ['x', 'y', 'width', 'height']) {
+      expect(Number.isFinite(parseFloat(wrapper.find('rect').attributes(attr)))).toBe(true);
+    }
+  } finally {
+    wrapper.destroy();
+  }
+});
+
+test('empty periods remain clickable and Today is end-exclusive and refreshed', async () => {
+  const current = period('2026-09-03T04:00:00', [7, 'days']);
+  const wrapper = mount(PeriodUsage, { propsData: { periodusage_arr: [entry(current)] } });
+  try {
+    expect(wrapper.find('rect title').text()).toContain('2026-09-03 – 2026-09-09');
+    expect(wrapper.findAll('line')).toHaveLength(1);
+    jest.setSystemTime(new Date('2026-09-10T04:00:00'));
+    await wrapper.setProps({ periodusage_arr: [entry({ ...current })] });
+    expect(wrapper.findAll('line')).toHaveLength(0);
+    wrapper.find('rect').element.dispatchEvent(new MouseEvent('click'));
+    expect(wrapper.emitted('update')[0][0]).toEqual(current);
+    await wrapper.setProps({ periodusage_arr: [] });
+    expect(wrapper.text()).toBe('No data');
+    expect(wrapper.findAll('rect')).toHaveLength(0);
+  } finally {
+    wrapper.destroy();
+  }
+});
+
+test.each([
+  ['day', 1, '2026-09-01'],
+  ['week', 1, '2026-09-01'],
+  ['month', 1, '2026-09-01'],
+  ['last7d', 7, '2026-09-07'],
+  ['last30d', 30, '2026-09-30'],
+])('%s click uses the correct route anchor', (periodLength, count, expected) => {
+  const vm = { periodLength, setDate: jest.fn() };
+  Activity.methods.setUsagePeriod.call(vm, period('2026-09-01T04:00:00', [count, 'days']));
+  expect(vm.setDate).toHaveBeenCalledWith(expected);
+});
+
+test.each(['last7d', 'last30d'])('%s route retains the supplied anchor', periodLength => {
+  const vm = {
+    periodLength,
+    settingsStore: { startOfDay: '04:00' },
+    periodIsBrowseable: false,
+    host: 'host',
+    subview: 'view',
+    currentViewId: 'default',
+    $route: { path: '', query: { test: 'value' } },
+    $router: { push: jest.fn() },
+  };
+  Activity.methods.setDate.call(vm, '2026-09-07');
+  expect(vm.$router.push).toHaveBeenCalledWith({
+    path: `/activity/host/${periodLength}/2026-09-07/view/default`,
+    query: { test: 'value' },
+  });
+});
+
+// Direct renderer checks for the degenerate inputs that produced invalid SVG:
+// padding of 100/(count-1) was Infinity for a single bar, and a zero maximum
+// made every height NaN.
+describe('renderer geometry', () => {
+  function render(entries) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.appendChild(el);
+    periodusage.create(el);
+    periodusage.update(el, entries, () => {});
+    return el;
+  }
+
+  function expectFinite(el) {
+    for (const rect of el.querySelectorAll('rect')) {
+      for (const name of ['x', 'y', 'width', 'height']) {
+        const raw = rect.getAttribute(name);
+        expect(raw).not.toBeNull();
+        expect(raw).not.toMatch(/NaN|Infinity/);
+        expect(Number.isFinite(parseFloat(raw))).toBe(true);
+      }
+      expect(parseFloat(rect.getAttribute('width'))).toBeGreaterThan(0);
+      expect(parseFloat(rect.getAttribute('height'))).toBeGreaterThanOrEqual(0);
+    }
+  }
+
+  const active = (p, duration) => ({
+    period: p,
+    events: [{ timestamp: p.start, duration, data: { status: 'not-afk' } }],
+  });
+
+  test('a single bar produces finite geometry', () => {
+    const el = render([active(period('2026-09-10T04:00:00'), 100)]);
+    expect(el.querySelectorAll('rect')).toHaveLength(1);
+    expectFinite(el);
+  });
+
+  test('all-zero durations produce finite geometry', () => {
+    const el = render([
+      active(period('2026-09-08T04:00:00'), 0),
+      active(period('2026-09-09T04:00:00'), 0),
+      active(period('2026-09-10T04:00:00'), 0),
+    ]);
+    expect(el.querySelectorAll('rect')).toHaveLength(3);
+    expectFinite(el);
+  });
+
+  test('a single all-zero bar produces finite geometry', () => {
+    expectFinite(render([active(period('2026-09-10T04:00:00'), 0)]));
+  });
+
+  test('empty entries still render a bar with finite geometry', () => {
+    const el = render([entry(period('2026-09-09T04:00:00'))]);
+    expect(el.querySelectorAll('rect')).toHaveLength(1);
+    expectFinite(el);
+  });
+
+  test.each([[[]], [null], [undefined]])('%p renders the No data status', entries => {
+    const el = render(entries);
+    expect(el.textContent).toContain('No data');
+    expect(el.querySelectorAll('rect')).toHaveLength(0);
+  });
+
+  test('all active events in a period are summed, not just the first', () => {
+    const p = period('2026-09-10T04:00:00');
+    const el = render([
+      {
+        period: p,
+        events: [
+          { timestamp: p.start, duration: 60, data: { status: 'not-afk' } },
+          { timestamp: p.start, duration: 30, data: { status: 'not-afk' } },
+          { timestamp: p.start, duration: 999, data: { status: 'afk' } },
+        ],
+      },
+    ]);
+    expect(el.querySelector('title').textContent).toContain('1m 30s');
+  });
+
+  test('re-rendering replaces stale bars and stale Today markers', () => {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.appendChild(el);
+    periodusage.create(el);
+
+    const todays = () =>
+      Array.from(el.querySelectorAll('text')).filter(t => t.textContent === 'Today').length;
+
+    // now is 2026-09-10T02:00, which belongs to the activity day starting 09-09.
+    periodusage.update(
+      el,
+      [active(period('2026-09-09T04:00:00'), 100), active(period('2026-09-08T04:00:00'), 50)],
+      () => {}
+    );
+    expect(el.querySelectorAll('rect')).toHaveLength(2);
+    expect(todays()).toBe(1);
+
+    periodusage.update(el, [active(period('2020-01-01T04:00:00'), 100)], () => {});
+    expect(el.querySelectorAll('rect')).toHaveLength(1);
+    expect(todays()).toBe(0);
+  });
+});

--- a/test/unit/SunburstClock.test.js
+++ b/test/unit/SunburstClock.test.js
@@ -1,0 +1,116 @@
+import moment from 'moment';
+import sunburst from '~/visualizations/sunburst-clock';
+
+// Renders the clock into a detached element and returns the texts of all
+// markers drawn around the dial.
+function renderMarkers(startOfDay) {
+  const el = document.createElement('div');
+  el.innerHTML = '<div class="legend"></div><div class="sequence"></div>';
+  sunburst.create(el);
+
+  const root_event = {
+    timestamp: startOfDay.toISOString(),
+    duration: 0,
+    data: { title: 'ROOT' },
+    children: [],
+  };
+  sunburst.update(el, root_event, startOfDay.clone());
+
+  return {
+    el,
+    markers: Array.from(el.querySelectorAll('#container text')).map(t => t.textContent),
+  };
+}
+
+function nowMarkerCount(startOfDay) {
+  return renderMarkers(startOfDay).markers.filter(t => t === 'Now').length;
+}
+
+describe('sunburst-clock Now marker', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function freeze(local) {
+    jest.useFakeTimers().setSystemTime(moment(local).toDate());
+  }
+
+  test('draws exactly one Now marker for the period containing now', () => {
+    freeze('2026-09-10T15:30:00');
+    expect(nowMarkerCount(moment('2026-09-10T00:00:00'))).toBe(1);
+  });
+
+  test('draws no Now marker for a historical period', () => {
+    freeze('2026-09-10T15:30:00');
+    expect(nowMarkerCount(moment('2026-09-01T00:00:00'))).toBe(0);
+  });
+
+  test('draws no Now marker for a future period', () => {
+    freeze('2026-09-10T15:30:00');
+    expect(nowMarkerCount(moment('2026-09-20T00:00:00'))).toBe(0);
+  });
+
+  test('includes now exactly at the start of the period', () => {
+    freeze('2026-09-10T00:00:00');
+    expect(nowMarkerCount(moment('2026-09-10T00:00:00'))).toBe(1);
+  });
+
+  test('excludes now exactly at the end of the period', () => {
+    // The day shown starts 2026-09-09T00:00 and ends 2026-09-10T00:00.
+    freeze('2026-09-10T00:00:00');
+    expect(nowMarkerCount(moment('2026-09-09T00:00:00'))).toBe(0);
+  });
+
+  test('with a 04:00 day start, 02:00 belongs to the preceding activity day', () => {
+    freeze('2026-09-10T02:00:00');
+    // The activity day starting 2026-09-09T04:00 runs to 2026-09-10T04:00,
+    // so 02:00 is inside it despite the differing calendar date.
+    expect(nowMarkerCount(moment('2026-09-09T04:00:00'))).toBe(1);
+    // ...and is outside the activity day starting on its own calendar date.
+    expect(nowMarkerCount(moment('2026-09-10T04:00:00'))).toBe(0);
+  });
+
+  test('respects a fractional-hour day start', () => {
+    freeze('2026-09-10T04:15:00');
+    expect(nowMarkerCount(moment('2026-09-10T04:30:00'))).toBe(0);
+    expect(nowMarkerCount(moment('2026-09-09T04:30:00'))).toBe(1);
+  });
+
+  test('switching periods leaves no stale Now marker', () => {
+    freeze('2026-09-10T15:30:00');
+    const el = document.createElement('div');
+    el.innerHTML = '<div class="legend"></div><div class="sequence"></div>';
+    sunburst.create(el);
+
+    const render = startOfDay => {
+      sunburst.update(
+        el,
+        {
+          timestamp: startOfDay.toISOString(),
+          duration: 0,
+          data: { title: 'ROOT' },
+          children: [],
+        },
+        startOfDay.clone()
+      );
+      return Array.from(el.querySelectorAll('#container text')).map(t => t.textContent);
+    };
+
+    expect(render(moment('2026-09-10T00:00:00')).filter(t => t === 'Now')).toHaveLength(1);
+    // Re-rendering a historical day must clear the marker from the previous render.
+    expect(render(moment('2026-09-01T00:00:00')).filter(t => t === 'Now')).toHaveLength(0);
+  });
+
+  test('keeps the standard clock ticks regardless of the Now marker', () => {
+    freeze('2026-09-10T15:30:00');
+    const past = renderMarkers(moment('2026-09-01T00:00:00')).markers;
+    const today = renderMarkers(moment('2026-09-10T00:00:00')).markers;
+
+    for (const tick of ['00:00', '06:00', '12:00', '18:00']) {
+      expect(past).toContain(tick);
+      expect(today).toContain(tick);
+    }
+    expect(today.filter(t => t === 'Now')).toHaveLength(1);
+    expect(past).not.toContain('Now');
+  });
+});

--- a/test/unit/activeDuration.test.node.ts
+++ b/test/unit/activeDuration.test.node.ts
@@ -1,0 +1,158 @@
+import { activeDurationQuery } from '~/queries';
+import { createPinia, setActivePinia } from 'pinia';
+import { useActivityStore } from '~/stores/activity';
+import { useSettingsStore } from '~/stores/settings';
+import { useBucketsStore } from '~/stores/buckets';
+import { getClient } from '~/util/awclient';
+
+const mockQuery = jest.fn();
+jest.mock('~/util/awclient', () => ({ getClient: () => ({ query: mockQuery }) }));
+const source = {
+  bid_afk: 'afk_host',
+  bid_window: 'window_host',
+  bid_browsers: ['aw-watcher-web-chrome_host'],
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  mockQuery
+    .mockReset()
+    .mockImplementation(periods =>
+      Promise.resolve(
+        periods.map(() => [
+          { timestamp: '2026-09-01T10:00:00Z', duration: 60, data: { app: 'Test' } },
+        ])
+      )
+    );
+});
+
+test('uses canonical active evidence with optional audible and app/title patterns', () => {
+  const query = activeDurationQuery([source], {
+    include_audible: true,
+    always_active_pattern: 'a"b;code',
+  }).join('\n');
+  expect(query).toContain('filter_keyvals(browser_events, "audible", [true])');
+  expect(query).toContain('filter_keyvals_regex(events, "app", "a\\"b;code")');
+  expect(query).toContain('filter_keyvals_regex(events, "title", "a\\"b;code")');
+  expect(query).toContain('union_no_overlap(history_events, not_afk)');
+  expect(query).not.toContain('categorize(');
+});
+
+test('disabled AFK filtering returns window coverage while AFK-only sources retain the fallback', () => {
+  const query = activeDurationQuery([source, { bid_afk: 'afk_only' }], { filter_afk: false }).join(
+    '\n'
+  );
+  expect(query).toContain('union_no_overlap(history_events, events)');
+  expect(query).toContain('query_bucket("afk_only")');
+  expect(query).not.toContain('filter_period_intersect(events, not_afk)');
+  expect(query.match(/RETURN/g)).toHaveLength(1);
+  expect(query).not.toContain('audible_events =');
+});
+
+test('missing browsers and an empty source list never introduce missing bucket references', () => {
+  expect(
+    activeDurationQuery([{ bid_afk: 'afk', bid_window: 'window' }], { include_audible: true }).join(
+      ' '
+    )
+  ).not.toMatch(/query_bucket\("(?:undefined|null)"\)/);
+  expect(activeDurationQuery([])).toEqual(['history_events = [];', 'RETURN = history_events;']);
+});
+
+test('store passes activity options and normalizes every returned event for the history chart', async () => {
+  const store = useActivityStore();
+  store.buckets.afk = [source.bid_afk];
+  store.buckets.window = [source.bid_window];
+  store.buckets.browser = source.bid_browsers;
+  await store.query_active_history({
+    host: 'host',
+    timeperiod: { start: '2026-01-01T04:00:00Z', length: [1, 'day'] },
+    include_audible: true,
+    always_active_pattern: 'Code',
+    filter_categories: [['Work']],
+  });
+  const query = (getClient().query as jest.Mock).mock.calls[0][1].join('\n');
+  expect(query).toContain('audible_events =');
+  expect(query).toContain('"Code"');
+  expect(query).not.toContain('Work');
+  expect(
+    Object.values(store.active.history).every(events => events[0].data.status === 'not-afk')
+  ).toBe(true);
+});
+
+test('multidevice history resolves real per-host window, AFK and browser bucket IDs', async () => {
+  useSettingsStore().useMultidevice = true;
+  const buckets = useBucketsStore();
+  buckets.buckets = Object.fromEntries(
+    [
+      ['custom-afk_a', 'afkstatus', 'a'],
+      ['custom-window_a', 'currentwindow', 'a'],
+      ['aw-watcher-web-chrome_a', 'web.tab.current', 'a'],
+      ['custom-afk_b', 'afkstatus', 'b'],
+    ].map(([id, type, hostname]) => [id, { id, type, hostname, data: {} }])
+  ) as any;
+  await useActivityStore().query_active_history({
+    host: 'a',
+    timeperiod: { start: '2026-01-01T04:00:00Z', length: [1, 'day'] },
+    include_audible: true,
+  });
+  const query = mockQuery.mock.calls[0][1].join('\n');
+  for (const id of ['custom-afk_a', 'custom-window_a', 'aw-watcher-web-chrome_a', 'custom-afk_b']) {
+    expect(query).toContain(`query_bucket("${id}")`);
+  }
+  expect(query).not.toContain('aw-watcher-window_b');
+});
+
+// Regression: the AFK-only fallback must contribute real intervals.
+//
+// Routing it through activityQuery left that function's trailing
+// merge_events_by_keys(not_afk, ["status"]) in the emitted query, which
+// collapses every not-afk period into a single event carrying the first
+// timestamp and the summed duration (see aw-transform's merge_events_by_keys).
+// Unioning that synthetic block against another source's real periods trims
+// time that was never concurrent, so multidevice with an AFK-only host
+// under-counted active time.
+describe('AFK-only sources keep their interval structure', () => {
+  const gen = sources => activeDurationQuery(sources).join('\n');
+
+  test('never merges periods before unioning them', () => {
+    for (const sources of [
+      [{ bid_afk: 'afk_a' }],
+      [{ bid_afk: 'afk_a' }, { bid_afk: 'afk_b' }],
+      [{ bid_afk: 'afk_a', bid_window: 'win_a' }, { bid_afk: 'afk_b' }],
+    ]) {
+      expect(gen(sources)).not.toContain('merge_events_by_keys');
+    }
+  });
+
+  test('each AFK-only source is queried as intervals and unioned', () => {
+    const q = gen([{ bid_afk: 'afk_a' }, { bid_afk: 'afk_b' }]);
+
+    expect(q).toContain('not_afk = flood(query_bucket("afk_a"));');
+    expect(q).toContain('not_afk = flood(query_bucket("afk_b"));');
+    expect(q.match(/union_no_overlap\(history_events, not_afk\)/g)).toHaveLength(2);
+  });
+
+  test('a mixed desktop and AFK-only set contributes both', () => {
+    const q = gen([{ bid_afk: 'afk_a', bid_window: 'win_a' }, { bid_afk: 'afk_b' }]);
+
+    expect(q).toContain('query_bucket("win_a")');
+    expect(q).toContain('not_afk = flood(query_bucket("afk_b"));');
+    expect(q).not.toContain('merge_events_by_keys');
+  });
+
+  test('AFK-only bucket ids are escaped', () => {
+    expect(gen([{ bid_afk: 'afk_ho"st' }])).toContain('query_bucket("afk_ho\\"st")');
+  });
+
+  test('brackets stay balanced for every source shape', () => {
+    for (const sources of [
+      [{ bid_afk: 'afk_a' }],
+      [{ bid_afk: 'afk_a' }, { bid_afk: 'afk_b' }],
+      [{ bid_afk: 'afk_a', bid_window: 'win_a', bid_browsers: ['web_a'] }, { bid_afk: 'afk_b' }],
+    ]) {
+      const q = gen(sources);
+      expect((q.match(/\(/g) || []).length).toEqual((q.match(/\)/g) || []).length);
+      expect((q.match(/\{/g) || []).length).toEqual((q.match(/\}/g) || []).length);
+    }
+  });
+});

--- a/test/unit/activeHistory.test.node.ts
+++ b/test/unit/activeHistory.test.node.ts
@@ -1,0 +1,192 @@
+import { activeHistoryCacheKey, selectPeriodsToQuery } from '~/util/activeHistory';
+
+const baseContext = {
+  platform: 'desktop' as const,
+  host: 'hostA',
+  useMultidevice: false,
+  startOfDay: '04:00',
+  include_audible: false,
+  always_active_pattern: '',
+};
+
+const baseSources = [
+  { bid_afk: 'aw-watcher-afk_hostA', bid_window: 'aw-watcher-window_hostA', bid_browsers: ['b1'] },
+];
+
+const key = (ctx = {}, sources = baseSources) =>
+  activeHistoryCacheKey({ ...baseContext, ...ctx }, sources);
+
+describe('activeHistoryCacheKey', () => {
+  test('identical context and sources produce the same key', () => {
+    expect(key()).toBe(key());
+  });
+
+  test.each([
+    ['host', { host: 'hostB' }],
+    ['platform', { platform: 'android' as const }],
+    ['multidevice mode', { useMultidevice: true }],
+    ['day boundary', { startOfDay: '00:00' }],
+    ['include_audible', { include_audible: true }],
+    ['always_active_pattern', { always_active_pattern: 'mpv' }],
+  ])('a different %s produces a different key', (_label, override) => {
+    expect(key(override)).not.toBe(key());
+  });
+
+  test.each([
+    [
+      'afk bucket',
+      [
+        {
+          bid_afk: 'aw-watcher-afk_other',
+          bid_window: 'aw-watcher-window_hostA',
+          bid_browsers: ['b1'],
+        },
+      ],
+    ],
+    [
+      'window bucket',
+      [{ bid_afk: 'aw-watcher-afk_hostA', bid_window: 'other', bid_browsers: ['b1'] }],
+    ],
+    [
+      'browser bucket set',
+      [
+        {
+          bid_afk: 'aw-watcher-afk_hostA',
+          bid_window: 'aw-watcher-window_hostA',
+          bid_browsers: ['b2'],
+        },
+      ],
+    ],
+    ['added source', [...baseSources, { bid_afk: 'aw-watcher-afk_hostB' }]],
+    ['removed source', []],
+  ])('a different %s produces a different key', (_label, sources) => {
+    expect(key({}, sources as any)).not.toBe(key());
+  });
+
+  test('source discovery order does not affect the key', () => {
+    const a = [{ bid_afk: 'afk_a' }, { bid_afk: 'afk_b' }];
+    const b = [{ bid_afk: 'afk_b' }, { bid_afk: 'afk_a' }];
+    expect(key({}, a)).toBe(key({}, b));
+  });
+
+  test('browser bucket order does not affect the key', () => {
+    const a = [{ bid_afk: 'afk', bid_browsers: ['b1', 'b2'] }];
+    const b = [{ bid_afk: 'afk', bid_browsers: ['b2', 'b1'] }];
+    expect(key({}, a)).toBe(key({}, b));
+  });
+
+  test('a bare bucket id is equivalent to an AFK-only source', () => {
+    expect(key({}, ['afk_only'] as any)).toBe(key({}, [{ bid_afk: 'afk_only' }]));
+  });
+
+  test('a missing browser list matches an empty one', () => {
+    expect(key({}, [{ bid_afk: 'afk' }])).toBe(key({}, [{ bid_afk: 'afk', bid_browsers: [] }]));
+  });
+
+  test('undefined semantic options match their falsy defaults', () => {
+    expect(
+      activeHistoryCacheKey(
+        { platform: 'desktop', host: 'h', useMultidevice: false, startOfDay: '04:00' },
+        [{ bid_afk: 'afk' }]
+      )
+    ).toBe(
+      activeHistoryCacheKey(
+        {
+          platform: 'desktop',
+          host: 'h',
+          useMultidevice: false,
+          startOfDay: '04:00',
+          include_audible: false,
+          always_active_pattern: '',
+        },
+        [{ bid_afk: 'afk' }]
+      )
+    );
+  });
+});
+
+describe('selectPeriodsToQuery', () => {
+  // Three consecutive days; "now" sits inside 2026-09-10.
+  const day = (d: string) =>
+    `2026-09-${d}T00:00:00+00:00/2026-09-${String(Number(d) + 1).padStart(2, '0')}T00:00:00+00:00`;
+  const past = day('08');
+  const yesterday = day('09');
+  const today = day('10');
+  const future = day('11');
+  const now = new Date('2026-09-10T12:00:00+00:00');
+
+  test('queries everything when nothing is cached', () => {
+    expect(selectPeriodsToQuery([past, yesterday, today], {}, now)).toEqual([
+      past,
+      yesterday,
+      today,
+    ]);
+  });
+
+  test('skips closed periods already cached', () => {
+    expect(
+      selectPeriodsToQuery([past, yesterday, today], { [past]: [], [yesterday]: [] }, now)
+    ).toEqual([today]);
+  });
+
+  test('a cached empty result counts as cached', () => {
+    // Nothing happened that day; that answer does not change.
+    expect(selectPeriodsToQuery([past], { [past]: [] }, now)).toEqual([]);
+  });
+
+  test('always refreshes the open period even when cached', () => {
+    expect(selectPeriodsToQuery([today], { [today]: [{ duration: 5 }] }, now)).toEqual([today]);
+  });
+
+  test('never queries a future period, cached or not', () => {
+    expect(selectPeriodsToQuery([future], {}, now)).toEqual([]);
+    expect(selectPeriodsToQuery([future], { [future]: [] }, now)).toEqual([]);
+  });
+
+  test('returns nothing when every period is cached and closed', () => {
+    expect(selectPeriodsToQuery([past, yesterday], { [past]: [], [yesterday]: [] }, now)).toEqual(
+      []
+    );
+  });
+
+  test('overlapping navigation only asks for the missing periods', () => {
+    const cached = { [yesterday]: [], [today]: [] };
+    expect(selectPeriodsToQuery([past, yesterday, today], cached, now)).toEqual([past, today]);
+  });
+
+  test('a period starting exactly at now is treated as future', () => {
+    const boundary = '2026-09-10T12:00:00+00:00/2026-09-11T12:00:00+00:00';
+    expect(selectPeriodsToQuery([boundary], {}, now)).toEqual([]);
+  });
+
+  test('a period ending exactly at now is closed and cacheable', () => {
+    const closed = '2026-09-09T12:00:00+00:00/2026-09-10T12:00:00+00:00';
+    expect(selectPeriodsToQuery([closed], {}, now)).toEqual([closed]);
+    expect(selectPeriodsToQuery([closed], { [closed]: [] }, now)).toEqual([]);
+  });
+
+  test('respects a non-midnight day boundary', () => {
+    // With a 04:00 boundary, the activity day starting 2026-09-09T04:00 is the
+    // one containing 02:00 on the 10th, so it is still open.
+    const activityDay = '2026-09-09T04:00:00+00:00/2026-09-10T04:00:00+00:00';
+    const at2am = new Date('2026-09-10T02:00:00+00:00');
+    expect(selectPeriodsToQuery([activityDay], { [activityDay]: [] }, at2am)).toEqual([
+      activityDay,
+    ]);
+  });
+
+  test('an unparseable period is queried rather than dropped', () => {
+    expect(selectPeriodsToQuery(['garbage'], {}, now)).toEqual(['garbage']);
+  });
+
+  test('an empty period list stays empty', () => {
+    expect(selectPeriodsToQuery([], {}, now)).toEqual([]);
+  });
+
+  test('inherited object properties are not mistaken for cached periods', () => {
+    // A period literally named "constructor" must not appear cached via the
+    // prototype chain.
+    const weird = '2026-09-08T00:00:00+00:00/2026-09-09T00:00:00+00:00';
+    expect(selectPeriodsToQuery([weird], Object.create({ [weird]: [] }), now)).toEqual([weird]);
+  });
+});

--- a/test/unit/activeHistory.test.node.ts
+++ b/test/unit/activeHistory.test.node.ts
@@ -5,6 +5,7 @@ const baseContext = {
   host: 'hostA',
   useMultidevice: false,
   startOfDay: '04:00',
+  filter_afk: true,
   include_audible: false,
   always_active_pattern: '',
 };
@@ -26,6 +27,7 @@ describe('activeHistoryCacheKey', () => {
     ['platform', { platform: 'android' as const }],
     ['multidevice mode', { useMultidevice: true }],
     ['day boundary', { startOfDay: '00:00' }],
+    ['filter_afk', { filter_afk: false }],
     ['include_audible', { include_audible: true }],
     ['always_active_pattern', { always_active_pattern: 'mpv' }],
   ])('a different %s produces a different key', (_label, override) => {
@@ -81,6 +83,13 @@ describe('activeHistoryCacheKey', () => {
 
   test('a missing browser list matches an empty one', () => {
     expect(key({}, [{ bid_afk: 'afk' }])).toBe(key({}, [{ bid_afk: 'afk', bid_browsers: [] }]));
+  });
+
+  test('an omitted filter_afk matches an explicit true', () => {
+    // activeDurationQuery reads it as `filter_afk !== false`, so the key must
+    // normalize the same way or a default-on view would miss its own cache.
+    expect(key({ filter_afk: undefined })).toBe(key({ filter_afk: true }));
+    expect(key({ filter_afk: false })).not.toBe(key({ filter_afk: true }));
   });
 
   test('undefined semantic options match their falsy defaults', () => {

--- a/test/unit/activeHistory.test.node.ts
+++ b/test/unit/activeHistory.test.node.ts
@@ -123,7 +123,7 @@ describe('selectPeriodsToQuery', () => {
     ]);
   });
 
-  test('skips closed periods already cached', () => {
+  test('skips closedPeriod periods already cached', () => {
     expect(
       selectPeriodsToQuery([past, yesterday, today], { [past]: [], [yesterday]: [] }, now)
     ).toEqual([today]);
@@ -143,7 +143,7 @@ describe('selectPeriodsToQuery', () => {
     expect(selectPeriodsToQuery([future], { [future]: [] }, now)).toEqual([]);
   });
 
-  test('returns nothing when every period is cached and closed', () => {
+  test('returns nothing when every period is cached and closedPeriod', () => {
     expect(selectPeriodsToQuery([past, yesterday], { [past]: [], [yesterday]: [] }, now)).toEqual(
       []
     );
@@ -159,10 +159,10 @@ describe('selectPeriodsToQuery', () => {
     expect(selectPeriodsToQuery([boundary], {}, now)).toEqual([]);
   });
 
-  test('a period ending exactly at now is closed and cacheable', () => {
-    const closed = '2026-09-09T12:00:00+00:00/2026-09-10T12:00:00+00:00';
-    expect(selectPeriodsToQuery([closed], {}, now)).toEqual([closed]);
-    expect(selectPeriodsToQuery([closed], { [closed]: [] }, now)).toEqual([]);
+  test('a period ending exactly at now is closedPeriod and cacheable', () => {
+    const closedPeriod = '2026-09-09T12:00:00+00:00/2026-09-10T12:00:00+00:00';
+    expect(selectPeriodsToQuery([closedPeriod], {}, now)).toEqual([closedPeriod]);
+    expect(selectPeriodsToQuery([closedPeriod], { [closedPeriod]: [] }, now)).toEqual([]);
   });
 
   test('respects a non-midnight day boundary', () => {

--- a/test/unit/alerts.test.node.ts
+++ b/test/unit/alerts.test.node.ts
@@ -22,10 +22,9 @@ describe('cleanAlertGoal', () => {
   });
 
   test('keeps nested category paths', () => {
-    expect(cleanAlertGoal({ name: 'Code', category: ['Work', 'Code'], goal: 30 }).category).toEqual([
-      'Work',
-      'Code',
-    ]);
+    expect(cleanAlertGoal({ name: 'Code', category: ['Work', 'Code'], goal: 30 }).category).toEqual(
+      ['Work', 'Code']
+    );
   });
 
   test('copies the category array rather than aliasing the input', () => {
@@ -74,12 +73,14 @@ describe('cleanAlertGoals', () => {
     expect(cleanAlertGoals([])).toEqual([]);
   });
 
-  test.each([['a string', 'nope'], ['an object', { name: 'Work' }], ['null', null], ['undefined', undefined]])(
-    'returns an empty list for %s',
-    (_label, candidate) => {
-      expect(cleanAlertGoals(candidate)).toEqual([]);
-    }
-  );
+  test.each([
+    ['a string', 'nope'],
+    ['an object', { name: 'Work' }],
+    ['null', null],
+    ['undefined', undefined],
+  ])('returns an empty list for %s', (_label, candidate) => {
+    expect(cleanAlertGoals(candidate)).toEqual([]);
+  });
 });
 
 describe('getDefaultAlertGoals', () => {

--- a/test/unit/alerts.test.node.ts
+++ b/test/unit/alerts.test.node.ts
@@ -1,0 +1,97 @@
+import { cleanAlertGoal, cleanAlertGoals, getDefaultAlertGoals } from '~/util/alerts';
+
+describe('cleanAlertGoal', () => {
+  test('accepts a well-formed goal', () => {
+    expect(cleanAlertGoal({ name: 'Work', category: ['Work'], goal: 100 })).toEqual({
+      name: 'Work',
+      category: ['Work'],
+      goal: 100,
+    });
+  });
+
+  test('normalizes the string a number input produces', () => {
+    expect(cleanAlertGoal({ name: 'Work', category: ['Work'], goal: ' 45 ' })).toEqual({
+      name: 'Work',
+      category: ['Work'],
+      goal: 45,
+    });
+  });
+
+  test('trims the name', () => {
+    expect(cleanAlertGoal({ name: '  Work  ', category: ['Work'], goal: 1 }).name).toBe('Work');
+  });
+
+  test('keeps nested category paths', () => {
+    expect(cleanAlertGoal({ name: 'Code', category: ['Work', 'Code'], goal: 30 }).category).toEqual([
+      'Work',
+      'Code',
+    ]);
+  });
+
+  test('copies the category array rather than aliasing the input', () => {
+    const category = ['Work'];
+    const cleaned = cleanAlertGoal({ name: 'Work', category, goal: 1 });
+    category.push('Mutated');
+    expect(cleaned.category).toEqual(['Work']);
+  });
+
+  test.each([
+    ['a non-object', 'nope'],
+    ['null', null],
+    ['a missing name', { category: ['Work'], goal: 1 }],
+    ['a blank name', { name: '   ', category: ['Work'], goal: 1 }],
+    ['a non-string name', { name: 7, category: ['Work'], goal: 1 }],
+    ['a null category (the "All" option)', { name: 'All', category: null, goal: 1 }],
+    ['an empty category', { name: 'Empty', category: [], goal: 1 }],
+    ['a non-array category', { name: 'Work', category: 'Work', goal: 1 }],
+    ['a non-string category segment', { name: 'Work', category: ['Work', 3], goal: 1 }],
+    ['a missing goal', { name: 'Work', category: ['Work'] }],
+    ['a non-numeric goal', { name: 'Work', category: ['Work'], goal: 'abc' }],
+    ['a NaN goal', { name: 'Work', category: ['Work'], goal: NaN }],
+    ['an infinite goal', { name: 'Work', category: ['Work'], goal: Infinity }],
+    ['a negative goal', { name: 'Work', category: ['Work'], goal: -5 }],
+  ])('rejects %s', (_label, candidate) => {
+    expect(cleanAlertGoal(candidate)).toBeNull();
+  });
+});
+
+describe('cleanAlertGoals', () => {
+  test('drops malformed entries and keeps valid ones', () => {
+    expect(
+      cleanAlertGoals([
+        { name: 'Work', category: ['Work'], goal: 100 },
+        { name: '', category: ['Broken'], goal: 1 },
+        null,
+        { name: 'Media', category: ['Media'], goal: '10' },
+      ])
+    ).toEqual([
+      { name: 'Work', category: ['Work'], goal: 100 },
+      { name: 'Media', category: ['Media'], goal: 10 },
+    ]);
+  });
+
+  test('preserves a stored empty list', () => {
+    expect(cleanAlertGoals([])).toEqual([]);
+  });
+
+  test.each([['a string', 'nope'], ['an object', { name: 'Work' }], ['null', null], ['undefined', undefined]])(
+    'returns an empty list for %s',
+    (_label, candidate) => {
+      expect(cleanAlertGoals(candidate)).toEqual([]);
+    }
+  );
+});
+
+describe('getDefaultAlertGoals', () => {
+  test('provides sample goals that survive their own validation', () => {
+    const defaults = getDefaultAlertGoals();
+    expect(defaults.length).toBeGreaterThan(0);
+    expect(cleanAlertGoals(defaults)).toEqual(defaults);
+  });
+
+  test('returns a fresh array each call, so callers cannot corrupt the defaults', () => {
+    const first = getDefaultAlertGoals();
+    first.pop();
+    expect(getDefaultAlertGoals()).toHaveLength(2);
+  });
+});

--- a/test/unit/calendar.test.node.ts
+++ b/test/unit/calendar.test.node.ts
@@ -1,0 +1,44 @@
+import { calendarTimeBounds } from '~/util/calendar';
+
+const event = (start: string, end: string) => ({ start, end });
+const fullDay = { slotMinTime: '00:00:00', slotMaxTime: '24:00:00' };
+
+test.each([
+  ['2026-09-10T10:15:00', '2026-09-10T10:20:00', '10:00:00', '11:00:00'],
+  ['2026-09-10T10:15:00', '2026-09-10T11:00:00', '10:00:00', '11:00:00'],
+  ['2026-09-10T10:15:00', '2026-09-10T11:00:00.001', '10:00:00', '12:00:00'],
+  ['2026-09-10T23:30:00', '2026-09-11T00:00:00', '23:00:00', '24:00:00'],
+  ['2026-09-10T23:30:00', '2026-09-11T00:30:00', '00:00:00', '24:00:00'],
+  ['2026-09-10T12:00:00', '2026-09-12T12:00:00', '00:00:00', '24:00:00'],
+])('fits %s through %s without wrapping the upper bound', (start, end, min, max) => {
+  expect(calendarTimeBounds([event(start, end)], true)).toEqual({
+    slotMinTime: min,
+    slotMaxTime: max,
+  });
+});
+
+test('fits clock-time extents across the week independently of date order', () => {
+  expect(
+    calendarTimeBounds(
+      [
+        event('2026-09-10T16:00:00', '2026-09-10T18:00:00'),
+        event('2026-09-11T08:15:00', '2026-09-11T09:00:00'),
+      ],
+      true
+    )
+  ).toEqual({ slotMinTime: '08:00:00', slotMaxTime: '18:00:00' });
+});
+
+test('falls back safely for empty, invalid, and nonpositive intervals or disabled fitting', () => {
+  for (const events of [
+    [],
+    [event('bad', 'bad')],
+    [event('2026-09-10T12:00:00', '2026-09-10T11:00:00')],
+    [event('2026-09-10T12:00:00', '2026-09-10T12:00:00')],
+  ]) {
+    expect(calendarTimeBounds(events, true)).toEqual(fullDay);
+  }
+  expect(calendarTimeBounds([event('2026-09-10T10:00:00', '2026-09-10T11:00:00')], false)).toEqual(
+    fullDay
+  );
+});

--- a/test/unit/datasets.test.node.ts
+++ b/test/unit/datasets.test.node.ts
@@ -1,0 +1,46 @@
+import { buildBarchartDataset } from '~/util/datasets';
+import { Category } from '~/util/classes';
+import { IEvent } from '~/util/interfaces';
+
+const event = (path: string[] | undefined, duration: number): IEvent => ({
+  timestamp: '2026-09-10T10:00:00Z',
+  duration,
+  data: { $category: path },
+});
+
+test('preserves missing paths, distinct separator-containing paths, and every period duration', () => {
+  const classes: Category[] = [
+    { name: ['Known'], rule: { type: 'none' }, data: { color: '#123456' } },
+    { name: ['Known', 'Child'], rule: { type: 'none' } },
+  ];
+  const periods = [
+    {
+      cat_events: [
+        event(['Known', 'Child'], 3600),
+        event(['Uncategorized'], 1800),
+        event(['Deleted', 'Child'], 900),
+        event(['A>>>B'], 360),
+        event(['A', 'B'], 720),
+      ],
+    },
+    { cat_events: [event(['Deleted', 'Child'], 1800), event(['Deleted', 'Child'], 900)] },
+  ];
+  const before = JSON.stringify({ classes, periods });
+  const datasets = buildBarchartDataset(periods, classes);
+  expect(datasets).toEqual([
+    { label: 'Known > Child', backgroundColor: '#123456', data: [1, null] },
+    { label: 'Uncategorized', backgroundColor: '#CCC', data: [0.5, null] },
+    { label: 'Deleted > Child', backgroundColor: '#CCC', data: [0.25, 0.75] },
+    { label: 'A>>>B', backgroundColor: '#CCC', data: [0.1, null] },
+    { label: 'A > B', backgroundColor: '#CCC', data: [0.2, null] },
+  ]);
+  expect(JSON.stringify({ classes, periods })).toBe(before);
+});
+
+test('retains unclassified events and handles empty input', () => {
+  expect(
+    buildBarchartDataset([{ cat_events: [event([], 1800), event(undefined, 1800)] }], [])
+  ).toEqual([{ label: 'Uncategorized', backgroundColor: '#CCC', data: [1] }]);
+  expect(buildBarchartDataset([], [])).toEqual([]);
+  expect(buildBarchartDataset(null, [])).toEqual([]);
+});

--- a/test/unit/store/activeHistoryCache.test.node.ts
+++ b/test/unit/store/activeHistoryCache.test.node.ts
@@ -153,6 +153,7 @@ describe('query_active_history caching', () => {
 
   test.each([
     ['host change', { host: 'otherhost' }],
+    ['filter_afk change', { filter_afk: false }],
     ['include_audible change', { include_audible: true }],
     ['always_active_pattern change', { always_active_pattern: 'mpv' }],
   ])('%s cannot reuse cached periods', async (_label, override) => {
@@ -161,6 +162,28 @@ describe('query_active_history caching', () => {
 
     await activityStore.query_active_history({ host: HOST, timeperiod: TIMEPERIOD, ...override });
     expect(periodsAsked()[1]).toEqual(first);
+  });
+
+  test('toggling the AFK filter both ways cannot reuse cached periods', async () => {
+    // With AFK filtering off the query measures window coverage instead of
+    // AFK-filtered intervals, so closed periods are not interchangeable.
+    await run({ filter_afk: true });
+    const first = periodsAsked()[0];
+
+    await run({ filter_afk: false });
+    expect(periodsAsked()[1]).toEqual(first);
+
+    await run({ filter_afk: true });
+    expect(periodsAsked()[2]).toEqual(first);
+  });
+
+  test('an omitted filter_afk still reuses the default-on cache', async () => {
+    await run({ filter_afk: true });
+    const first = periodsAsked()[0];
+
+    await run();
+    // Only the open period may be refetched; the default is AFK-filtering on.
+    expect(periodsAsked()[1].length).toBeLessThan(first.length);
   });
 
   test('a day-boundary change cannot reuse cached periods', async () => {

--- a/test/unit/store/activeHistoryCache.test.node.ts
+++ b/test/unit/store/activeHistoryCache.test.node.ts
@@ -1,0 +1,340 @@
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useActivityStore } from '~/stores/activity';
+import { useBucketsStore } from '~/stores/buckets';
+import { useSettingsStore } from '~/stores/settings';
+import * as awclient from '~/util/awclient';
+
+// Captures the query the store submits, without reaching a server.
+function mockQuery(result: unknown[] = []) {
+  const query = jest.fn().mockResolvedValue(result);
+  jest.spyOn(awclient, 'getClient').mockReturnValue({
+    query,
+    abort: jest.fn(),
+    req: { defaults: {} },
+  } as any);
+  return query;
+}
+
+const HOST = 'testhost';
+
+function seedBuckets(hosts: Record<string, { window?: boolean; browser?: boolean }>) {
+  const buckets: any[] = [];
+  for (const [host, has] of Object.entries(hosts)) {
+    buckets.push({ id: `aw-watcher-afk_${host}`, type: 'afkstatus', hostname: host, data: {} });
+    if (has.window) {
+      buckets.push({
+        id: `aw-watcher-window_${host}`,
+        type: 'currentwindow',
+        hostname: host,
+        data: {},
+      });
+    }
+    if (has.browser) {
+      buckets.push({
+        id: `aw-watcher-web-firefox_${host}`,
+        type: 'web.tab.current',
+        hostname: host,
+        data: {},
+      });
+    }
+  }
+  useBucketsStore().update_buckets(buckets);
+}
+
+const TIMEPERIOD = { start: '2026-09-10T00:00:00+00:00', length: [1, 'day'] as [number, string] };
+
+describe('query_active_history caching', () => {
+  let activityStore: any;
+  let query: jest.Mock;
+
+  const DESKTOP_BUCKETS = {
+    afk: [`aw-watcher-afk_${HOST}`],
+    window: [`aw-watcher-window_${HOST}`],
+    browser: [],
+    editor: [],
+    android: [],
+    stopwatch: [],
+  };
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useSettingsStore().$patch({ _loaded: true, startOfDay: '00:00', useMultidevice: false });
+    activityStore = useActivityStore();
+    jest.restoreAllMocks();
+    // activeDurationQuery returns an event array per period on this branch.
+    query = mockQuery([]);
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 60, data: {} }])
+    );
+    activityStore.buckets = { ...DESKTOP_BUCKETS };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const run = (options: Record<string, unknown> = {}) =>
+    activityStore.query_active_history({ host: HOST, timeperiod: TIMEPERIOD, ...options });
+
+  const periodsAsked = () => query.mock.calls.map(call => call[0]);
+
+  test('repeating the same request skips cached closed periods', async () => {
+    await run();
+    const first = periodsAsked()[0];
+    expect(first.length).toBeGreaterThan(0);
+
+    await run();
+    const second = periodsAsked()[1];
+
+    // Only the still-open period may be refetched.
+    expect(second.length).toBeLessThan(first.length);
+    for (const tp of second) {
+      const [start, end] = tp.split('/').map((d: string) => new Date(d).getTime());
+      const now = Date.now();
+      expect(start <= now && now < end).toBe(true);
+    }
+  });
+
+  test('a cached empty result is not refetched', async () => {
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 0, data: {} }])
+    );
+    await run();
+    const first = periodsAsked()[0];
+
+    await run();
+    const second = periodsAsked()[1];
+
+    // Every closed period returned 0 and must still count as cached.
+    expect(second.length).toBeLessThan(first.length);
+  });
+
+  test('navigating a nearby date only queries the newly needed periods', async () => {
+    await run();
+    const first = periodsAsked()[0];
+
+    await activityStore.query_active_history({
+      host: HOST,
+      timeperiod: { start: '2026-09-11T00:00:00+00:00', length: [1, 'day'] },
+    });
+    const second = periodsAsked()[1];
+
+    expect(second.length).toBeGreaterThan(0);
+    // Anything already fetched is re-requested only if it is the open period,
+    // whose duration is still growing.
+    const overlap = second.filter((tp: string) => first.includes(tp));
+    for (const tp of overlap) {
+      const [start, end] = tp.split('/').map((d: string) => new Date(d).getTime());
+      expect(start <= Date.now() && Date.now() < end).toBe(true);
+    }
+  });
+
+  test('no request is sent when nothing is missing', async () => {
+    // A period window entirely in the past, so there is no open period.
+    const pastPeriod = {
+      start: '2020-01-05T00:00:00+00:00',
+      length: [1, 'day'] as [number, string],
+    };
+    await activityStore.query_active_history({ host: HOST, timeperiod: pastPeriod });
+    expect(query).toHaveBeenCalledTimes(1);
+
+    await activityStore.query_active_history({ host: HOST, timeperiod: pastPeriod });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  test('force reload bypasses the cache', async () => {
+    await run();
+    const first = periodsAsked()[0];
+
+    await run({ force: true });
+    expect(periodsAsked()[1]).toEqual(first);
+  });
+
+  test.each([
+    ['host change', { host: 'otherhost' }],
+    ['include_audible change', { include_audible: true }],
+    ['always_active_pattern change', { always_active_pattern: 'mpv' }],
+  ])('%s cannot reuse cached periods', async (_label, override) => {
+    await run();
+    const first = periodsAsked()[0];
+
+    await activityStore.query_active_history({ host: HOST, timeperiod: TIMEPERIOD, ...override });
+    expect(periodsAsked()[1]).toEqual(first);
+  });
+
+  test('a day-boundary change cannot reuse cached periods', async () => {
+    await run();
+    expect(Object.keys(activityStore.active.history).length).toBeGreaterThan(0);
+
+    useSettingsStore().$patch({ startOfDay: '04:00' });
+    await run();
+
+    // The old key no longer matches, so everything was refetched.
+    expect(periodsAsked()[1]).toEqual(periodsAsked()[0]);
+  });
+
+  test('a source-bucket change cannot reuse cached periods', async () => {
+    await run();
+    const first = periodsAsked()[0];
+
+    activityStore.buckets = { ...DESKTOP_BUCKETS, browser: ['aw-watcher-web-firefox_testhost'] };
+    await run({ include_audible: true });
+
+    expect(periodsAsked()[1]).toEqual(first);
+  });
+
+  test('switching multidevice mode cannot reuse cached periods', async () => {
+    await run();
+    const first = periodsAsked()[0];
+
+    seedBuckets({ [HOST]: { window: true } });
+    useSettingsStore().$patch({ useMultidevice: true });
+    await run();
+
+    expect(periodsAsked()[1]).toEqual(first);
+  });
+
+  test('a delayed response from the previous host cannot populate the new one', async () => {
+    let releaseA: (v: unknown) => void;
+    query.mockImplementationOnce(
+      (periods: string[]) =>
+        new Promise(resolve => {
+          releaseA = () =>
+            resolve(
+              periods.map((tp: string) => [
+                { timestamp: tp.split('/')[0], duration: 111, data: {} },
+              ])
+            );
+        })
+    );
+
+    // Host A's request starts but does not resolve.
+    const pendingA = run();
+    // Host B completes first.
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 222, data: {} }])
+    );
+    await activityStore.query_active_history({ host: 'hostB', timeperiod: TIMEPERIOD });
+
+    const afterB = { ...activityStore.active.history };
+    expect(Object.keys(afterB).length).toBeGreaterThan(0);
+
+    // Now A's stale response lands.
+    releaseA!(null);
+    await pendingA;
+
+    for (const [tp, events] of Object.entries(activityStore.active.history)) {
+      expect((events as any[])[0].duration).not.toBe(111);
+      expect(afterB[tp]).toBeDefined();
+    }
+  });
+
+  test('a failed request leaves the cache untouched and is retryable', async () => {
+    query.mockRejectedValueOnce(new Error('offline'));
+    await expect(run()).rejects.toThrow('offline');
+    expect(activityStore.active.history).toEqual({});
+
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 60, data: {} }])
+    );
+    await run();
+    expect(Object.keys(activityStore.active.history).length).toBeGreaterThan(0);
+  });
+
+  test('the open period keeps growing across repeated requests', async () => {
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 100, data: {} }])
+    );
+    await run();
+
+    const openPeriod = periodsAsked()[0].find((tp: string) => {
+      const [start, end] = tp.split('/').map((d: string) => new Date(d).getTime());
+      return start <= Date.now() && Date.now() < end;
+    });
+    expect(openPeriod).toBeDefined();
+    expect(activityStore.active.history[openPeriod].duration).toBeUndefined();
+    expect(activityStore.active.history[openPeriod][0].duration).toBe(100);
+
+    query.mockImplementation(async (periods: string[]) =>
+      periods.map((tp: string) => [{ timestamp: tp.split('/')[0], duration: 250, data: {} }])
+    );
+    await run();
+    expect(activityStore.active.history[openPeriod][0].duration).toBe(250);
+  });
+});
+
+describe('query_active_history_android caching', () => {
+  let activityStore: any;
+  let query: jest.Mock;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useSettingsStore().$patch({ _loaded: true, startOfDay: '00:00', useMultidevice: false });
+    activityStore = useActivityStore();
+    jest.restoreAllMocks();
+    query = mockQuery([]);
+    // activityQueryAndroid returns a total per period, not events.
+    query.mockImplementation(async (periods: string[]) => periods.map(() => 60));
+    activityStore.buckets = {
+      afk: [],
+      window: [],
+      browser: [],
+      editor: [],
+      android: ['aw-watcher-android-test_phone'],
+      stopwatch: [],
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const run = (options: Record<string, unknown> = {}) =>
+    activityStore.query_active_history_android({
+      host: 'phone',
+      timeperiod: TIMEPERIOD,
+      ...options,
+    });
+
+  test('skips cached closed periods on a repeat request', async () => {
+    await run();
+    const first = query.mock.calls[0][0];
+    await run();
+    expect(query.mock.calls[1][0].length).toBeLessThan(first.length);
+  });
+
+  test('does not query future periods, matching desktop', async () => {
+    await run();
+    const now = Date.now();
+    for (const tp of query.mock.calls[0][0]) {
+      expect(new Date(tp.split('/')[0]).getTime()).toBeLessThan(now);
+    }
+  });
+
+  test('force reload bypasses the cache', async () => {
+    await run();
+    const first = query.mock.calls[0][0];
+    await run({ force: true });
+    expect(query.mock.calls[1][0]).toEqual(first);
+  });
+
+  test('a bucket change cannot reuse cached periods', async () => {
+    await run();
+    const first = query.mock.calls[0][0];
+
+    activityStore.buckets = {
+      ...activityStore.buckets,
+      android: ['aw-import-screentime_phone'],
+    };
+    await run();
+    expect(query.mock.calls[1][0]).toEqual(first);
+  });
+
+  test('still produces status-carrying events with the returned duration', async () => {
+    await run();
+    const tp = query.mock.calls[0][0][0];
+    expect(activityStore.active.history[tp][0].data).toEqual({ status: 'not-afk' });
+    expect(activityStore.active.history[tp][0].duration).toBe(60);
+  });
+});

--- a/test/unit/store/activeHistoryCache.test.node.ts
+++ b/test/unit/store/activeHistoryCache.test.node.ts
@@ -196,7 +196,9 @@ describe('query_active_history caching', () => {
   });
 
   test('a delayed response from the previous host cannot populate the new one', async () => {
-    let releaseA: (v: unknown) => void;
+    let releaseA: (v: unknown) => void = () => {
+      throw new Error('releaseA called before the pending mock was installed');
+    };
     query.mockImplementationOnce(
       (periods: string[]) =>
         new Promise(resolve => {
@@ -221,7 +223,7 @@ describe('query_active_history caching', () => {
     expect(Object.keys(afterB).length).toBeGreaterThan(0);
 
     // Now A's stale response lands.
-    releaseA!(null);
+    releaseA(null);
     await pendingA;
 
     for (const [tp, events] of Object.entries(activityStore.active.history)) {

--- a/test/unit/timelineHtml.test.js
+++ b/test/unit/timelineHtml.test.js
@@ -1,0 +1,186 @@
+import { buildTooltip } from '~/util/tooltip';
+import { getSwimlane } from '~/util/swimlane';
+import { FilterXSS } from 'xss';
+
+const event = data => ({ timestamp: '2026-09-10T10:00:00Z', duration: 60, data });
+function parse(html) {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  return el;
+}
+const attack = '<img src=x onerror=alert(1)><b>text</b>';
+
+test.each([
+  'javascript:alert(1)',
+  'data:text/html,<script>alert(1)</script>',
+  '',
+  undefined,
+  'not a url',
+])('unsafe or invalid URL %s is plain text', url => {
+  const el = parse(buildTooltip({ type: 'web.tab.current' }, event({ url, title: attack })));
+  expect(el.querySelector('a')).toBeNull();
+  expect(el.querySelector('img,script,b')).toBeNull();
+  expect(el.textContent).toContain(attack);
+});
+
+test.each([
+  'https://example.test/ onmouseover=alert(1)',
+  'https://example.test/?q="hello"&x=<b>',
+  'http://example.test/path',
+])('keeps HTTP URL %s in one safe attribute', url => {
+  const el = parse(buildTooltip({ type: 'web.tab.current' }, event({ url, title: 'Title' })));
+  const link = el.querySelector('a');
+  expect(link.getAttributeNames()).toEqual(['href']);
+  expect(link.href).toBe(new URL(url).href);
+  expect(link.textContent).toBe(url);
+});
+
+test.each([
+  ['currentwindow', { app: attack, title: attack }],
+  ['app.editor.activity', { file: attack, language: attack }],
+  ['general.stopwatch', { label: attack }],
+  ['unknown', { arbitrary: attack }],
+])('renders %s event fields as text', (type, data) => {
+  const el = parse(buildTooltip({ type }, event(data)));
+  expect(el.querySelector('img,script,b')).toBeNull();
+  expect(el.textContent).toContain(attack);
+});
+
+test.each(['currentwindow', 'app.editor.activity', 'general.stopwatch'])(
+  'escapes %s swimlane labels',
+  type => {
+    const el = parse(
+      getSwimlane(
+        { type },
+        null,
+        'bucketType',
+        event({ app: attack, language: attack, label: attack })
+      )
+    );
+    expect(el.children).toHaveLength(0);
+    expect(el.textContent).toBe(attack);
+  }
+);
+
+test('escapes category labels and tolerates malformed or missing browser URLs', () => {
+  expect(parse(getSwimlane({}, attack, 'category', event({}))).textContent).toBe(attack);
+  for (const url of [undefined, '', 'invalid', 'javascript:alert(1)']) {
+    expect(getSwimlane({ type: 'web.tab.current' }, null, 'bucketType', event({ url }))).toBe(
+      'unknown'
+    );
+  }
+  expect(
+    getSwimlane(
+      { type: 'web.tab.current' },
+      null,
+      'bucketType',
+      event({ url: 'https://www.example.test/path' })
+    )
+  ).toBe('example.test');
+  expect(() => buildTooltip({ type: 'app.editor.activity' }, event({}))).not.toThrow();
+});
+
+// A bucket with no type, or an event with no data, previously threw and took
+// the whole timeline render down.
+describe('malformed input tolerance', () => {
+  test.each([
+    ['no bucket type', {}, { app: 'a' }],
+    ['no data', { type: 'currentwindow' }, undefined],
+    ['no data on a web bucket', { type: 'web.tab.current' }, undefined],
+    ['no data on an editor bucket', { type: 'app.editor.activity' }, undefined],
+  ])('buildTooltip survives %s', (_label, bucket, data) => {
+    let html;
+    expect(() => {
+      html = buildTooltip(bucket, { timestamp: '2026-09-10T10:00:00Z', duration: 60, data });
+    }).not.toThrow();
+    expect(parse(html).querySelector('table')).not.toBeNull();
+  });
+
+  test.each([
+    ['no bucket type', {}],
+    ['no data', { type: 'currentwindow' }],
+  ])('getSwimlane survives %s', (_label, bucket) => {
+    expect(() =>
+      getSwimlane(bucket, 'c', 'bucketType', { timestamp: 't', duration: 1, data: undefined })
+    ).not.toThrow();
+  });
+});
+
+// Grouping keys must stay distinct: escaping is reversible, so two different
+// values cannot collapse onto one subgroup.
+describe('swimlane grouping keys stay distinct', () => {
+  const lane = app =>
+    getSwimlane({ type: 'currentwindow' }, 'c', 'bucketType', {
+      timestamp: 't',
+      duration: 1,
+      data: { app },
+    });
+
+  test('values differing only inside markup do not collide', () => {
+    expect(lane('<b>one</b>')).not.toBe(lane('<b>two</b>'));
+    expect(lane('<i>x</i>')).not.toBe(lane('<b>x</b>'));
+  });
+
+  test('ordinary names are unchanged', () => {
+    expect(lane('Firefox')).toBe('Firefox');
+  });
+});
+
+// The tooltip string is handed to vis-timeline as an item `title`, which the
+// library runs through its own filter: the esnext build constructs
+// `new FilterXSS()` with the xss library's defaults and defaults the option to
+// `xss: { disabled: false }`. `xss` ships as a vis-timeline peer dependency,
+// so this exercises the real downstream sink.
+//
+// Documented finding for the FIXMEs this replaces: that filter DID mitigate
+// the old builder's defects end-to-end. Given the previous unquoted
+// `<a href=${url}>` it stripped an injected `onmouseover`, emptied a
+// `javascript:` href, and reduced `<img src=x onerror=alert(1)>` in a text
+// field to `<img src>`. The builder output was unsafe on its own but not
+// exploitable through this sink; the fix removes the reliance on that second
+// line of defence, and these tests assert both layers now agree.
+describe('output at the vis-timeline sink', () => {
+  const downstream = new FilterXSS();
+  const afterSink = html => parse(downstream.process(html));
+  const handlerAttrs = el =>
+    Array.from(el.querySelectorAll('*'))
+      .flatMap(n => Array.from(n.attributes).map(a => a.name))
+      .filter(n => n.startsWith('on'));
+
+  test('a benign link survives the downstream filter intact', () => {
+    const el = afterSink(
+      buildTooltip(
+        { type: 'web.tab.current' },
+        event({ title: 'T', url: 'https://example.test/?a=1&b=2' })
+      )
+    );
+    expect(el.querySelector('a').getAttribute('href')).toBe('https://example.test/?a=1&b=2');
+  });
+
+  test('markup in a text field reaches the sink as text', () => {
+    const el = afterSink(
+      buildTooltip({ type: 'currentwindow' }, event({ app: attack, title: attack }))
+    );
+    expect(handlerAttrs(el)).toEqual([]);
+    expect(el.querySelector('img,script')).toBeNull();
+  });
+
+  test('whitespace injection reaches the sink with only an href', () => {
+    const el = afterSink(
+      buildTooltip(
+        { type: 'web.tab.current' },
+        event({ title: 'T', url: 'https://example.test/ onmouseover=alert(1)' })
+      )
+    );
+    expect(Array.from(el.querySelector('a').attributes).map(a => a.name)).toEqual(['href']);
+  });
+
+  test.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>'])(
+    'the unsafe scheme %s never becomes an href',
+    url => {
+      const el = afterSink(buildTooltip({ type: 'web.tab.current' }, event({ title: 'T', url })));
+      expect(el.querySelector('a')).toBeNull();
+      expect(handlerAttrs(el)).toEqual([]);
+    }
+  );
+});


### PR DESCRIPTION
Clears out a batch of long-standing TODO/FIXME markers in the webui. Each
commit addresses one tracked issue and is independently reviewable and
mergeable; the test suite passes at every commit (308 → 505 tests), with
`tsc --noEmit` clean throughout.

Several of these markers turned out to be documenting real bugs rather than
pending work, so where a comment claimed something was unfinished I verified
the current behaviour before either removing the comment or fixing the defect.

### Stale comments (no behaviour change)

- **`TimelineBarChart`** — the FIXME asked for access to the timeperiod start;
  `labels()` already assigns `const start = this.timeperiod_start` and derives
  the month length from it.
- **`CategoryEditModal`** — the FIXME asked for the store's category ID to be
  used so saves are uniquely targeted; `resetModal()` (on `@show`) already
  loads `cat.id` and `handleSubmit()` passes it to `updateClass()`. The `id: 0`
  initializer is never read and is now labelled as the placeholder it is.

### Correctness fixes

- **Sunburst clock** — the `Now` marker was drawn unconditionally, so
  historical and future day views showed a marker for the current wall-clock
  time. Now guarded by the whole-day bounds already computed above it,
  start-inclusive/end-exclusive, which also makes 02:00 correctly belong to the
  activity day that began at 04:00 the previous date.
- **Alerts date range** — `check()` built its range as
  `moment().subtract(1, 'days').startOf('day')` plus one day, i.e. *yesterday's*
  complete calendar day, despite the neighbouring "Get start of today" comment.
  Now derives the current activity-day boundary from the user's `startOfDay`
  setting via the existing helpers, and ends at a single captured instant.
- **Alerts persistence** — goals lived only in component data, so every add or
  delete was lost on reload. Persisted through the settings store (localStorage
  is deprecated there), with a `hasStoredAlerts` getter so a saved empty list is
  distinguishable from a first run and deleting every goal stays deleted.
  Malformed stored data is dropped rather than crashing the view.
- **`EventEditor`** — `save()`/`delete_()` emitted success *before* awaiting the
  request, and the button handlers called `close()` immediately, so a failed
  request closed the editor and told parents the operation had succeeded. The
  old FIXMEs noted that moving the emit later stopped it firing at all; the
  cause was the lifecycle, not the ordering — consumers render the editor behind
  a `v-if` on the event being edited, so the component could already be gone.
  The modal is now hidden before the success event is emitted, with the ref
  access guarded, and a failure keeps the editor, its input and a visible error.
- **Bar-chart durations** — durations were dropped when a category definition
  was missing.
- **Calendar** — fit-to-active produced unsafe bounds for short and overnight
  events.
- **Timeline tooltips** — fields were sanitized individually and then
  interpolated into markup, which is the wrong tool: the URL went into an
  unquoted `<a href=${url}>`, so a URL ending in ` onmouseover=alert(1)` parsed
  as a separate handler attribute; a `javascript:` URL was kept as the href; and
  because DOMPurify is an HTML sanitizer, `<img src=x onerror=…>` in a text
  field lost the handler but kept the element. `getSwimlane` also called
  `new URL()` unguarded, so a malformed URL aborted the whole visualization.
  Text is now escaped for its insertion context, URLs are restricted to http(s)
  and emitted in a quoted href, and the assembled markup is sanitized once as a
  boundary check.

  Worth recording for reviewers: vis-timeline's own filter *did* mitigate all of
  this end-to-end — its esnext build constructs a `FilterXSS` with the `xss`
  library's defaults and defaults to `xss: { disabled: false }`, which stripped
  the injected handler and emptied the `javascript:` href. The builder output
  was unsafe on its own but not exploitable through this sink. The fix removes
  the reliance on that second line of defence, and the new tests assert both
  layers agree.

- **Usage-chart period identity** — each bar's identity was derived from
  `events[0].timestamp`, which fails for an empty period (no event to read),
  for a period whose first activity starts late, and for rolling ranges, which
  aren't identified by their start day at all. Period metadata is now carried
  through explicitly; `Today` marks the period *containing* the current instant;
  durations are summed rather than taken from an arbitrary first event; and
  clicking a `last7d`/`last30d` bar no longer shifts the range backwards by its
  own length. Degenerate inputs (0/1 bars, all-zero durations) keep finite SVG
  geometry, where padding of `100/(count-1)` was previously `Infinity`.
- **Active-duration semantics** — the history query was AFK-only, so it
  disagreed with the main activity view whenever `always_active_pattern` or
  audible-as-active mattered. It now derives active evidence from
  `canonicalEvents` per source so the two cannot drift, and unions across
  sources so overlapping evidence and devices count once. AFK-only hosts still
  contribute, and with AFK filtering disabled the history measures window
  coverage, matching what the main view then reports.
- **Active-history cache** — three defects compounded, leaving the cache
  simultaneously never hit and never cleared. Lookup used
  `_.includes(this.active.history, tp_str)`, and on an object lodash checks
  *values* (which are event arrays), so it was always false and every navigation
  refetched every period. Fixing only that would have exposed the second
  problem: nothing invalidated the cache — `start_loading`'s guard only cleared
  an already-empty map, so data from a previous host or settings context
  survived indefinitely. The third was that the open period would then be cached
  forever, freezing a duration that is still growing. Cache identity now covers
  host, platform, multidevice mode, the `startOfDay` boundary, the resolved
  source buckets and the semantic settings above; the open period is always
  refetched; future periods are never queried (previously desktop-only, now
  consistent with Android/iOS); no request is sent when nothing is missing; and
  an invalidation generation stops a delayed response for the previous host from
  landing in the new context.

### Testing

`npm test` — 48 suites, 505 tests, 3 snapshots. `tsc --noEmit` clean;
`vue-cli-service lint` reports only 3 pre-existing warnings in
`vite.config.js` / `vue.config.js`. Production build verified.

Behavioural fixes were checked against the pre-fix code to confirm the new
tests actually fail without them, rather than only passing with them.

One deliberate snapshot update: the `fullDesktopQuery` active-duration snapshot
changes because the AFK-only path now floods the AFK bucket, matching
`canonicalEvents`.

### Known adjacent issues, left alone

- The Alerts category `<select>` offers "All" with a `null` value, which the
  view's `alertTime()` cannot sum. Validation now rejects it with a message
  instead of persisting an entry that would crash the view, but the option
  itself is still wrong and wants its own fix.
- `periodLengthConvertMoment` logs `Invalid periodLength last7d` and defaults to
  `'day'` on each rolling-range click. That default happens to be the correct
  normalization for an anchor date, and the function is shared with other
  callers, so it is untouched here.
